### PR TITLE
Fix user roles and permissions

### DIFF
--- a/common/src/python/centers/center_group.py
+++ b/common/src/python/centers/center_group.py
@@ -321,12 +321,15 @@ class CenterGroup(GroupAdaptor):
         if study.is_primary():
             suffix = ""
 
+        admin_access = self.get_user_access()
+
         accepted_label = f"accepted{suffix}"
         accepted_project = self.__add_project(accepted_label)
         study_info.add_accepted(
             ProjectMetadata(study_id=study.study_id,
                             project_id=accepted_project.id,
                             project_label=accepted_label))
+        accepted_project.add_admin_users(admin_access)
 
         if self.__is_active:
             for pipeline in ['ingest', 'sandbox']:
@@ -338,6 +341,7 @@ class CenterGroup(GroupAdaptor):
                                               project_id=project.id,
                                               project_label=project_label,
                                               datatype=datatype))
+                    project.add_admin_users(admin_access)
 
         self.update_project_info(portal_info)
 
@@ -345,7 +349,8 @@ class CenterGroup(GroupAdaptor):
             f"retrospective-{datatype.lower()}" for datatype in study.datatypes
         ]
         for label in labels:
-            self.__add_project(label)
+            project = self.__add_project(label)
+            project.add_admin_users(admin_access)
 
     def add_redcap_project(self, redcap_project: 'REDCapProjectInput') -> None:
         """Adds the REDCap project to the center group.

--- a/common/src/python/centers/center_group.py
+++ b/common/src/python/centers/center_group.py
@@ -9,6 +9,7 @@ from typing import Dict, List, Optional
 
 import flywheel
 from flywheel.models.group import Group
+from flywheel.models.role_output import RoleOutput
 from flywheel.models.user import User
 from flywheel_adaptor.flywheel_proxy import (FlywheelProxy, GroupAdaptor,
                                              ProjectAdaptor)
@@ -513,7 +514,7 @@ class CenterGroup(GroupAdaptor):
             return False
 
         role_map = self._fw.get_roles()
-        roles = []
+        roles: List[RoleOutput] = []
         for role_name in role_set:
             role = role_map.get(role_name)
             if role:

--- a/common/src/python/centers/center_group.py
+++ b/common/src/python/centers/center_group.py
@@ -64,6 +64,7 @@ class CenterGroup(GroupAdaptor):
                                    active=active,
                                    group=group,
                                    proxy=proxy)
+        metadata_project.add_admin_users(center_group.get_user_access())
 
         return center_group
 
@@ -108,6 +109,7 @@ class CenterGroup(GroupAdaptor):
 
         metadata_project = center_group.get_metadata()
         assert metadata_project, "expecting metadata project"
+        metadata_project.add_admin_users(center_group.get_user_access())
         metadata_project.update_info({
             'adcid': center.adcid,
             'active': center.is_active()
@@ -344,6 +346,9 @@ class CenterGroup(GroupAdaptor):
                                               project_label=project_label,
                                               datatype=datatype))
                     project.add_admin_users(admin_access)
+
+        portal_project = self.__add_project('center-portal')
+        portal_project.add_admin_users(admin_access)
 
         self.update_project_info(portal_info)
 

--- a/common/src/python/centers/center_group.py
+++ b/common/src/python/centers/center_group.py
@@ -164,7 +164,8 @@ class CenterGroup(GroupAdaptor):
         """
         if not self.__metadata:
             self.__metadata = self.get_project('metadata')
-            assert self.__metadata, "expecting metadata project"
+            assert self.__metadata, ("Expecting metadata project. "
+                                     "Check user has permissions.")
 
         return self.__metadata
 

