### PR TITLE
Fix container parent type

### DIFF
--- a/gear/identifer_lookup/src/python/identifer_app/run.py
+++ b/gear/identifer_lookup/src/python/identifer_app/run.py
@@ -58,8 +58,9 @@ def get_adcid(proxy: FlywheelProxy, file_id: str) -> Optional[int]:
       the ADCID for the center
     """
     file = proxy.get_file(file_id)
-    group = file.parents.group
-    center = CenterGroup(group=group, proxy=proxy)
+    group_id = file.parents.group
+    groups = proxy.find_groups(group_id)
+    center = CenterGroup(group=groups[0], proxy=proxy)
     return center.center_id()
 
 

--- a/mypy-stubs/src/python/flywheel/models/container_parents.pyi
+++ b/mypy-stubs/src/python/flywheel/models/container_parents.pyi
@@ -4,5 +4,5 @@ from flywheel.models.group import Group
 class ContainerParents:
 
     @property
-    def group(self) -> Group:
+    def group(self) -> str:
         ...


### PR DESCRIPTION
Fixes return type of group property in type stub for parent_container, which returns the group ID rather than the group itself.