### PR TITLE
Generic parameters/Add RDS parameters

### DIFF
--- a/common/src/python/inputs/parameter_store.py
+++ b/common/src/python/inputs/parameter_store.py
@@ -35,7 +35,8 @@ class ParameterError(Exception):
     """Error class for errors that occur when reading parameters."""
 
 
-P = TypeVar('P', bound=TypedDict)
+# TODO: remove type ignore when using python 3.12 or above
+P = TypeVar('P', bound=TypedDict)  # type: ignore
 
 
 class ParameterStore:
@@ -69,7 +70,12 @@ class ParameterStore:
         """Returns the GearBot API key."""
         parameter_name = 'apikey'
         parameter_path = f'/prod/flywheel/gearbot/{parameter_name}'
-        parameter = self.__store.get_parameter(parameter_path, decrypt=True)
+        try:
+            parameter = self.__store.get_parameter(parameter_path,
+                                                   decrypt=True)
+        except self.__store.client.exceptions.ParameterNotFound as error:  # type: ignore
+            raise ParameterError("No API Key found") from error
+
         apikey = parameter.get(parameter_name)
         if not apikey:
             raise ParameterError("No API Key found")

--- a/common/test/python/inputs/test_parameter_store.py
+++ b/common/test/python/inputs/test_parameter_store.py
@@ -21,22 +21,28 @@ def aws_credentials():
     os.environ['AWS_DEFAULT_REGION'] = "us-east-1"
 
 
+# pylint: disable=(redefined-outer-name,unused-argument)
 @pytest.fixture(scope="function")
 def ssm(aws_credentials):
+    """Fixture for mocking SSM service."""
     with mock_ssm():
         yield boto3.client('ssm', region_name="us-east-1")
 
 
 class TestParameters(TypedDict):
+    """Dummy class for testing get_parameters."""
     param1: str
     param2: str
 
 
+# pylint: disable=(no-self-use)
 @mock_ssm
 class TestParameterStore:
     """Tests for parameter store class."""
 
+    # pylint: disable=(unused-argument,import-outside-toplevel)
     def test_empty(self, aws_credentials):
+        """Test what happens when pull from empty store."""
         from inputs.parameter_store import ParameterError, ParameterStore
 
         store = ParameterStore.create_from_environment()
@@ -47,6 +53,7 @@ class TestParameterStore:
             store.get_api_key()
 
     def test_api_key(self, ssm):