--- a/common/src/python/centers/nacc_group.py
+++ b/common/src/python/centers/nacc_group.py
@@ -78,7 +78,8 @@ class NACCGroup(GroupAdaptor):
         """
         if not self.__metadata:
             self.__metadata = self.get_project('metadata')
-            assert self.__metadata, "expecting metadata project"
+            assert self.__metadata, ("Expecting metadata project. "
+                                     "Check user has permissions.")
 
         return self.__metadata
 

--- a/common/src/python/flywheel_adaptor/flywheel_proxy.py
+++ b/common/src/python/flywheel_adaptor/flywheel_proxy.py
@@ -262,9 +262,9 @@ class FlywheelProxy:
         return self.__fw.projects.find_first(f"_id={project_id}")
 
     def get_roles(self) -> Mapping[str, RoleOutput]:
-        """Gets all roles for the FW instance.
+        """Gets all user roles for the FW instance.
 
-        Does not include GroupRoles.
+        Does not include access roles for Groups.
         """
         if not self.__project_roles:
             all_roles = self.__fw.get_all_roles()
@@ -272,7 +272,7 @@ class FlywheelProxy:
         return self.__project_roles
 
     def get_role(self, label: str) -> Optional[RoleOutput]:
-        """Gets project role with label.
+        """Gets project role by label.
 
         Args:
           label: the name of the role

--- a/common/src/python/flywheel_adaptor/flywheel_proxy.py
+++ b/common/src/python/flywheel_adaptor/flywheel_proxy.py
@@ -230,8 +230,6 @@ class FlywheelProxy:
                       project_label)
             return None
 
-        # reload the group to ensure projects are refreshed
-        group = group.reload()
         project = group.projects.find_first(f"label={project_label}")
         if project:
             log.info('Project %s/%s exists', group.id, project_label)
@@ -961,10 +959,13 @@ class ProjectAdaptor:
         """
         admin_role = self.__fw.get_admin_role()
         assert admin_role
-        for permission in permissions:
+        admin_users = [
+            permission.id for permission in permissions
+            if permission.access == 'admin'
+        ]
+        for user_id in admin_users:
             self.add_user_role_assignments(
-                RolesRoleAssignment(id=permission.id,
-                                    role_ids=[admin_role.id]))
+                RolesRoleAssignment(id=user_id, role_ids=[admin_role.id]))
 
     def get_gear_rules(self) -> List[GearRule]:
         """Gets the gear rules for this project.

--- a/gear/project_management/src/docker/BUILD
+++ b/gear/project_management/src/docker/BUILD
@@ -6,5 +6,5 @@ docker_image(
     dependencies=[
         ":manifest", "gear/project_management/src/python/project_app:bin"
     ],
-    image_tags=["0.0.17", "latest"],
+    image_tags=["0.0.26", "latest"],
 )

--- a/gear/project_management/src/docker/manifest.json
+++ b/gear/project_management/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "project-management",
     "label": "Project management",
     "description": "Creates and updates projects from project YAML file",
-    "version": "0.0.17",
+    "version": "0.0.26",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/project-management:0.0.17"
+            "image": "naccdata/project-management:0.0.26"
         },
         "flywheel": {
             "suite": "NACC Admin Gears",
@@ -51,6 +51,11 @@
             "description": "Only create projects for centers tagged as new",
             "type": "boolean",
             "default": false
+        },
+        "apikey_path_prefix": {
+            "description": "The instance specific AWS parameter gearbot path prefix",
+            "type": "string",
+            "default": "/prod/flywheel/gearbot"
         }
     },
     "command": "/bin/run"

--- a/gear/project_management/src/python/project_app/run.py
+++ b/gear/project_management/src/python/project_app/run.py
@@ -91,7 +91,7 @@ class ProjectCreationVisitor(GearExecutionEnvironment):
         run(proxy=proxy,
             admin_group=admin_group,
             project_list=self.__project_list,
-            role_names=['curate', 'upload'],
+            role_names=['curate', 'upload', 'gear-bot'],
             new_only=self.__new_only)
 
 

--- a/mypy-stubs/src/python/flywheel/models/access_level.pyi
+++ b/mypy-stubs/src/python/flywheel/models/access_level.pyi
@@ -1,2 +1,4 @@
 class AccessLevel:
-    ...
+    RO: str
+    RW: str
+    ADMIN: str


### PR DESCRIPTION
Makes assignment of user roles and permissions more consistent.

1. Ensures that metadata and center-portal projects have admin user permissions set either when created, or reloaded.
2. Ensures that admin user roles are set for center group projects when created or updated