### PR TITLE
Parameterize gearbot API key

### DIFF
--- a/common/src/python/inputs/parameter_store.py
+++ b/common/src/python/inputs/parameter_store.py
@@ -67,10 +67,18 @@ class ParameterStore:
             ) from error
 
     # pylint disable=(line-to-long)
-    def get_api_key(self) -> str:
-        """Returns the GearBot API key."""
+    def get_api_key(self, path_prefix: str) -> str:
+        """Returns the GearBot API key.
+
+        Args:
+          path_prefix: the prefix for the parameter path
+        Returns:
+          the GearBot API key
+        Raises:
+          ParameterError: if the API key is not found
+        """
         parameter_name = 'apikey'
-        parameter_path = f'/prod/flywheel/gearbot/{parameter_name}'
+        parameter_path = f'{path_prefix}/{parameter_name}'
         try:
             parameter = self.__store.get_parameter(parameter_path,
                                                    decrypt=True)

--- a/common/test/python/inputs/test_parameter_store.py
+++ b/common/test/python/inputs/test_parameter_store.py
@@ -50,20 +50,21 @@ class TestParameterStore:
 
         # TODO: check error message
         with pytest.raises(ParameterError):
-            store.get_api_key()
+            store.get_api_key(path_prefix='/prod/flywheel/gearbot')
 
     def test_api_key(self, ssm):
         """Test getting api key that is present in store."""
         from inputs.parameter_store import ParameterStore
 
-        ssm.put_parameter(Name='/prod/flywheel/gearbot/apikey',
+        prefix = '/prod/flywheel/gearbot'
+        ssm.put_parameter(Name=f'{prefix}/apikey',
                           Type='SecureString',
                           Value='dummy')  # type: ignore
 
         store = ParameterStore.create_from_environment()
         assert store
 
-        value = store.get_api_key()
+        value = store.get_api_key(path_prefix=prefix)
         assert value == 'dummy'
 
     def test_dict_parameters(self, ssm):

--- a/gear/form_qc_checker/src/docker/manifest.json
+++ b/gear/form_qc_checker/src/docker/manifest.json
@@ -39,6 +39,12 @@
             "type": "boolean",
             "default": false
         },
+        "apikey_path_prefix": {
+            "description": "The instance specific AWS parameter gearbot path prefix",
+            "type": "string",
+            "default": "/prod/flywheel/gearbot"
+
+        },
         "parameter_path": {
             "description": "Parameter path for QC rules on S3",
             "type": "string"

--- a/gear/form_qc_checker/src/python/form_qc_app/run.py
+++ b/gear/form_qc_checker/src/python/form_qc_app/run.py
@@ -22,9 +22,12 @@ def main():
         gear_context.init_logging()
         gear_context.log_config()
 
+        apikey_path_prefix = gear_context.config.get("apikey_path_prefix",
+                                                     "/prod/flywheel/gearbot")
         try:
             parameter_store = ParameterStore.create_from_environment()
-            api_key = parameter_store.get_api_key()
+            api_key = parameter_store.get_api_key(
+                path_prefix=apikey_path_prefix)
 
             s3_param_path = get_config(gear_context=gear_context,
                                        key='parameter_path')

--- a/gear/identifer_lookup/src/docker/manifest.json
+++ b/gear/identifer_lookup/src/docker/manifest.json
@@ -43,6 +43,12 @@
             "description": "SSM parameter path for identifiers RDS credentials",
             "type": "string",
             "default": "/prod/flywheel/gearbot/identifiers"
+        },
+        "apikey_path_prefix": {
+            "description": "The instance specific AWS parameter gearbot path prefix",
+            "type": "string",
+            "default": "/prod/flywheel/gearbot"
+
         }
     },
     "command": "/bin/run"

--- a/gear/identifer_lookup/src/python/identifer_app/run.py
+++ b/gear/identifer_lookup/src/python/identifer_app/run.py
@@ -77,10 +77,13 @@ def main():
     with GearToolkitContext() as gear_context:
         gear_context.init_logging()
 
+        apikey_path_prefix = gear_context.config.get("apikey_path_prefix",
+                                                     "/prod/flywheel/gearbot")
         try:
             parameter_store = ParameterStore.create_from_environment()
             dry_run = gear_context.config.get("dry_run", False)
