### PR TITLE
Handle empty credentials

### DIFF
--- a/common/src/python/redcap/nacc_directory.py
+++ b/common/src/python/redcap/nacc_directory.py
@@ -203,11 +203,15 @@ class UserDirectory:
     def add(self, entry: UserDirectoryEntry) -> None:
         """Adds a directory entry to the user directory.
 
-        Ignores the entry if another entry already has the email address.
+        Ignores the entry if it has no ID, or another entry already has the
+        email address.
 
         Args:
           entry: the directory entry
         """
+        if not entry.credentials['id']:
+            return
+
         if self.has_entry_email(entry.email):
             return
 

--- a/common/src/python/redcap/nacc_directory.py
+++ b/common/src/python/redcap/nacc_directory.py
@@ -2,6 +2,7 @@
 
 from collections import defaultdict
 from datetime import datetime
+from enum import Enum
 from typing import Any, Dict, Iterable, List, NewType, Optional, Set, TypedDict
 
 
@@ -182,10 +183,16 @@ class UserDirectoryEntry:
                                       "%Y-%m-%d %H:%M"),
                                   authorizations=authorizations)
 
+class ConflictEnum(Enum):
+    """Enumerated type for directory conflicts"""
+    EMAIL = 1
+    IDENTIFIER = 2
+
 
 class DirectoryConflict(TypedDict):
     """Entries with conflicting user_id and/or emails."""
     user_id: str
+    conflict_type: ConflictEnum
     entries: List[EntryDictType]
 
 
@@ -295,12 +302,14 @@ class UserDirectory:
                         entries=[
                             entry.as_dict()
                             for entry in self.__get_entry_list(email_list)
-                        ]))
+                        ],
+                        conflict_type=ConflictEnum.IDENTIFIER))
         for entry in self.__email_map.values():
             if entry.email in self.__conflict_set:
                 conflicts.append(
                     DirectoryConflict(user_id=entry.credentials['id'],
-                                      entries=[entry.as_dict()]))
+                                      entries=[entry.as_dict()],
+                                      conflict_type=ConflictEnum.EMAIL))
 
         return conflicts
 

--- a/common/src/python/redcap/nacc_directory.py
+++ b/common/src/python/redcap/nacc_directory.py
@@ -157,7 +157,7 @@ class UserDirectoryEntry:
 
         credentials: Credentials = {
             "type": record['fw_credential_type'],
-            "id": record['fw_credential_id'].lower()
+            "id": record['fw_credential_id']
         }
 
         name: PersonName = {

--- a/common/src/python/redcap/nacc_directory.py
+++ b/common/src/python/redcap/nacc_directory.py
@@ -2,7 +2,7 @@
 
 from collections import defaultdict
 from datetime import datetime
-from typing import Any, Dict, Iterable, List, NewType, Optional, TypedDict
+from typing import Any, Dict, Iterable, List, NewType, Optional, Set, TypedDict
 
 
 class Authorizations(TypedDict):
@@ -198,6 +198,7 @@ class UserDirectory:
     def __init__(self) -> None:
         """Initializes a user directory."""
         self.__email_map: Dict[str, UserDirectoryEntry] = {}
+        self.__conflict_set: Set[str] = set()
         self.__id_map: Dict[str, List[str]] = defaultdict(list)
 
     def add(self, entry: UserDirectoryEntry) -> None:
@@ -209,13 +210,33 @@ class UserDirectory:
         Args:
           entry: the directory entry
         """
+        # check that entry has an ID
         if not entry.credentials['id']:
             return
 
+        # check that doesn't have duplicate email
+        # (REDCap directory uses email as key)
         if self.has_entry_email(entry.email):
             return
 
         self.__email_map[entry.email] = entry
+
+        # check that someone else's ID is not this entry's email
+        if entry.email in self.__id_map:
+            # other entry is in conflict
+            for other_email in self.__id_map[entry.email]:
+                self.__conflict_set.add(other_email)
+            return
+
+        if entry.email == entry.credentials['id']:
+            return
+
+        # check that ID is not someone else's email
+        if self.has_entry_email(entry.credentials['id']):
+            # new entry is in conflict
+            self.__conflict_set.add(entry.email)
+            return
+
         self.__id_map[entry.credentials['id']].append(entry.email)
 
     def get_entries(self) -> List[UserDirectoryEntry]:
@@ -225,10 +246,18 @@ class UserDirectory:
         Returns:
           List of UserDirectoryEntry with no email/ID conflicts
         """
+        id_conflicts = set()
+        for email_list in self.__id_map.values():
+            if len(email_list) > 1:
+                for email in email_list:
+                    id_conflicts.add(email)
+
         non_conflicts = {
-            email_list[0]
-            for email_list in self.__id_map.values() if len(email_list) == 1
+            email
+            for email in self.__email_map
+            if email not in self.__conflict_set and email not in id_conflicts
         }
+
         entries = self.__get_entry_list(non_conflicts)
         return entries
 
@@ -250,18 +279,30 @@ class UserDirectory:
     def get_conflicts(self) -> List[DirectoryConflict]:
         """Returns the list of conflicting directory entries.
 
+        Conflicts occur
+        - if two entries have the same ID, or
+        - if an entry has an ID that is the email of another entry.
+
         Return:
           List of DirectoryConflict objects for entries with conflicting IDs
         """
-        return [
-            DirectoryConflict(
-                user_id=user_id,
-                entries=[
-                    entry.as_dict()
-                    for entry in self.__get_entry_list(email_list)
-                ]) for user_id, email_list in self.__id_map.items()
-            if len(email_list) > 1
-        ]
+        conflicts = []
+        for user_id, email_list in self.__id_map.items():
+            if len(email_list) > 1:
+                conflicts.append(
+                    DirectoryConflict(
+                        user_id=user_id,
+                        entries=[
+                            entry.as_dict()
+                            for entry in self.__get_entry_list(email_list)
+                        ]))
+        for entry in self.__email_map.values():
+            if entry.email in self.__conflict_set:
+                conflicts.append(
+                    DirectoryConflict(user_id=entry.credentials['id'],
+                                      entries=[entry.as_dict()]))
+
+        return conflicts
 
     def has_entry_email(self, email):
         """Determines whether directory has an entry for the email address.

--- a/common/test/python/redcap/test_nacc_directory.py
+++ b/common/test/python/redcap/test_nacc_directory.py
@@ -86,9 +86,23 @@ class TestNACCDirectory:
         second_entry = user_entry(email='cah@one.org', user_id='bah@one.org')
         directory.add(second_entry)
         entries = directory.get_entries()
-        assert not entries
+        assert len(entries) == 1
+        assert entries[0].email == 'bah@one.org'
         conflicts = directory.get_conflicts()
         assert len(conflicts) == 1
+        assert conflicts[0]['entries'][0]['email'] == 'cah@one.org'
+
+    def test_id_id_conflict(self):
+        """Test adding record with conflicting ids."""
+        directory = UserDirectory()
+        first_entry = user_entry(email='aah@two.org', user_id='1111@two.org')
+        directory.add(first_entry)
+        second_entry = user_entry(email='bah@two.org', user_id='1111@two.org')
+        directory.add(second_entry)
+        assert not directory.get_entries()
+        conflicts = directory.get_conflicts()
+        assert conflicts[0]['entries'][0]['email'] == 'aah@two.org'
+        assert conflicts[0]['entries'][1]['email'] == 'bah@two.org'
 
     def test_missing_id(self):
         """Test record with missing ID is not added."""

--- a/common/test/python/redcap/test_nacc_directory.py
+++ b/common/test/python/redcap/test_nacc_directory.py
@@ -19,7 +19,7 @@ def user_entry(email: str,
     Returns:
       Dummy user entry object with specific parameters set
     """
-    if not user_id:
+    if user_id is None:
         user_id = email
     if not name:
         name = PersonName(first_name='dummy', last_name='name')
@@ -89,3 +89,10 @@ class TestNACCDirectory:
         assert not entries
         conflicts = directory.get_conflicts()
         assert len(conflicts) == 1
+
+    def test_missing_id(self):
+        """Test record with missing ID is not added."""
+        directory = UserDirectory()
+        no_id_entry = user_entry(email='bah@two.org', user_id='')
+        directory.add(no_id_entry)
+        assert not directory.get_entries()

--- a/pull_directory/src/docker/BUILD
+++ b/pull_directory/src/docker/BUILD
@@ -4,4 +4,4 @@ docker_image(
     name="pull-directory",
     source="Dockerfile",
     dependencies=[":manifest", "pull_directory/src/python/directory_app:bin"],
-    image_tags=["0.0.8", "latest"])
+    image_tags=["0.0.9", "latest"])