+        """Test getting api key that is present in store."""
         from inputs.parameter_store import ParameterStore
 
         ssm.put_parameter(Name='/prod/flywheel/gearbot/apikey',
@@ -60,6 +67,7 @@ class TestParameterStore:
         assert value == 'dummy'
 
     def test_dict_parameters(self, ssm):
+        """Tests for pulling dictionary of parameters (aka, by path)"""
         from inputs.parameter_store import ParameterError, ParameterStore
 
         ssm.put_parameter(Name='/test/valid/param1', Type='String', Value='1')

--- a/common/test/python/inputs/test_parameter_store.py
+++ b/common/test/python/inputs/test_parameter_store.py
@@ -1,0 +1,83 @@
+"""Tests for parameter store class.
+
+Note: ParameterStore uses boto3 and these tests use moto for mocking.
+Moto documentation says imports of boto3 need to occur within scope
+where the mock is enabled.
+So, imports of ParameterStore are done within tests.
+"""
+import os
+
+import boto3
+import pytest
+from moto import mock_ssm
+from typing_extensions import TypedDict
+
+
+@pytest.fixture(scope="function")
+def aws_credentials():
+    """Mock AWS credentials for moto."""
+    os.environ['AWS_SECRET_ACCESS_KEY'] = "testing"
+    os.environ['AWS_ACCESS_KEY_ID'] = "testing"
+    os.environ['AWS_DEFAULT_REGION'] = "us-east-1"
+
+
+@pytest.fixture(scope="function")
+def ssm(aws_credentials):
+    with mock_ssm():
+        yield boto3.client('ssm', region_name="us-east-1")
+
+
+class TestParameters(TypedDict):
+    param1: str
+    param2: str
+
+
+@mock_ssm
+class TestParameterStore:
+    """Tests for parameter store class."""
+
+    def test_empty(self, aws_credentials):
+        from inputs.parameter_store import ParameterError, ParameterStore
+
+        store = ParameterStore.create_from_environment()
+        assert store
+
+        # TODO: check error message
+        with pytest.raises(ParameterError):
+            store.get_api_key()
+
+    def test_api_key(self, ssm):
+        from inputs.parameter_store import ParameterStore
+
+        ssm.put_parameter(Name='/prod/flywheel/gearbot/apikey',
+                          Type='SecureString',
+                          Value='dummy')  # type: ignore
+
+        store = ParameterStore.create_from_environment()
+        assert store
+
+        value = store.get_api_key()
+        assert value == 'dummy'
+
+    def test_dict_parameters(self, ssm):
+        from inputs.parameter_store import ParameterError, ParameterStore
+
+        ssm.put_parameter(Name='/test/valid/param1', Type='String', Value='1')
+        ssm.put_parameter(Name='/test/valid/param2', Type='String', Value='2')
+        ssm.put_parameter(Name='/test/invalid/nonparam1',
+                          Type='String',
+                          Value='one')
+
+        store = ParameterStore.create_from_environment()
+        assert store
+
+        # NOTE: type parameter must be a subtype of typing_extensions.TypeDict
+        valid_parameters = store.get_parameters(param_type=TestParameters,
+                                                parameter_path='/test/valid')
+        assert valid_parameters
+        assert list(valid_parameters.keys()) == ['param1', 'param2']
+
+        # TODO: check error message
+        with pytest.raises(ParameterError):
+            store.get_parameters(param_type=TestParameters,
+                                 parameter_path='/test/invalid')

--- a/gear/push_template/src/docker/BUILD
+++ b/gear/push_template/src/docker/BUILD
@@ -5,5 +5,3 @@ docker_image(
     source="Dockerfile",
     dependencies=[":manifest", "gear/push_template/src/python/template_app:bin"],
     image_tags=["0.0.9", "latest"])
-
-shell_sources()

--- a/python-default.lock
+++ b/python-default.lock
@@ -18,13 +18,16 @@
 //     "moto[s3,ssm]>=4.2.5",
 //     "pandas-stubs>=2.0.3",
 //     "pandas>=2.1.1",
+//     "pydantic>=2.5.2",
 //     "pytest>=7.2.0",
 //     "pyyaml==6.0",
 //     "requests>=2.18.4",
 //     "setuptools>=68.2.2",
+//     "sqlalchemy>=2.0.23",
 //     "ssm-parameter-store>=19.11.0",
 //     "types-PyYAML>=6.0.12",
-//     "types-requests"
+//     "types-requests",
+//     "typing-extensions>=4.8.0"
 //   ],
 //   "manylinux": "manylinux2014",
 //   "requirement_constraints": [],
@@ -106,43 +109,43 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "fcc24f62a1f512dd9b4a7a8af6f5fbfb3d69842a92aa2e79c2ca551ac49a4757",
-              "url": "https://files.pythonhosted.org/packages/98/ac/bc3123e2a2b5fb99e5632f622a20d6c8c1a7f7ff56fd0f98e77a18cc28b1/boto3-1.33.5-py3-none-any.whl"
+              "hash": "baa6ea61527bcc82365a4ef365aa8f34126483ff8533d01274f3cdb340c22d73",
+              "url": "https://files.pythonhosted.org/packages/b2/78/9894551b1340ffa202ae6ec368e4d26e0a5172b9dec8275873d89afceb16/boto3-1.33.9-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6a1d938bbf11518b1d17ca8186168f3ba2a0e8b2bf3c82cdd810ecb884627d2a",
-              "url": "https://files.pythonhosted.org/packages/33/d2/b60aebc8cf6b496a71738a5ac60b5e9b1dc0cb3d207d79cd7fb2af511cf2/boto3-1.33.5.tar.gz"
+              "hash": "9486f66f9a89f66d64d25cb4baa55aad323a1734ef9815b7a2c4c0787a3fc1fb",
+              "url": "https://files.pythonhosted.org/packages/90/d6/a8a7e77043103c1f2975af03aeae8391c9dd7096a5dca8a550f220da1b41/boto3-1.33.9.tar.gz"
             }
           ],
           "project_name": "boto3",
           "requires_dists": [
-            "botocore<1.34.0,>=1.33.5",
+            "botocore<1.34.0,>=1.33.9",
             "botocore[crt]<2.0a0,>=1.21.0; extra == \"crt\"",
             "jmespath<2.0.0,>=0.7.1",
             "s3transfer<0.9.0,>=0.8.2"
           ],
           "requires_python": ">=3.7",
