### PR TITLE
Pull identifiers from identifier-lookup-gear

### DIFF
--- a/common/src/python/identifiers/BUILD
+++ b/common/src/python/identifiers/BUILD
@@ -1,0 +1,1 @@
+python_sources(name="lib")

--- a/common/src/python/identifiers/database.py
+++ b/common/src/python/identifiers/database.py
@@ -1,0 +1,23 @@
+"""Utilities for managing connection to identifier database."""
+from identifiers.identifiers_tables import metadata
+from inputs.parameter_store import RDSParameters
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+
+def create_from(parameters: RDSParameters) -> Session:
+    """Creates an IdentifierRepository.
+
+    Args:
+        parameters: the credentials for the database connection
+    Returns:
+        the IdentifierRepository for the identifier database at the URL
+    """
+    port = 3306
+    database = 'identifier'
+    database_url = (f"mysql+mysqlconnector://{parameters['user']}:"
+                    f"{parameters['password']}@{parameters['host']}:"
+                    f"{port}/{database}")
+    engine = create_engine(url=database_url)
+    metadata.create_all(engine)
+    return sessionmaker(bind=engine)()

--- a/common/src/python/identifiers/database.py
+++ b/common/src/python/identifiers/database.py
@@ -5,13 +5,13 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
 
 
-def create_from(parameters: RDSParameters) -> Session:
-    """Creates an IdentifierRepository.
+def create_session(parameters: RDSParameters) -> Session:
+    """Creates a Session for the identifiers database.
 
     Args:
         parameters: the credentials for the database connection
     Returns:
-        the IdentifierRepository for the identifier database at the URL
+        the Session for the identifier database at the URL
     """
     port = 3306
     database = 'identifier'

--- a/common/src/python/identifiers/identifiers_repository.py
+++ b/common/src/python/identifiers/identifiers_repository.py
@@ -15,6 +15,9 @@ class IdentifierRepository:
     """Repository for Identifier records.
 
     Assumes the Identifier class is mapped to the identifier table.
