### PR TITLE
Post-merge-fixes

### DIFF
--- a/gear/form_qc_checker/src/python/form_qc_app/main.py
+++ b/gear/form_qc_checker/src/python/form_qc_app/main.py
@@ -12,6 +12,7 @@ from json.decoder import JSONDecodeError
 from typing import Any, Dict, List, Optional
 
 from flywheel import Client
+from flywheel_adaptor.flywheel_proxy import FlywheelProxy
 from flywheel_gear_toolkit import GearToolkitContext
 from form_qc_app.error_info import ErrorComposer, REDCapErrorStore
 from form_qc_app.flywheel_datastore import FlywheelDatastore
@@ -194,7 +195,10 @@ def run(*,
     valid, sys_failure, dict_errors, error_tree = qual_check.validate_record(
         form_data)
 
-    error_writer = ListErrorWriter(container_id=file_id)
+    proxy = FlywheelProxy(client=fw_client)
+    error_writer = ListErrorWriter(container_id=file_id,
+                                   fw_path=proxy.get_lookup_path(
+                                       proxy.get_file(file_id)))
     if not valid:
         error_messages = qual_check.validator.get_error_messages()
         error_composer = ErrorComposer(input_data=form_data,

--- a/gear/identifer_lookup/src/python/identifer_app/run.py
+++ b/gear/identifer_lookup/src/python/identifer_app/run.py
@@ -123,7 +123,9 @@ class IdentifierLookupVisitor(GearExecutionEnvironment):
             with context.open_output(f'{filename}.csv',
                                      mode='w',
                                      encoding='utf-8') as out_file:
-                error_writer = ListErrorWriter(container_id=file_id)
+                error_writer = ListErrorWriter(container_id=file_id,
+                                               fw_path=proxy.get_lookup_path(
+                                                   proxy.get_file(file_id)))
                 errors = run(input_file=csv_file,
                              identifiers=identifiers,
                              output_file=out_file,


### PR DESCRIPTION
This fixes issues found after merging the gear engine changes. Mostly error writers expecting the flywheel path of the input file and it not being given