-          "version": "1.33.5"
+          "version": "1.33.9"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "4f19917a817f5530c5a05924ff009929218664c75140f47fd57e3ba6d477ab48",
-              "url": "https://files.pythonhosted.org/packages/11/0c/ffc62fd4a9237f13f82664ae32c903011f1138f97971901382e3a2894db1/boto3_stubs-1.33.5-py3-none-any.whl"
+              "hash": "2652bf7ac8413b7d34971cdef2ca012422a33dd4dd717a168fe1233477f50a76",
+              "url": "https://files.pythonhosted.org/packages/ba/86/4eb2f4240db70ceab64385b84a3ac1d58ed9d0bedc780837369204bc1d57/boto3_stubs-1.33.9-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "40d7a52e60d477822655938083be43a9097a405f1d748ce86f5233685e0cddcc",
-              "url": "https://files.pythonhosted.org/packages/3f/0c/83a4f94d44059d90d7d22de6e154958f684b5504d2ff3aac809833b0dbb1/boto3-stubs-1.33.5.tar.gz"
+              "hash": "d22dcc7aba3f314644eeda426bca9aa6dea15de1594c35c743f980e8814f0c6a",
+              "url": "https://files.pythonhosted.org/packages/05/23/753c95f3f9aa821e877b5960734ee9cc8a737e5b2f2dbadb6c61483a9f46/boto3-stubs-1.33.9.tar.gz"
             }
           ],
           "project_name": "boto3-stubs",
           "requires_dists": [
-            "boto3==1.33.5; extra == \"boto3\"",
+            "boto3==1.33.9; extra == \"boto3\"",
             "botocore-stubs",
-            "botocore==1.33.5; extra == \"boto3\"",
+            "botocore==1.33.9; extra == \"boto3\"",
             "mypy-boto3-accessanalyzer<1.34.0,>=1.33.0; extra == \"accessanalyzer\"",
             "mypy-boto3-accessanalyzer<1.34.0,>=1.33.0; extra == \"all\"",
             "mypy-boto3-account<1.34.0,>=1.33.0; extra == \"account\"",
@@ -902,19 +905,19 @@
             "typing-extensions>=4.1.0; python_version < \"3.12\""
           ],
           "requires_python": ">=3.7",
-          "version": "1.33.5"
+          "version": "1.33.9"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "c165207fb33e8352191d6a2770bce9f9bf01c62f5149824c4295d7f49bf96746",
-              "url": "https://files.pythonhosted.org/packages/dd/e7/ff2caeee2a512ebbdf0552d60a98a192b8006f89888c90a71581cde01c10/botocore-1.33.5-py3-none-any.whl"
+              "hash": "07ff4eea62f546da540310887000c81fca802c788eb374fef06eda28009dcafd",
+              "url": "https://files.pythonhosted.org/packages/70/35/43e84991c5f62cf821b18d46c4385327f1dff84bb4e2238fec8a279d209c/botocore-1.33.9-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "aa4a5c7cf78a403280e50daba8966479e23577b4a5c20165f71fab7a9b405e99",
-              "url": "https://files.pythonhosted.org/packages/e8/3c/4e87ed46d4038233454188c37a38f6e81ae307c09e1a45f73e6383acdf42/botocore-1.33.5.tar.gz"
+              "hash": "1b90be11dd9a9a25290c995a6b713e76b9e2bf7bf86ba9036e0d28f2ceb2edfc",
+              "url": "https://files.pythonhosted.org/packages/17/d3/53323326e24271c8e5767b1e4cd0ac6752ed5dfbc92a7f50b8c77be1f795/botocore-1.33.9.tar.gz"
             }
           ],
           "project_name": "botocore",
