### PR TITLE
Pull error handling from identifier lookup

### DIFF
--- a/common/src/python/outputs/BUILD
+++ b/common/src/python/outputs/BUILD
@@ -1,0 +1,1 @@
+python_sources(name="lib")

--- a/common/src/python/outputs/errors.py
+++ b/common/src/python/outputs/errors.py
@@ -57,7 +57,6 @@ class FileError(BaseModel):
         """
         return type.model_dump_json()
 
-
 def identifier_error(line: int, value: str) -> FileError:
     """Creates a FileError for an unrecognized PTID error in a CSV file.
 

--- a/common/src/python/outputs/errors.py
+++ b/common/src/python/outputs/errors.py
@@ -2,12 +2,12 @@
 from typing import Literal, Optional, TextIO
 
 from outputs.outputs import CSVWriter
-from pydantic import BaseModel, field_serializer
+from pydantic import BaseModel, Field, field_serializer
 
 
 class ErrorType(BaseModel):
     """Represents type of error."""
-    type: Literal['alert', 'error']
+    error_type: Literal['alert', 'error'] = Field(serialization_alias='type')
     detail: str
 
 
@@ -26,6 +26,7 @@ class FileError(BaseModel):
     """Represents an error that might be found in file during a step in a
     pipeline."""
     error_type: ErrorType
+    error_id: Optional[str] = None
     error_location: Optional[CSVLocation | JSONLocation] = None
     container_id: Optional[str] = None
     value: Optional[str] = None
@@ -62,7 +63,7 @@ class FileError(BaseModel):
         if not error_type:
             return None
 
-        return error_type.model_dump_json()
+        return error_type.model_dump_json(by_alias=True)
 
 
 def identifier_error(line: int, value: str) -> FileError:
