### PR TITLE
Fix-center-portal-authorization

### DIFF
--- a/common/src/python/centers/center_group.py
+++ b/common/src/python/centers/center_group.py
@@ -472,6 +472,13 @@ class CenterGroup(GroupAdaptor):
                                              project_id=metadata_project.id,
                                              auth_map=auth_map,
                                              authorizations=authorizations)
+            
+        center_portal = self.get_portal()
+        if center_portal:
+            self.__add_user_roles_to_project(user=user,
+                                             project_id=center_portal.id,
+                                             auth_map=auth_map,
+                                             authorizations=authorizations)
 
     def __add_user_roles_to_project(self, *, user: User, project_id: str,
                                     authorizations: Authorizations,

--- a/gear/user_management/src/docker/BUILD
+++ b/gear/user_management/src/docker/BUILD
@@ -4,5 +4,5 @@ docker_image(
     name="user-management",
     source="Dockerfile",
     dependencies=[":manifest", "gear/user_management/src/python/user_app:bin"],
-    image_tags=["0.0.24", "latest"],
+    image_tags=["0.0.25", "latest"],
 )

--- a/gear/user_management/src/docker/manifest.json
+++ b/gear/user_management/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "user-management",
     "label": "User Management",
     "description": "Creates and updates user and user roles",
-    "version": "0.0.24",
+    "version": "0.0.25",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/user-management:0.0.24"
+            "image": "naccdata/user-management:0.0.25"
         },
         "flywheel": {
             "suite": "NACC Admin Gears",


### PR DESCRIPTION
Changes role management to set read-only for center-portal project. This allows user to see UI extensions loaded from the project.