@@ -926,19 +929,19 @@
             "urllib3<2.1,>=1.25.4; python_version >= \"3.10\""
           ],
           "requires_python": ">=3.7",
-          "version": "1.33.5"
+          "version": "1.33.9"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "af2d6f5a00c003df38bd28ac21a52d4d23cce9d5cc9f864656a85b569b88657c",
-              "url": "https://files.pythonhosted.org/packages/6d/f5/19ca1628b5a074445c3ab4568c5f2b753b08a53cd73fdcf2484eaae88d9f/botocore_stubs-1.33.5-py3-none-any.whl"
+              "hash": "9d1fef0e22953102239fb3108b18588d980823ea765aef21ab861b65eba37e31",
+              "url": "https://files.pythonhosted.org/packages/ea/48/6f23507c3ff13a2f196a4eb5cfa617c117a7ef5084f55188260703a8cff3/botocore_stubs-1.33.9-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "826147bc4134cffd5310c36065131e9955d434b30ddb0ccecb16fc66ea3461fd",
-              "url": "https://files.pythonhosted.org/packages/eb/8f/939e137829594b6e804ea688c4f4cdce715feb40a4b61fc5ab322ea36df4/botocore_stubs-1.33.5.tar.gz"
+              "hash": "60e1ace3785ecdfec5ed4bfc7c03161a5a478cd45184a4042a0238ce6f56a18a",
+              "url": "https://files.pythonhosted.org/packages/85/1a/7a6774b36f6b8a5b259f4b548c3d10d647521cb328389653c3d30a9c6db2/botocore_stubs-1.33.9.tar.gz"
             }
           ],
           "project_name": "botocore-stubs",
@@ -948,7 +951,7 @@
             "typing-extensions>=4.1.0; python_version < \"3.9\""
           ],
           "requires_python": "<4.0,>=3.7",
-          "version": "1.33.5"
+          "version": "1.33.9"
         },
         {
           "artifacts": [
@@ -1339,8 +1342,8 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "9d380b4aaba17ff0c7b11bc5384c1194cc62a0613deb95dfdbe10370caab51c7",
-              "url": "https://files.pythonhosted.org/packages/41/1c/16441024c6ca3905b35193356fd79649a85c8049db032a72e6d9074d16e0/fw_utils-4.3.5-py3-none-any.whl"
+              "hash": "841b5208361329035be341683c521ff4a3ba88dc4bd81a888afdf19111505e5e",
+              "url": "https://files.pythonhosted.org/packages/0f/10/41661e9d724c4f53a4e044007dc1495438f0e865da8d23acdd20949100aa/fw_utils-4.3.6-py3-none-any.whl"
             }
           ],
           "project_name": "fw-utils",
@@ -1350,7 +1353,64 @@
             "tzlocal>=4.1"
           ],
           "requires_python": "<4.0,>=3.8",