@@ -76,7 +77,8 @@ def identifier_error(line: int, value: str) -> FileError:
     Returns:
       a FileError object initialized for an identifier error
     """
-    return FileError(error_type=ErrorType(type='error', detail='identifier'),
+    return FileError(error_type=ErrorType(error_type='error',
+                                          detail='identifier'),
                      error_location=CSVLocation(line=line, column_name='ptid'),
                      value=value,
                      message='Unrecognized participant ID')
@@ -84,13 +86,14 @@ def identifier_error(line: int, value: str) -> FileError:
 
 def empty_file_error() -> FileError:
     """Creates a FileError for an empty input file."""
-    return FileError(error_type=ErrorType(type='error', detail='empty-file'),
+    return FileError(error_type=ErrorType(error_type='error',
+                                          detail='empty-file'),
                      message='Empty input file')
 
 
 def missing_header_error() -> FileError:
     """Creates a FileError for a missing header."""
-    return FileError(error_type=ErrorType(type='error',
+    return FileError(error_type=ErrorType(error_type='error',
                                           detail='missing-header'),
                      message='No file header found')
 
@@ -99,9 +102,10 @@ def missing_header_error() -> FileError:
 class ErrorWriter:
     """Writes FileErrors to a stream as CSV."""
 
-    def __init__(self, stream: TextIO,
-                 container_id: str) -> None:
-        self.__writer = CSVWriter(stream=stream, fieldnames=list(FileError.__annotations__.keys()))
+    def __init__(self, stream: TextIO, container_id: str) -> None:
+        self.__writer = CSVWriter(stream=stream,
+                                  fieldnames=list(
+                                      FileError.__annotations__.keys()))
         self.__container_id = container_id
 
     def write(self, error: FileError) -> None:

--- a/common/src/python/outputs/errors.py
+++ b/common/src/python/outputs/errors.py
@@ -1,0 +1,113 @@
+"""Utilities for writing errors to a CSV error file."""
+from csv import DictWriter
+from typing import Literal, Optional, TextIO
+
+from pydantic import BaseModel, field_serializer
+
+
+class ErrorType(BaseModel):
+    """Represents type of error."""
+    type: Literal['alert', 'error']
+    detail: str
+
+
+class CSVLocation(BaseModel):
+    """Represents location of an error in a CSV file."""
+    line: int
+    column_name: str
+
+
+class JSONLocation(BaseModel):
+    """Represents the location of an error in a JSON file."""
+    key_path: str
+
+
+class FileError(BaseModel):
+    """Represents an error that might be found in file during a step in a
+    pipeline."""
+    error_type: ErrorType
+    error_location: CSVLocation | JSONLocation
+    flywheel_path: Optional[str] = None
+    container_id: Optional[str] = None
+    value: str
+    expected: Optional[str] = None
+    message: str
+
+    # pylint: disable=no-self-use
+    @field_serializer('error_location')
+    def serialize_location(self, location: CSVLocation | JSONLocation):
+        """Serializes the error_location field to a JSON string.
+
+        Args:
+          location: the location object
+        Returns:
+          JSON string representation of the location object
+        """
+        return location.model_dump_json()
+
+    # pylint: disable=no-self-use
+    @field_serializer('error_type')
+    def serialize_type(self, type: ErrorType):
+        """Serializes the error_type field to a JSON string.
+
+        Args:
+          type: the error type
+        Returns:
+          JSON string representation of the error type
+        """
+        return type.model_dump_json()
+
+
+def identifier_error(line: int, value: str) -> FileError:
+    """Creates a FileError for an unrecognized PTID error in a CSV file.
+
+    Tags the error type as 'error:identifier'
+
+    Args:
+      line: the line where error occurred
+      value: the value of the PTID
+    Returns:
+      a FileError object initialized for an identifier error
+    """
+    return FileError(error_type=ErrorType(type='error', detail='identifier'),
+                     error_location=CSVLocation(line=line, column_name='ptid'),
+                     flywheel_path=None,
+                     container_id=None,
+                     value=value,
+                     expected=None,
+                     message='Unrecognized participant ID')
+
+
+# pylint: disable=(too-few-public-methods)
+class ErrorWriter:
+    """Writes FileErrors to a stream as CSV."""
+
+    def __init__(self, stream: TextIO, flywheel_path: str,
+                 container_id: str) -> None:
+        self.__writer = DictWriter(stream,
+                                   fieldnames=FileError.__annotations__.keys(),
+                                   dialect='unix')
+        self.__flywheel_path = flywheel_path
+        self.__container_id = container_id
+        self.__header_written = False
+
+    def __write_header(self):
+        """Writes the header to the output stream."""
+        if self.__header_written:
+            return
+
+        self.__writer.writeheader()
+        self.__header_written = True
+
+    def write(self, error: FileError) -> None:
+        """Writes the error to the output stream with flywheel hierarchy
+        information filled in for the reference file.
+
+        Args:
+          error: the file error object
+        """
+        self.__write_header()
+
+        error.flywheel_path = self.__flywheel_path
+        error.container_id = self.__container_id
+        self.__writer.writerow(error.model_dump())

--- a/common/src/python/outputs/errors.py
+++ b/common/src/python/outputs/errors.py
@@ -26,10 +26,10 @@ class FileError(BaseModel):
     """Represents an error that might be found in file during a step in a
     pipeline."""
     error_type: ErrorType
-    error_location: CSVLocation | JSONLocation
+    error_location: Optional[CSVLocation | JSONLocation] = None
     flywheel_path: Optional[str] = None
     container_id: Optional[str] = None
-    value: str
+    value: Optional[str] = None
     expected: Optional[str] = None
     message: str
 
@@ -70,12 +70,18 @@ def identifier_error(line: int, value: str) -> FileError:
     """
     return FileError(error_type=ErrorType(type='error', detail='identifier'),
                      error_location=CSVLocation(line=line, column_name='ptid'),
-                     flywheel_path=None,
-                     container_id=None,
                      value=value,
-                     expected=None,
                      message='Unrecognized participant ID')
 
+def empty_file_error() -> FileError:
+    """Creates a FileError for an empty input file."""
+    return FileError(error_type=ErrorType(type='error', detail='empty-file'),
+                     message='Empty input file')
+
+def missing_header_error() -> FileError:
+    """Creates a FileError for a missing header"""
+    return FileError(error_type=ErrorType(type='error', detail='missing-header'),
+                     message='No file header found')
 
 # pylint: disable=(too-few-public-methods)
 class ErrorWriter:

--- a/common/src/python/outputs/errors.py
+++ b/common/src/python/outputs/errors.py
@@ -27,7 +27,6 @@ class FileError(BaseModel):
     pipeline."""
     error_type: ErrorType
     error_location: Optional[CSVLocation | JSONLocation] = None
-    flywheel_path: Optional[str] = None
     container_id: Optional[str] = None
     value: Optional[str] = None
     expected: Optional[str] = None
@@ -100,10 +99,9 @@ def missing_header_error() -> FileError:
 class ErrorWriter:
     """Writes FileErrors to a stream as CSV."""
 
-    def __init__(self, stream: TextIO, flywheel_path: str,
+    def __init__(self, stream: TextIO,
                  container_id: str) -> None:
         self.__writer = CSVWriter(stream=stream, fieldnames=list(FileError.__annotations__.keys()))
-        self.__flywheel_path = flywheel_path
         self.__container_id = container_id
 
     def write(self, error: FileError) -> None:
@@ -113,6 +111,5 @@ class ErrorWriter:
         Args:
           error: the file error object
         """
-        error.flywheel_path = self.__flywheel_path
         error.container_id = self.__container_id
         self.__writer.write(error.model_dump())

--- a/common/src/python/outputs/errors.py
+++ b/common/src/python/outputs/errors.py
@@ -97,17 +97,16 @@ def missing_header_error() -> FileError:
 
 
 # pylint: disable=(too-few-public-methods)
-class ErrorWriter(CSVWriter):
+class ErrorWriter:
     """Writes FileErrors to a stream as CSV."""
 
     def __init__(self, stream: TextIO, flywheel_path: str,
                  container_id: str) -> None:
-        super().__init__(stream,
-                         fieldnames=list(FileError.__annotations__.keys()))
+        self.__writer = CSVWriter(stream=stream, fieldnames=list(FileError.__annotations__.keys()))
         self.__flywheel_path = flywheel_path
         self.__container_id = container_id
 
-    def write_error(self, error: FileError) -> None:
+    def write(self, error: FileError) -> None:
         """Writes the error to the output stream with flywheel hierarchy
         information filled in for the reference file.
 
@@ -116,4 +115,4 @@ class ErrorWriter(CSVWriter):
         """
         error.flywheel_path = self.__flywheel_path
         error.container_id = self.__container_id
-        self.write(error.model_dump())
+        self.__writer.write(error.model_dump())

--- a/common/src/python/outputs/errors.py
+++ b/common/src/python/outputs/errors.py
@@ -35,7 +35,8 @@ class FileError(BaseModel):
 
     # pylint: disable=no-self-use
     @field_serializer('error_location')
-    def serialize_location(self, location: CSVLocation | JSONLocation):
+    def serialize_location(self,
+                           location: Optional[CSVLocation | JSONLocation]):
         """Serializes the error_location field to a JSON string.
 
         Args:
@@ -43,11 +44,14 @@ class FileError(BaseModel):
         Returns:
           JSON string representation of the location object
         """
+        if not location:
+            return None
+
         return location.model_dump_json()
 
     # pylint: disable=no-self-use
     @field_serializer('error_type')
-    def serialize_type(self, type: ErrorType):
+    def serialize_type(self, type: Optional[ErrorType]):
         """Serializes the error_type field to a JSON string.
 
         Args:
@@ -55,7 +59,12 @@ class FileError(BaseModel):
         Returns:
           JSON string representation of the error type
         """
+
+        if not type:
+            return None
+
         return type.model_dump_json()