-            proxy = FlywheelProxy(client=Client(parameter_store.get_api_key()),
+            proxy = FlywheelProxy(client=Client(
+                parameter_store.get_api_key(path_prefix=apikey_path_prefix)),
                                   dry_run=dry_run)
             rds_parameters = parameter_store.get_rds_parameters(
                 param_path=get_config(gear_context=gear_context,

--- a/gear/pull_metadata/src/docker/manifest.json
+++ b/gear/pull_metadata/src/docker/manifest.json
@@ -34,6 +34,12 @@
             "description": "Parameter path for S3 credentials",
             "type": "string"
         },
+        "apikey_path_prefix": {
+            "description": "The instance specific AWS parameter gearbot path prefix",
+            "type": "string",
+            "default": "/prod/flywheel/gearbot"
+
+        },
         "destination_label": {
             "description": "Label of destination project",
             "type": "string"

--- a/gear/pull_metadata/src/python/metadata_app/run.py
+++ b/gear/pull_metadata/src/python/metadata_app/run.py
@@ -73,9 +73,12 @@ def main():
             log.error('Incomplete configuration: %s', error.message)
             sys.exit(1)
 
+        apikey_path_prefix = gear_context.config.get("apikey_path_prefix",
+                                                     "/prod/flywheel/gearbot")
         try:
             parameter_store = ParameterStore.create_from_environment()
-            api_key = parameter_store.get_api_key()
+            api_key = parameter_store.get_api_key(
+                path_prefix=apikey_path_prefix)
             s3_parameters = parameter_store.get_s3_parameters(
                 param_path=s3_param_path)
         except ParameterError as error:

--- a/gear/redcap_fw_transfer/src/docker/manifest.json
+++ b/gear/redcap_fw_transfer/src/docker/manifest.json
@@ -37,6 +37,12 @@
             "description": "Parameter path for REDCap project credentials",
             "type": "string",
             "default": "/prod/flywheel/redcap/"
+        },
+        "apikey_path_prefix": {
+            "description": "The instance specific AWS parameter gearbot path prefix",
+            "type": "string",
+            "default": "/prod/flywheel/gearbot"
+
         }
     },
     "command": "/bin/run"

--- a/gear/redcap_fw_transfer/src/python/redcap_fw_transfer_app/run.py
+++ b/gear/redcap_fw_transfer/src/python/redcap_fw_transfer_app/run.py
@@ -53,10 +53,13 @@ def main():
         gear_context.init_logging()
         gear_context.log_config()
 
+        apikey_path_prefix = gear_context.config.get("apikey_path_prefix",
+                                                     "/prod/flywheel/gearbot")
         try:
             parameter_store = ParameterStore.create_from_environment()
 
-            api_key = parameter_store.get_api_key()
+            api_key = parameter_store.get_api_key(
+                path_prefix=apikey_path_prefix)
 
             param_path = str(
                 get_config(gear_context=gear_context, key='parameter_path'))

--- a/gear/user_management/src/docker/manifest.json
+++ b/gear/user_management/src/docker/manifest.json
@@ -35,6 +35,12 @@
             "type": "string",
             "default": "nacc"
         },
+        "apikey_path_prefix": {
+            "description": "The instance specific AWS parameter gearbot path prefix",
+            "type": "string",
+            "default": "/prod/flywheel/gearbot"
+
+        },
         "source": {
             "description": "Name of the source project",
             "type": "string",

--- a/gear/user_management/src/python/user_app/run.py
+++ b/gear/user_management/src/python/user_app/run.py
@@ -41,9 +41,11 @@ def main() -> None:
     with GearToolkitContext() as gear_context:
         gear_context.init_logging()
 
+        path_prefix = gear_context.config.get("apikey_path_prefix",
+                                              "/prod/flywheel/gearbot")
         try:
             parameter_store = ParameterStore.create_from_environment()
-            api_key = parameter_store.get_api_key()
+            api_key = parameter_store.get_api_key(path_prefix=path_prefix)
         except ParameterError as error:
             log.error('Parameter error: %s', error)
             sys.exit(1)

--- a/templates/gear/{{cookiecutter.module_name}}/src/docker/manifest.json
+++ b/templates/gear/{{cookiecutter.module_name}}/src/docker/manifest.json
@@ -51,6 +51,12 @@
             "description": "Only create projects for centers tagged as new",
             "type": "boolean",
             "default": false
+        },
+        "apikey_path_prefix": {
+            "description": "The instance specific AWS parameter path prefix for apikey",
+            "type": "string",
+            "default": "/prod/flywheel/gearbot"
+
         }
     },
     "command": "/bin/run"


### PR DESCRIPTION
Changes the retrieval of the gearbot API key to allow for gearbots on different Flywheel instances.

Requires that a gear using a gearbot have a parameter in the manifest that is the prefix for `apikey` in the parameter store. 
So, if there is an API key at `/prod/flywheel/gearbot/apikey`, the prefix would be `/prod/flywheel/gearbot`.

The PR also updates all existing gearbot gears, and the manifest in the gear template.