-          "version": "4.3.5"
+          "version": "4.3.6"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "5805e71e5b570d490938d55552f5a9e10f477c19400c38bf1d5190d760691846",
+              "url": "https://files.pythonhosted.org/packages/28/1c/ae9064db808a13be14c765214d502a87a840112d5b9761ad60f2299bfd2c/greenlet-3.0.1-cp310-cp310-musllinux_1_1_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "b8ba29306c5de7717b5761b9ea74f9c72b9e2b834e24aa984da99cbfc70157fd",
+              "url": "https://files.pythonhosted.org/packages/13/7e/3d6c8ab4a868cbe13acdc7fa2589e6848a16e10a9d47a97aa9493fa0d9c3/greenlet-3.0.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "599daf06ea59bfedbec564b1692b0166a0045f32b6f0933b0dd4df59a854caf2",
+              "url": "https://files.pythonhosted.org/packages/1b/10/095ac4f9c3d74d672ea5059eaddf245108371498ff348d23dd91992184ce/greenlet-3.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "816bd9488a94cba78d93e1abb58000e8266fa9cc2aa9ccdd6eb0696acb24005b",
+              "url": "https://files.pythonhosted.org/packages/54/df/718c9b3e90edba70fa919bb3aaa5c3c8dabf3a8252ad1e93d33c348e5ca4/greenlet-3.0.1.tar.gz"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "d57e20ba591727da0c230ab2c3f200ac9d6d333860d85348816e1dca4cc4792e",
+              "url": "https://files.pythonhosted.org/packages/73/f2/f66764fda8e31e742fb7ee2bfaef83fd856681c6da504d8784d2e58f2dac/greenlet-3.0.1-cp310-cp310-musllinux_1_1_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "19bbdf1cce0346ef7341705d71e2ecf6f41a35c311137f29b8a2dc2341374565",
+              "url": "https://files.pythonhosted.org/packages/af/64/7c601dc6e20dfb855bf81654a81daf71522a4c66af2a576a25373d10871f/greenlet-3.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "28e89e232c7593d33cac35425b58950789962011cc274aa43ef8865f2e11f46d",
+              "url": "https://files.pythonhosted.org/packages/b0/44/22b51624026a9cdf2160eb1ec2bb22dd6de00bc9afefbd63eb57808af79c/greenlet-3.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "f89e21afe925fcfa655965ca8ea10f24773a1791400989ff32f467badfe4a064",
+              "url": "https://files.pythonhosted.org/packages/d0/ea/011598ab312a1caf413cd8d12675342e2a7a74d3b8bfac3f2a051649aba4/greenlet-3.0.1-cp310-cp310-macosx_10_9_universal2.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "b641161c302efbb860ae6b081f406839a8b7d5573f20a455539823802c655f63",
+              "url": "https://files.pythonhosted.org/packages/da/ab/7cc6502628565d70dce2edb619d87554d65ac4e2f17c805a5a45bfaefa5c/greenlet-3.0.1-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl"
+            }
+          ],
+          "project_name": "greenlet",
+          "requires_dists": [
+            "Sphinx; extra == \"docs\"",
+            "objgraph; extra == \"test\"",
+            "psutil; extra == \"test\""
+          ],
+          "requires_python": ">=3.7",
+          "version": "3.0.1"
         },
         {
           "artifacts": [
@@ -1559,13 +1619,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "5cf0736d1f43cb887498d00b00ae522774bfddb7db1f4994fedea65b290b9f0e",
-              "url": "https://files.pythonhosted.org/packages/16/74/d358d6b8859168a778a4c01630f1f5ab6fb1ae3fe3f516b2ba4269158d3d/moto-4.2.10-py2.py3-none-any.whl"
+              "hash": "58c12ab9ee69b6a5d1cddf83611ba4071508f07894317c57844b3ae6dc5bcd38",
+              "url": "https://files.pythonhosted.org/packages/25/2f/5d75d73bced248bcd024284f4c99d019841a2535199611fbdc614b75f270/moto-4.2.11-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "92595fe287474a31ac3ef847941ebb097e8ffb0c3d6c106e47cf573db06933b2",
-              "url": "https://files.pythonhosted.org/packages/ee/bc/4ec843bf29f682e0aa14645ddcba9e203b4fe5363d3cce1724dda7199981/moto-4.2.10.tar.gz"
+              "hash": "2da62d52eaa765dfe2762c920f0a88a58f3a09e04581c91db967d92faec848f1",
+              "url": "https://files.pythonhosted.org/packages/f0/9d/32031dee4457a6c6ef0b8c4ad18a170ca471c20cb83313c13bb896e09ead/moto-4.2.11.tar.gz"
             }
           ],
           "project_name": "moto",