+
+    Create repository within a resource block for a session to ensure that
+    session lifecycle is correct.
     """
 
     def __init__(self, session: Session) -> None:

--- a/common/src/python/identifiers/identifiers_repository.py
+++ b/common/src/python/identifiers/identifiers_repository.py
@@ -6,12 +6,9 @@ https://github.com/cosmicpython/code/tree/chapter_02_repository_exercise
 
 from typing import List, Optional, overload
 
-from identifiers.identifiers_tables import metadata
 from identifiers.model import Identifier
-from inputs.parameter_store import RDSParameters
-from sqlalchemy import create_engine
 from sqlalchemy.exc import NoResultFound
-from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.orm import Session
 
 
 class IdentifierRepository:
@@ -22,27 +19,6 @@ class IdentifierRepository:
 
     def __init__(self, session: Session) -> None:
         self.__session = session
-
-    @classmethod
-    def create_from(cls, parameters: RDSParameters) -> 'IdentifierRepository':
-        """Creates an IdentifierRepository.
-
-        Args:
-          parameters: the credentials for the database connection
-        Returns:
-          the IdentifierRepository for the identifier database at the URL
-        """
-        port = 3306
-        database = 'identifier'
-        database_url = (f"mysql+mysqlconnector://{parameters['user']}:"
-                        f"{parameters['password']}@{parameters['host']}:"
-                        f"{port}/{database}")
-        engine = create_engine(url=database_url)
-        metadata.create_all(engine)
-        session = sessionmaker(bind=engine)()
-        return IdentifierRepository(session)
-
-    # def add(self, identifier: Identifier):
 
     @overload
     def get(self, nacc_id: int) -> Identifier:

--- a/common/src/python/identifiers/identifiers_repository.py
+++ b/common/src/python/identifiers/identifiers_repository.py
@@ -1,0 +1,119 @@
+"""Repository for Identifiers.
+
+Inspired by
+https://github.com/cosmicpython/code/tree/chapter_02_repository_exercise
+"""
+
+from typing import List, Optional, overload
+
+from identifiers.identifiers_tables import metadata
+from identifiers.model import Identifier
+from inputs.parameter_store import RDSParameters
+from sqlalchemy import create_engine
+from sqlalchemy.exc import NoResultFound
+from sqlalchemy.orm import Session, sessionmaker
+
+
+class IdentifierRepository:
+    """Repository for Identifier records.
+
+    Assumes the Identifier class is mapped to the identifier table.
+    """
+
+    def __init__(self, session: Session) -> None:
+        self.__session = session
+
+    @classmethod
+    def create_from(cls, parameters: RDSParameters) -> 'IdentifierRepository':
+        """Creates an IdentifierRepository.
+
+        Args:
+          parameters: the credentials for the database connection
+        Returns:
+          the IdentifierRepository for the identifier database at the URL
+        """
+        port = 3306
+        database = 'identifier'
+        database_url = (f"mysql+mysqlconnector://{parameters['user']}:"
+                        f"{parameters['password']}@{parameters['host']}:"
+                        f"{port}/{database}")
+        engine = create_engine(url=database_url)
+        metadata.create_all(engine)
+        session = sessionmaker(bind=engine)()
+        return IdentifierRepository(session)
+
+    # def add(self, identifier: Identifier):
+
+    @overload
+    def get(self, nacc_id: int) -> Identifier:
+        ...
+
+    @overload
+    def get(self, nacc_id: Optional[int], adc_id: int,
+            ptid: str) -> Identifier:
+        ...
+
+    def get(self,
+            nacc_id: Optional[int] = None,
+            adc_id: Optional[int] = None,
+            ptid: Optional[str] = None) -> Identifier:
+        """Returns Identifier object for the IDs given.
+
+        Note: some valid arguments can be falsey.
+        These are explicitly checked that they are not None.
+
+        Args:
+          nacc_id: the (integer part of the) NACCID
+          adc_id: the center ID
+          ptid: the participant ID assigned by the center
+        Returns:
+          the identifier for the nacc_id or the adcid-ptid pair
+        Raises:
+          NoMatchingIdentifier: if no Identifier record was found
+          TypeError: if the arguments are nonsensical
+        """
+        print(f"arguments: {nacc_id}, {adc_id}, {ptid}")
+        if nacc_id is not None:
+            try:
+                return self.__session.query(Identifier).filter_by(
+                    nacc_id=nacc_id).one()
+            except NoResultFound as error:
+                raise NoMatchingIdentifier("NACCID not found") from error
+
+        if adc_id is not None and ptid:
+            try:
+                return self.__session.query(Identifier).filter_by(
+                    adc_id=adc_id, patient_id=ptid).one()
+            except NoResultFound as error:
+                raise NoMatchingIdentifier(
+                    "ADCID-PTID pair not found") from error
+
+        raise TypeError("Invalid arguments")
+
+    @overload
+    def list(self, adc_id: int) -> List[Identifier]:
+        ...
+
+    @overload
+    def list(self) -> List[Identifier]:
+        ...
+
+    def list(self, adc_id: Optional[int] = None) -> List[Identifier]:
+        """Returns the list of all identifiers in the repository.
+
+        If an ADCID is given filters identifiers by the center.
+
+        Args:
+          adc_id: the ADCID used for filtering
+
+        Returns:
+          List of all identifiers in the repository
+        """
+        if adc_id is None:
+            return self.__session.query(Identifier).all()
+
+        return self.__session.query(Identifier).filter_by(adc_id=adc_id).all()
+
+
+class NoMatchingIdentifier(Exception):
+    """Exception for case when identifier is matched."""

--- a/common/src/python/identifiers/identifiers_repository.py
+++ b/common/src/python/identifiers/identifiers_repository.py
@@ -95,4 +95,4 @@ class IdentifierRepository:
 
 
 class NoMatchingIdentifier(Exception):
-    """Exception for case when identifier is matched."""
+    """Exception for case when identifier is not matched."""

--- a/common/src/python/identifiers/identifiers_tables.py
+++ b/common/src/python/identifiers/identifiers_tables.py
@@ -1,0 +1,15 @@
+"""Defines the table for the identifier database and maps the identifier class
+to the table."""
+from identifiers.model import Identifier
+from sqlalchemy import Column, Integer, MetaData, String, Table
+from sqlalchemy.orm import registry
+
+metadata = MetaData()
+
+identifier_table = Table('identifier', metadata,
+                         Column("nacc_id", Integer, primary_key=True),
+                         Column("nacc_adc", Integer, nullable=False),
+                         Column("adc_id", Integer, nullable=False),
+                         Column("patient_id", String(10), nullable=False))
+
+registry().map_imperatively(Identifier, identifier_table)

--- a/common/src/python/identifiers/model.py
+++ b/common/src/python/identifiers/model.py
@@ -17,5 +17,5 @@ class Identifier:
 
     @property
     def ptid(self) -> str:
-        """The center assigned participant ID"""
+        """The center assigned participant ID."""
         return self.patient_id

--- a/common/src/python/identifiers/model.py
+++ b/common/src/python/identifiers/model.py
@@ -1,0 +1,21 @@
+"""Defines the Identifier data class."""
+from dataclasses import dataclass
+
+
+@dataclass(unsafe_hash=True)
+class Identifier:
+    """Record for identifier correspondence."""
+    nacc_id: int
+    nacc_adc: int
+    adc_id: int
+    patient_id: str
+
+    @property
+    def naccid(self) -> str:
+        """The string NACCID for this identifier."""
+        return f"NACC{str(self.nacc_id).zfill(6)}"
+
+    @property
+    def ptid(self) -> str:
+        """The center assigned participant ID"""
+        return self.patient_id

--- a/common/test/python/identifiers/BUILD
+++ b/common/test/python/identifiers/BUILD
@@ -1,0 +1,3 @@
+python_sources()
+
+python_tests(name="tests", )

--- a/common/test/python/identifiers/test_identifiers.py
+++ b/common/test/python/identifiers/test_identifiers.py
@@ -1,0 +1,122 @@
+"""Tests for IdentifierRepository."""
+
+import pytest
+from identifiers.identifiers_repository import (IdentifierRepository,
+                                                NoMatchingIdentifier)
+from identifiers.identifiers_tables import metadata
+from identifiers.model import Identifier
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+
+# pylint: disable=(redefined-outer-name)
+@pytest.fixture(scope="function")
+def sqlite_db():
+    """Fixture to create sqlite database for testing."""
+    engine = create_engine("sqlite:///:memory:")
+    metadata.create_all(engine)
+    return engine
+
+
+# pylint: disable=(redefined-outer-name)
+@pytest.fixture(scope="function")
+def session(sqlite_db):
+    """Fixture to create session for sqlite database."""
+    yield sessionmaker(bind=sqlite_db)()
+
+
+# pylint: disable=(no-self-use)
+class TestIdentifierRepository:
+    """Tests for the IdentifierRepository class."""
+
+    def test_identifier_load(self, session):
+        """Sanity check that mapping works for save."""
+        session.execute(
+            text("INSERT INTO identifier "
+                 "(nacc_id, nacc_adc, adc_id, patient_id) VALUES "
+                 '(1, 2934, 0, "992321"),'
+                 '(2, 5397, 0, "168721"),'
+                 '(3, 7162, 0, "239451")'))
+        expected = [
+            Identifier(nacc_id=1, nacc_adc=2934, adc_id=0,
+                       patient_id="992321"),
+            Identifier(nacc_id=2, nacc_adc=5397, adc_id=0,
+                       patient_id="168721"),
+            Identifier(nacc_id=3, nacc_adc=7162, adc_id=0, patient_id="239451")
+        ]
+        assert session.query(Identifier).all() == expected
+
+    def test_identifier_save(self, session):
+        """Sanity check that mapping works for save."""
+        new_identifier = Identifier(nacc_id=4,
+                                    nacc_adc=9999,
+                                    adc_id=0,
+                                    patient_id="11111")
+        session.add(new_identifier)
+        session.commit()
+
+        rows = list(
+            session.execute(
+                text('SELECT nacc_id, nacc_adc, adc_id, patient_id '
+                     'FROM "identifier"')))
+        assert rows == [(4, 9999, 0, "11111")]
+
+    def test_empty_repository(self, session):
+        """Test empty repository behaves empty."""
+        repo = IdentifierRepository(session)
+        assert not repo.list()
+
+        with pytest.raises(NoMatchingIdentifier) as error:
+            repo.get(nacc_id=1)
+        assert str(error.value) == "NACCID not found"
+
+    def test_non_empty_repository(self, session):
+        """Test repository after add."""
+        expected = [
+            Identifier(nacc_id=1, nacc_adc=2934, adc_id=0,
+                       patient_id="992321"),
+            Identifier(nacc_id=2, nacc_adc=5397, adc_id=0,
+                       patient_id="168721"),
+            Identifier(nacc_id=3, nacc_adc=7162, adc_id=0, patient_id="239451")
+        ]
+
+        for identifier in expected:
+            session.add(identifier)
+        session.commit()
+
+        repo = IdentifierRepository(session)
+        assert repo.list() == expected
+        assert repo.get(nacc_id=1) == Identifier(nacc_id=1,
+                                                 nacc_adc=2934,
+                                                 adc_id=0,
+                                                 patient_id="992321")
+        assert repo.get(adc_id=0, ptid="992321") == Identifier(  # type: ignore
+            nacc_id=1,
+            nacc_adc=2934,
+            adc_id=0,
+            patient_id="992321")
+        with pytest.raises(NoMatchingIdentifier) as error:
+            repo.get(adc_id=1, ptid="0")  # type: ignore
+        assert str(error.value) == "ADCID-PTID pair not found"
+        with pytest.raises(TypeError) as error:
+            repo.get(adc_id=0, ptid="")  # type: ignore
+        assert str(error.value) == "Invalid arguments"
+
+    def test_list_by_adcid(self, session):
+        """Test listing by ADCID."""
+
+        expected = [
+            Identifier(nacc_id=1, nacc_adc=2934, adc_id=0,
+                       patient_id="992321"),
+            Identifier(nacc_id=3, nacc_adc=7162, adc_id=0, patient_id="239451")
+        ]
+
+        for identifier in expected:
+            session.add(identifier)
+        session.add(
+            Identifier(nacc_id=2, nacc_adc=5397, adc_id=1,
+                       patient_id="168721"))
+        session.commit()
+
+        repo = IdentifierRepository(session)
+        assert repo.list(adc_id=0) == expected


### PR DESCRIPTION
Adds a repository for identifiers. Currently, uses SQLAlchemy to connect to RDS identifier database.  Includes tests using local sqlite database.