+
 
 def identifier_error(line: int, value: str) -> FileError:
     """Creates a FileError for an unrecognized PTID error in a CSV file.
@@ -73,15 +82,19 @@ def identifier_error(line: int, value: str) -> FileError:
                      value=value,
                      message='Unrecognized participant ID')
 
+
 def empty_file_error() -> FileError:
     """Creates a FileError for an empty input file."""
     return FileError(error_type=ErrorType(type='error', detail='empty-file'),
                      message='Empty input file')
 
+
 def missing_header_error() -> FileError:
-    """Creates a FileError for a missing header"""
-    return FileError(error_type=ErrorType(type='error', detail='missing-header'),
+    """Creates a FileError for a missing header."""
+    return FileError(error_type=ErrorType(type='error',
+                                          detail='missing-header'),
                      message='No file header found')
+
 
 # pylint: disable=(too-few-public-methods)
 class ErrorWriter:

--- a/common/src/python/outputs/outputs.py
+++ b/common/src/python/outputs/outputs.py
@@ -1,0 +1,33 @@
+from csv import DictWriter
+from typing import Dict, List, Optional, TextIO
+
+
+class CSVWriter:
+    """Wrapper for DictWriter that ensures header is written."""
+
+    def __init__(self, stream: TextIO, fieldnames: List[str]) -> None:
+        self.__writer = DictWriter(stream,
+                                   fieldnames=fieldnames,
+                                   dialect='unix')
+        self.__header_written = False
+
+    def __write_header(self):
+        """Writes the header to the output stream."""
+        if self.__header_written:
+            return
+
+        self.__writer.writeheader()
+        self.__header_written = True
+
+    def write(self, object: Dict[str,
+                                 Optional[int | str | bool | float]]) -> None:
+        """Writes the dictionary to the stream.
+
+        Dictionary is assumed to correspond to a row from a CSV file, and so
+        the values all must have primitive types.
+
+        Args:
+          object: dictionary with only primitive values
+        """
+        self.__write_header()
+        self.__writer.writerow(object)

--- a/common/src/python/outputs/outputs.py
+++ b/common/src/python/outputs/outputs.py
@@ -1,7 +1,12 @@
+"""Defines utilities for writing data files."""
+
 from csv import DictWriter
 from typing import Dict, List, Optional, TextIO
 
+SimpleJSONObject = Dict[str, Optional[int | str | bool | float]]
 
+
+# pylint: disable=(too-few-public-methods)
 class CSVWriter:
     """Wrapper for DictWriter that ensures header is written."""
 
@@ -19,15 +24,14 @@ class CSVWriter:
         self.__writer.writeheader()
         self.__header_written = True
 
-    def write(self, object: Dict[str,
-                                 Optional[int | str | bool | float]]) -> None:
+    def write(self, json_object: SimpleJSONObject) -> None:
         """Writes the dictionary to the stream.
 
         Dictionary is assumed to correspond to a row from a CSV file, and so
         the values all must have primitive types.
 
         Args:
-          object: dictionary with only primitive values
+          json_object: dictionary with only primitive values
         """
         self.__write_header()
-        self.__writer.writerow(object)
+        self.__writer.writerow(json_object)

--- a/common/test/python/outputs/BUILD
+++ b/common/test/python/outputs/BUILD
@@ -1,0 +1,1 @@
+python_tests(name="tests", )

--- a/common/test/python/outputs/test_errors.py
+++ b/common/test/python/outputs/test_errors.py
@@ -15,7 +15,7 @@ class TestFileError:
     def test_serialization(self):
         """Tests that serialization produces a dict with the location a
         string."""
-        error = FileError(error_type=ErrorType(type='error',
+        error = FileError(error_type=ErrorType(error_type='error',
                                                detail='the-error'),
                           error_location=JSONLocation(key_path='k1.k2.k3'),
                           value='the-value',
@@ -49,10 +49,10 @@ class TestErrorWriter:
         """Tests that the error writer writes CSV with the flywheel hierarchy
         information inserted."""
         stream = StringIO()
-        writer = ErrorWriter(stream=stream,
-                             container_id='the-id')
+        writer = ErrorWriter(stream=stream, container_id='the-id')
         writer.write(
-            FileError(error_type=ErrorType(type='error', detail='the-error'),
+            FileError(error_type=ErrorType(error_type='error',
+                                           detail='the-error'),
                       error_location=CSVLocation(line=10, column_name='ptid'),
                       container_id=None,
                       value='the-value',

--- a/common/test/python/outputs/test_errors.py
+++ b/common/test/python/outputs/test_errors.py
@@ -5,7 +5,8 @@ from csv import DictReader
 from io import StringIO
 
 from outputs.errors import (CSVLocation, ErrorType, ErrorWriter, FileError,
-                            JSONLocation)
+                            JSONLocation, empty_file_error, identifier_error,
+                            missing_header_error)
 
 
 class TestFileError:
@@ -23,6 +24,22 @@ class TestFileError:
         assert isinstance(result, dict)
         assert result['error_location'] == '{"key_path":"k1.k2.k3"}'
         assert result['error_type'] == '{"type":"error","detail":"the-error"}'
+
+    def test_identifier_serialization(self):
+        """Tests that error created by identifier_error can be serialized."""
+        error = identifier_error(line=11, value='dummy')
+        assert error.model_dump()
+
+    def test_empty_file_serialization(self):
+        """Test that error created by empty_file_error can be serialized."""
+        error = empty_file_error()
+        assert error.model_dump()
+
+    def test_missing_header_serialization(self):
+        """Test that error created by missing_header_error can be
+        serialized."""
+        error = missing_header_error()
+        assert error.model_dump()
 
 
 class TestErrorWriter:

--- a/common/test/python/outputs/test_errors.py
+++ b/common/test/python/outputs/test_errors.py
@@ -52,7 +52,7 @@ class TestErrorWriter:
         writer = ErrorWriter(stream=stream,
                              flywheel_path="the-path",
                              container_id='the-id')
-        writer.write(
+        writer.write_error(
             FileError(error_type=ErrorType(type='error', detail='the-error'),
                       error_location=CSVLocation(line=10, column_name='ptid'),
                       flywheel_path=None,

--- a/common/test/python/outputs/test_errors.py
+++ b/common/test/python/outputs/test_errors.py
@@ -50,12 +50,10 @@ class TestErrorWriter:
         information inserted."""
         stream = StringIO()
         writer = ErrorWriter(stream=stream,
-                             flywheel_path="the-path",
                              container_id='the-id')
         writer.write(
             FileError(error_type=ErrorType(type='error', detail='the-error'),
                       error_location=CSVLocation(line=10, column_name='ptid'),
-                      flywheel_path=None,
                       container_id=None,
                       value='the-value',
                       expected=None,
@@ -65,5 +63,4 @@ class TestErrorWriter:
         assert reader.fieldnames
         assert reader.fieldnames == list(FileError.__annotations__.keys())
         row = next(reader)
-        assert row['flywheel_path'] == 'the-path'
         assert row['container_id'] == 'the-id'

--- a/common/test/python/outputs/test_errors.py
+++ b/common/test/python/outputs/test_errors.py
@@ -52,7 +52,7 @@ class TestErrorWriter:
         writer = ErrorWriter(stream=stream,
                              flywheel_path="the-path",
                              container_id='the-id')
-        writer.write_error(
+        writer.write(
             FileError(error_type=ErrorType(type='error', detail='the-error'),
                       error_location=CSVLocation(line=10, column_name='ptid'),
                       flywheel_path=None,

--- a/common/test/python/outputs/test_errors.py
+++ b/common/test/python/outputs/test_errors.py
@@ -1,0 +1,51 @@
+"""Tests for ErrorWriter class."""
+
+# pylint: disable=no-self-use,redefined-outer-name,too-few-public-methods
+from csv import DictReader
+from io import StringIO
+
+from outputs.errors import CSVLocation, ErrorType, ErrorWriter, FileError, JSONLocation
+
+
+class TestFileError:
+    """Tests the FileError model class."""
+
+    def test_serialization(self):
+        """Tests that serialization produces a dict with the location a
+        string."""
+        error = FileError(error_type=ErrorType(type='error', detail='the-error'),
+                          error_location=JSONLocation(key_path='k1.k2.k3'),
+                          value='the-value',
+                          message='the-message')
+        result = error.model_dump()
+        assert isinstance(result, dict)
+        assert result['error_location'] == '{"key_path":"k1.k2.k3"}'
+        assert result['error_type'] == '{"type":"error","detail":"the-error"}'
+
+
+class TestErrorWriter:
+    """Tests the error writer class."""
+
+    def test_write(self):
+        """Tests that the error writer writes CSV with the flywheel hierarchy
+        information inserted."""
+        stream = StringIO()
+        writer = ErrorWriter(stream=stream,
+                             flywheel_path="the-path",
+                             container_id='the-id')
+        writer.write(
+            FileError(error_type=ErrorType(type='error', detail='the-error'),
+                      error_location=CSVLocation(line=10, column_name='ptid'),
+                      flywheel_path=None,
+                      container_id=None,
+                      value='the-value',
+                      expected=None,
+                      message='the-message'))
+        stream.seek(0)
+        reader = DictReader(stream, dialect='unix')
+        assert reader.fieldnames
+        assert reader.fieldnames == list(FileError.__annotations__.keys())
+        row = next(reader)
+        assert row['flywheel_path'] == 'the-path'
+        assert row['container_id'] == 'the-id'
+

--- a/common/test/python/outputs/test_errors.py
+++ b/common/test/python/outputs/test_errors.py
@@ -4,7 +4,8 @@
 from csv import DictReader
 from io import StringIO
 
-from outputs.errors import CSVLocation, ErrorType, ErrorWriter, FileError, JSONLocation
+from outputs.errors import (CSVLocation, ErrorType, ErrorWriter, FileError,
+                            JSONLocation)
 
 
 class TestFileError:
@@ -13,7 +14,8 @@ class TestFileError:
     def test_serialization(self):
         """Tests that serialization produces a dict with the location a
         string."""
-        error = FileError(error_type=ErrorType(type='error', detail='the-error'),
+        error = FileError(error_type=ErrorType(type='error',
+                                               detail='the-error'),
                           error_location=JSONLocation(key_path='k1.k2.k3'),
                           value='the-value',
                           message='the-message')
@@ -48,4 +50,3 @@ class TestErrorWriter:
         row = next(reader)
         assert row['flywheel_path'] == 'the-path'
         assert row['container_id'] == 'the-id'
-

--- a/gear/project_management/src/docker/BUILD
+++ b/gear/project_management/src/docker/BUILD
@@ -3,6 +3,7 @@ file(name="manifest", source="manifest.json")
 docker_image(name="project-management",
              source="Dockerfile",
              dependencies=[
-                 ":manifest", "gear/project_management/src/python/project_app:bin"
+                 ":manifest",
+                 "gear/project_management/src/python/project_app:bin"
              ],
              image_tags=["0.0.1", "latest"])

--- a/gear/pull_directory/src/docker/BUILD
+++ b/gear/pull_directory/src/docker/BUILD
@@ -1,7 +1,9 @@
 file(name="manifest", source="manifest.json")
 
-docker_image(
-    name="pull-directory",
-    source="Dockerfile",
-    dependencies=[":manifest", "gear/pull_directory/src/python/directory_app:bin"],
-    image_tags=["0.0.9", "latest"])
+docker_image(name="pull-directory",
+             source="Dockerfile",
+             dependencies=[
+                 ":manifest",
+                 "gear/pull_directory/src/python/directory_app:bin"
+             ],
+             image_tags=["0.0.9", "latest"])

--- a/gear/pull_metadata/src/docker/BUILD
+++ b/gear/pull_metadata/src/docker/BUILD
@@ -1,7 +1,8 @@
 file(name="manifest", source="manifest.json")
 
-docker_image(
-    name="pull-metadata",
-    source="Dockerfile",
-    dependencies=[":manifest", "gear/pull_metadata/src/python/metadata_app:bin"],
-    image_tags=["0.0.9", "latest"])
+docker_image(name="pull-metadata",
+             source="Dockerfile",
+             dependencies=[
+                 ":manifest", "gear/pull_metadata/src/python/metadata_app:bin"
+             ],
+             image_tags=["0.0.9", "latest"])

--- a/gear/push_template/src/docker/BUILD
+++ b/gear/push_template/src/docker/BUILD
@@ -1,7 +1,8 @@
 file(name="manifest", source="manifest.json")
 
-docker_image(
-    name="push-template",
-    source="Dockerfile",
-    dependencies=[":manifest", "gear/push_template/src/python/template_app:bin"],
-    image_tags=["0.0.9", "latest"])
+docker_image(name="push-template",
+             source="Dockerfile",
+             dependencies=[
+                 ":manifest", "gear/push_template/src/python/template_app:bin"
+             ],
+             image_tags=["0.0.9", "latest"])


### PR DESCRIPTION
Adds classes for capturing and outputting errors/alerts to CSV file
Based on current error output format from @dpark6060's file-validator.

Uses Pydantic model classes to define error data.
Modifies serialization so that when errors are dumped to dict, fields that are also models are serialized to JSON strings.

Includes a helper method for the error that occurs when a PTID isn't recognized when checking identifiers. (In that scenario, the center ID is fixed). Expect would want to write similar helpers for other scenarios.

ErrorWriter class is used to write errors to CSV, inserting Flywheel coordinates for the referenced input file.