@@ -1679,7 +1739,7 @@
             "xmltodict"
           ],
           "requires_python": ">=3.7",
-          "version": "4.2.10"
+          "version": "4.2.11"
         },
         {
           "artifacts": [
@@ -2525,6 +2585,87 @@
           "artifacts": [
             {
               "algorithm": "sha256",
+              "hash": "31952bbc527d633b9479f5f81e8b9dfada00b91d6baba021a869095f1a97006d",
+              "url": "https://files.pythonhosted.org/packages/a9/a3/9afc2bf14c5892640c15d050bd9c9bfefead29cb041560734dff13bf0890/SQLAlchemy-2.0.23-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "0666031df46b9badba9bed00092a1ffa3aa063a5e68fa244acd9f08070e936d3",
+              "url": "https://files.pythonhosted.org/packages/1d/40/9c7169cb4dc66c0a2d4cf5ff016faab417d30a1d2deea57780b329dd4fe5/SQLAlchemy-2.0.23-cp310-cp310-musllinux_1_1_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "787af80107fb691934a01889ca8f82a44adedbf5ef3d6ad7d0f0b9ac557e0c34",
+              "url": "https://files.pythonhosted.org/packages/53/30/339fd68c0200a8f70d9198ca250c2ba0e4683ba11ba42423f300a041dfc9/SQLAlchemy-2.0.23-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "638c2c0b6b4661a4fd264f6fb804eccd392745c5887f9317feb64bb7cb03b3ea",
+              "url": "https://files.pythonhosted.org/packages/53/ce/d7262dcc228f66c4d805c8975f71deca581e8a56b46612eb35708ec5cb51/SQLAlchemy-2.0.23-cp310-cp310-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "c14eba45983d2f48f7546bb32b47937ee2cafae353646295f0e99f35b14286ab",
+              "url": "https://files.pythonhosted.org/packages/aa/1c/0b66318368b1c9ef51c5c8560530b8ef842164e10eea08cacb06739388e0/SQLAlchemy-2.0.23-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "89a01238fcb9a8af118eaad3ffcc5dedaacbd429dc6fdc43fe430d3a941ff965",
+              "url": "https://files.pythonhosted.org/packages/ac/40/efe4320de1de9af3b6e538f89e2f1d56f83209fddbec77bafa06ee4f42c6/SQLAlchemy-2.0.23-cp310-cp310-musllinux_1_1_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "e3b5036aa326dc2df50cba3c958e29b291a80f604b1afa4c8ce73e78e1c9f01d",
+              "url": "https://files.pythonhosted.org/packages/e7/25/cfcc50c21cb133ae44f9aba61b48285451b6ecb882af291fe9da6445f4da/SQLAlchemy-2.0.23-cp310-cp310-macosx_11_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "c1bda93cbbe4aa2aa0aa8655c5aeda505cd219ff3e8da91d1d329e143e4aff69",
+              "url": "https://files.pythonhosted.org/packages/ee/46/a3196db7ffd2609c7935798730e21bed8806d9bf4401921587dac4be0747/SQLAlchemy-2.0.23.tar.gz"
+            }
+          ],
+          "project_name": "sqlalchemy",
+          "requires_dists": [
+            "aiomysql>=0.2.0; extra == \"aiomysql\"",
+            "aioodbc; extra == \"aioodbc\"",
+            "aiosqlite; extra == \"aiosqlite\"",
+            "asyncmy!=0.2.4,!=0.2.6,>=0.2.3; extra == \"asyncmy\"",
+            "asyncpg; extra == \"postgresql_asyncpg\"",
+            "cx-oracle>=8; extra == \"oracle\"",
+            "greenlet!=0.4.17; extra == \"aiomysql\"",
+            "greenlet!=0.4.17; extra == \"aioodbc\"",
+            "greenlet!=0.4.17; extra == \"aiosqlite\"",
+            "greenlet!=0.4.17; extra == \"asyncio\"",
+            "greenlet!=0.4.17; extra == \"asyncmy\"",
+            "greenlet!=0.4.17; extra == \"postgresql_asyncpg\"",
+            "greenlet!=0.4.17; platform_machine == \"aarch64\" or (platform_machine == \"ppc64le\" or (platform_machine == \"x86_64\" or (platform_machine == \"amd64\" or (platform_machine == \"AMD64\" or (platform_machine == \"win32\" or platform_machine == \"WIN32\")))))",
+            "importlib-metadata; python_version < \"3.8\"",
+            "mariadb!=1.1.2,!=1.1.5,>=1.0.1; extra == \"mariadb_connector\"",
+            "mypy>=0.910; extra == \"mypy\"",
+            "mysql-connector-python; extra == \"mysql_connector\"",
+            "mysqlclient>=1.4.0; extra == \"mysql\"",
+            "oracledb>=1.0.1; extra == \"oracle_oracledb\"",
+            "pg8000>=1.29.1; extra == \"postgresql_pg8000\"",
+            "psycopg2-binary; extra == \"postgresql_psycopg2binary\"",
+            "psycopg2>=2.7; extra == \"postgresql\"",
+            "psycopg2cffi; extra == \"postgresql_psycopg2cffi\"",
+            "psycopg>=3.0.7; extra == \"postgresql_psycopg\"",
+            "psycopg[binary]>=3.0.7; extra == \"postgresql_psycopgbinary\"",
+            "pymssql; extra == \"mssql_pymssql\"",
+            "pymysql; extra == \"pymysql\"",
+            "pyodbc; extra == \"mssql\"",
+            "pyodbc; extra == \"mssql_pyodbc\"",
+            "sqlcipher3-binary; extra == \"sqlcipher\"",
+            "typing-extensions!=3.10.0.1; extra == \"aiosqlite\"",
+            "typing-extensions>=4.2.0"
+          ],
+          "requires_python": ">=3.7",
+          "version": "2.0.23"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
               "hash": "a4ca3d31594ce8e9e7914d44b6f4607e45bebd79a44bb9c1ffe25d06db9ccb9f",
               "url": "https://files.pythonhosted.org/packages/96/ca/d91d9363cc6032d9c034657073eb5033e2d6fe586e43659cc7c0f6c492b5/ssm_parameter_store-19.11.0-py2.py3-none-any.whl"
             },
@@ -2798,13 +2939,16 @@
     "moto[s3,ssm]>=4.2.5",
     "pandas-stubs>=2.0.3",
     "pandas>=2.1.1",
+    "pydantic>=2.5.2",
     "pytest>=7.2.0",
     "pyyaml==6.0",
     "requests>=2.18.4",
     "setuptools>=68.2.2",
+    "sqlalchemy>=2.0.23",
     "ssm-parameter-store>=19.11.0",
     "types-PyYAML>=6.0.12",
-    "types-requests"
+    "types-requests",
+    "typing-extensions>=4.8.0"
   ],
   "requires_python": [
     "==3.10.*"

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,9 +7,12 @@ fw-utils>=3
 moto[s3,ssm]>=4.2.5
 pandas>=2.1.1
 pandas-stubs>=2.0.3
+pydantic>=2.5.2
 pyyaml==6.0
 pytest>=7.2.0
 requests>=2.18.4
 setuptools>=68.2.2
+sqlalchemy>=2.0.23
 ssm-parameter-store>=19.11.0
+typing-extensions>=4.8.0 # only needed for python < 3.12
 types-PyYAML>=6.0.12


### PR DESCRIPTION
This changes parameter methods so use a common generic method using Pydantic dictionary checking to eliminate duplicated code across methods.

Also, adds a method for pulling RDS parameters. Though may want to remove specialized methods at some point.

Note that using Pydantic in the way that is used here either requires Python 3.12 or above or using the typing-extensions package. Using typing-extensions here, but does cause some weirdness of types.
Also, it appears that VSCode Plyance doesn't handle some of the typing correctly.