--- a/pull_directory/src/docker/BUILD
+++ b/pull_directory/src/docker/BUILD
@@ -4,4 +4,4 @@ docker_image(
     name="pull-directory",
     source="Dockerfile",
     dependencies=[":manifest", "pull_directory/src/python/directory_app:bin"],
-    image_tags=["0.0.7", "latest"])
+    image_tags=["0.0.8", "latest"])

--- a/pull_directory/src/docker/manifest.json
+++ b/pull_directory/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "pull-directory",
     "label": "Pull Directory",
     "description": "Pull user information from NACC directory and save to admin project",
-    "version": "0.0.7",
+    "version": "0.0.8",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/pull-directory:0.0.7"
+            "image": "naccdata/pull-directory:0.0.8"
         },
         "flywheel": {
             "suite": "NACC Admin Gears",

--- a/pull_directory/src/docker/manifest.json
+++ b/pull_directory/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "pull-directory",
     "label": "Pull Directory",
     "description": "Pull user information from NACC directory and save to admin project",
-    "version": "0.0.8",
+    "version": "0.0.9",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/pull-directory:0.0.8"
+            "image": "naccdata/pull-directory:0.0.9"
         },
         "flywheel": {
             "suite": "NACC Admin Gears",

--- a/pull_directory/src/python/directory_app/main.py
+++ b/pull_directory/src/python/directory_app/main.py
@@ -50,10 +50,14 @@ def run(*, user_report: List[Dict[str, str]], user_filename: str,
 
         directory.add(entry)
 
-    upload_yaml(project=project,
-                filename=user_filename,
-                data=[entry.as_dict() for entry in directory.get_entries()])
+    entries = [entry.as_dict() for entry in directory.get_entries()]
+    if entries:
+        upload_yaml(project=project,
+                    filename=user_filename,
+                    data=entries)
 
-    upload_yaml(project=project,
-                filename=f"conflicts-{user_filename}",
-                data=directory.get_conflicts())
+    conflicts = directory.get_conflicts()
+    if conflicts:
+        upload_yaml(project=project,
+                    filename=f"conflicts-{user_filename}",
+                    data=conflicts)


### PR DESCRIPTION
Improves handling of ID/email errors in  the NACC directory pulled from REDCap.

Separates errors where:

* a user gave another user's email as their ID
* two or more users gave the same ID

