### PR TITLE
Update retrieving REDCap report credentials

### DIFF
--- a/common/src/python/centers/center_group.py
+++ b/common/src/python/centers/center_group.py
@@ -588,6 +588,7 @@ class REDCapFormProject(BaseModel):
 
     redcap_pid: int
     label: str
+    report_id: int
 
 
 class FormIngestProjectMetadata(IngestProjectMetadata):
@@ -622,15 +623,15 @@ class FormIngestProjectMetadata(IngestProjectMetadata):
         """
         self.redcap_projects[redcap_project.label] = redcap_project
 
-    def get(self, form_name: str) -> Optional[REDCapFormProject]:
-        """Gets the REDCap project metadata for the form name.
+    def get(self, module_name: str) -> Optional[REDCapFormProject]:
+        """Gets the REDCap project metadata for the module name.
 
         Args:
-            form_name: the form name
+            module_name: the module name
         Returns:
-            the REDCap project metadata for the form name
+            the REDCap project metadata for the module name
         """
-        return self.redcap_projects.get(form_name, None)
+        return self.redcap_projects.get(module_name, None)
 
 
 class StudyMetadata(BaseModel):

--- a/common/src/python/inputs/parameter_store.py
+++ b/common/src/python/inputs/parameter_store.py
@@ -1,6 +1,7 @@
 """Module for getting proxy object for AWS SSM parameter store object."""
 import logging
 
+from botocore.exceptions import ClientError, ParamValidationError
 from inputs.environment import get_environment_variable
 from pydantic import TypeAdapter, ValidationError
 from ssm_parameter_store import EC2ParameterStore
@@ -92,12 +93,70 @@ class ParameterStore:
 
         return apikey
 
-    def get_redcap_report_connection(
-            self, param_path: str) -> REDCapReportParameters:
-        """Pulls URL and Token for REDCap project from SSM parameter store.
+    def get_redcap_parameters_for_module(
+            self, *, base_path: str, pid: int, module: str, fw_group: str,
+            fw_project: str) -> REDCapReportParameters:
+        """Pulls URL, Token, and ReportID for the respective REDCap report for
+        the specified module from SSM parameter store.
 
         Args:
-        store: the parameter store object
+          base_path: base path in the parameter store
+          pid: REDCap project ID
+          module: module name
+          fw_group: Flywheel group id for the center
+          fw_project: Flywheel project label
+        Returns:
+          the REDCap report credentials stored at the parameter path
+        Raises:
+          ParameterError if any of the credentials are missing
+        """
+
+        if not base_path.endswith('/'):
+            base_path += '/'
+
+        param_path = base_path + 'pid_' + str(pid)
+        try:
+            prj_params = self.__store.get_parameters_by_path(param_path,
+                                                             decrypt=True)
+        except (ClientError, ParamValidationError) as error:
+            raise ParameterError(
+                f"Failed to retrieve parameters at {param_path}") from error
+
+        if (not prj_params or 'url' not in prj_params
+                or 'token' not in prj_params):
+            raise ParameterError(f"Incorrect parameters at {param_path}")
+
+        param_path = base_path + fw_group + '/' + fw_project + '/' + module
+        try:
+            module_params = self.__store.get_parameters_by_path(param_path,
+                                                                decrypt=True)
+        except (ClientError, ParamValidationError) as error:
+            raise ParameterError(
+                f"Failed to retrieve parameters at {param_path}") from error
+
+        if not module_params or 'reportid' not in module_params:
+            raise ParameterError(f"Incorrect parameters at {param_path}")
+
+        url = prj_params.get('url')
+        token = prj_params.get('token')
+        reportid = module_params.get('reportid')
+
+        if not url or not token or not reportid:
+            raise ParameterError(f"Incorrect parameters at {param_path}")
+
+        return REDCapReportParameters(url=url, token=token, reportid=reportid)
+
+    def get_redcap_report_parameters(
+            self, param_path: str) -> REDCapReportParameters:
+        """Pulls URL, Token, and ReportID for REDCap report from SSM parameter
+        store.
+
+        Args:
+          param_path: the path in the parameter store
+        Returns:
+          the REDCap report credentials stored at the parameter path
+        Raises:
+          ParameterError if any of the credentials are missing
         """
         return self.get_parameters(param_type=REDCapReportParameters,
                                    parameter_path=param_path)

--- a/common/src/python/inputs/parameter_store.py
+++ b/common/src/python/inputs/parameter_store.py
@@ -93,20 +93,17 @@ class ParameterStore:
 
         return apikey
 
-    def get_redcap_parameters_for_module(
-            self, *, base_path: str, pid: int, module: str, fw_group: str,
-            fw_project: str) -> REDCapReportParameters:
-        """Pulls URL, Token, and ReportID for the respective REDCap report for
-        the specified module from SSM parameter store.
+    def get_redcap_project_prameters(self, *, base_path: str, pid: int,
+                                     report_id: int) -> REDCapReportParameters:
+        """Pulls URL and Token for the respective REDCap project from SSM
+        parameter store.
 
         Args:
           base_path: base path in the parameter store
           pid: REDCap project ID
-          module: module name
-          fw_group: Flywheel group id for the center
-          fw_project: Flywheel project label
+          report_id: REDCap report ID
         Returns:
-          the REDCap report credentials stored at the parameter path
+          the REDCap credentials stored at the parameter path
         Raises:
           ParameterError if any of the credentials are missing
         """
@@ -126,25 +123,15 @@ class ParameterStore:
                 or 'token' not in prj_params):
             raise ParameterError(f"Incorrect parameters at {param_path}")
 
-        param_path = base_path + fw_group + '/' + fw_project + '/' + module
-        try:
-            module_params = self.__store.get_parameters_by_path(param_path,
-                                                                decrypt=True)
-        except (ClientError, ParamValidationError) as error:
-            raise ParameterError(
-                f"Failed to retrieve parameters at {param_path}") from error
-
-        if not module_params or 'reportid' not in module_params:
-            raise ParameterError(f"Incorrect parameters at {param_path}")
-
         url = prj_params.get('url')
         token = prj_params.get('token')
-        reportid = module_params.get('reportid')
 
-        if not url or not token or not reportid:
+        if not url or not token:
             raise ParameterError(f"Incorrect parameters at {param_path}")
 
-        return REDCapReportParameters(url=url, token=token, reportid=reportid)
+        return REDCapReportParameters(url=url,
+                                      token=token,
+                                      reportid=str(report_id))
 
     def get_redcap_report_parameters(
             self, param_path: str) -> REDCapReportParameters:

--- a/common/test/python/centers/test_portal_metadata.py
+++ b/common/test/python/centers/test_portal_metadata.py
@@ -40,7 +40,8 @@ def ingest_project_with_redcap():
                                     redcap_projects={
                                         "dummyv9":
                                         REDCapFormProject(redcap_pid=12345,
-                                                          label="dummyv9")
+                                                          label="dummyv9",
+                                                          report_id=22)
                                     })
 
 
@@ -189,11 +190,15 @@ class TestREDCapUpdate:
         """Tests for updating redcap project info."""
         assert portal_metadata, "expect non-null info object"
 
-        input_object = REDCapProjectInput(
-            center_id="dummy",
-            study_id="test",
-            project_label="ingest-form-test",
-            projects=[REDCapFormProject(redcap_pid=12345, label="ptenrlv1")])
+        input_object = REDCapProjectInput(center_id="dummy",
+                                          study_id="test",
+                                          project_label="ingest-form-test",
+                                          projects=[
+                                              REDCapFormProject(
+                                                  redcap_pid=12345,
+                                                  label="ptenrlv1",
+                                                  report_id=22)
+                                          ])
         study_info = portal_metadata.studies.get(input_object.study_id)
         ingest_project = study_info.get_ingest(input_object.project_label)
         assert ingest_project, "expect non-null ingest project"

--- a/common/test/python/centers/test_redcap_project_model.py
+++ b/common/test/python/centers/test_redcap_project_model.py
@@ -10,11 +10,15 @@ class TestREDCapProjectInput:
     # pylint: disable=no-self-use
     def test_redcap_project_input(self):
         """Test REDCap Project Input."""
-        project_model = REDCapProjectInput(
-            center_id="test",
-            study_id="test",
-            project_label="test",
-            projects=[REDCapFormProject(redcap_pid=12345, label="test")])
+        project_model = REDCapProjectInput(center_id="test",
+                                           study_id="test",
+                                           project_label="test",
+                                           projects=[
+                                               REDCapFormProject(
+                                                   redcap_pid=12345,
+                                                   label="test",
+                                                   report_id=22)
+                                           ])
         project_dump = project_model.model_dump(by_alias=True,
                                                 exclude_none=True)
         assert 'center-id' in project_dump

--- a/gear/form_qc_checker/src/python/form_qc_app/run.py
+++ b/gear/form_qc_checker/src/python/form_qc_app/run.py
@@ -71,7 +71,7 @@ class FormQCCheckerVisitor(GearExecutionEnvironment):
             s3_parameters = parameter_store.get_s3_parameters(
                 param_path=s3_param_path)
 
-            redcap_params = parameter_store.get_redcap_report_connection(
+            redcap_params = parameter_store.get_redcap_report_parameters(
                 param_path=qc_checks_db_path)
         except ParameterError as error:
             raise GearExecutionError(f'Parameter error: {error}') from error

--- a/gear/pull_directory/src/python/directory_app/run.py
+++ b/gear/pull_directory/src/python/directory_app/run.py
@@ -49,7 +49,7 @@ class DirectoryPullVisitor(GearExecutionEnvironment):
             raise GearExecutionError("No parameter path")
 
         try:
-            report_parameters = parameter_store.get_redcap_report_connection(
+            report_parameters = parameter_store.get_redcap_report_parameters(
                 param_path=param_path)
         except ParameterError as error:
             raise GearExecutionError(f'Parameter error: {error}') from error

--- a/gear/redcap_fw_transfer/src/docker/BUILD
+++ b/gear/redcap_fw_transfer/src/docker/BUILD
@@ -7,4 +7,4 @@ docker_image(
         ":manifest",
         "gear/redcap_fw_transfer/src/python/redcap_fw_transfer_app:bin"
     ],
-    image_tags=["0.0.14", "latest"])
+    image_tags=["0.0.15", "latest"])

--- a/gear/redcap_fw_transfer/src/docker/BUILD
+++ b/gear/redcap_fw_transfer/src/docker/BUILD
@@ -7,4 +7,4 @@ docker_image(
         ":manifest",
         "gear/redcap_fw_transfer/src/python/redcap_fw_transfer_app:bin"
     ],
-    image_tags=["0.0.12", "latest"])
+    image_tags=["0.0.14", "latest"])

--- a/gear/redcap_fw_transfer/src/docker/manifest.json
+++ b/gear/redcap_fw_transfer/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "redcap-fw-transfer",
     "label": "REDCap to Flywheel Transfer",
     "description": "Gear to transfer from data from a REDCap project to the respective Flywheel project",
-    "version": "0.0.12",
+    "version": "0.0.14",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/redcap-fw-transfer:0.0.12"
+            "image": "naccdata/redcap-fw-transfer:0.0.14"
         },
         "flywheel": {
             "suite": "Import",
@@ -34,7 +34,7 @@
             "default": "/prod/flywheel/gearbot"
         },
         "parameter_path": {
-            "description": "AWS parameter path for REDCap project credentials",
+            "description": "AWS parameter base path for REDCap instance",
             "type": "string",
             "default": "/redcap/aws"
         }

--- a/gear/redcap_fw_transfer/src/docker/manifest.json
+++ b/gear/redcap_fw_transfer/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "redcap-fw-transfer",
     "label": "REDCap to Flywheel Transfer",
     "description": "Gear to transfer from data from a REDCap project to the respective Flywheel project",
-    "version": "0.0.14",
+    "version": "0.0.15",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/redcap-fw-transfer:0.0.14"
+            "image": "naccdata/redcap-fw-transfer:0.0.15"
         },
         "flywheel": {
             "suite": "Import",

--- a/gear/redcap_fw_transfer/src/python/redcap_fw_transfer_app/main.py
+++ b/gear/redcap_fw_transfer/src/python/redcap_fw_transfer_app/main.py
@@ -156,8 +156,8 @@ def run(*, gear_context: GearToolkitContext,
                                           schema['definitions'])
 
     timestamp = datetime.now()
-    file_name = 'redcap_ingest-' + timestamp.strftime(
-        '%Y%m%d_%H%M%S') + '-' + module + '.csv'
+    file_name = 'redcapingest-' + timestamp.strftime(
+        '%Y%m%d-%H%M%S') + '-' + module + '.csv'
 
     with gear_context.open_output(file_name, mode='w',
                                   encoding='utf-8') as output_file:

--- a/gear/redcap_fw_transfer/src/python/redcap_fw_transfer_app/run.py
+++ b/gear/redcap_fw_transfer/src/python/redcap_fw_transfer_app/run.py
@@ -143,9 +143,6 @@ class REDCapFlywheelTransferVisitor(GearExecutionEnvironment):
         client_wrapper = GearBotClient.create(context=context,
                                               parameter_store=parameter_store)
 
-        if not param_path.endswith('/'):
-            param_path += '/'
-
         return REDCapFlywheelTransferVisitor(client=client_wrapper,
                                              parameter_store=parameter_store,
                                              param_path=param_path)
@@ -193,12 +190,13 @@ class REDCapFlywheelTransferVisitor(GearExecutionEnvironment):
 
         failed_count = 0
         for redcap_project in redcap_projects.values():
-            redcap_project_path = (self.__param_path + 'pid_' +
-                                   str(redcap_project.redcap_pid) + '/' +
-                                   redcap_project.label)
             try:
-                redcap_params = self.__param_store.get_redcap_report_connection(
-                    param_path=redcap_project_path)
+                redcap_params = self.__param_store.get_redcap_parameters_for_module(
+                    base_path=self.__param_path,
+                    pid=redcap_project.redcap_pid,
+                    module=redcap_project.label,
+                    fw_group=group_id,
+                    fw_project=project.label)
                 redcap_report_con = REDCapReportConnection.create_from(
                     redcap_params)
             except ParameterError as error:

--- a/gear/redcap_fw_transfer/src/python/redcap_fw_transfer_app/run.py
+++ b/gear/redcap_fw_transfer/src/python/redcap_fw_transfer_app/run.py
@@ -189,14 +189,20 @@ class REDCapFlywheelTransferVisitor(GearExecutionEnvironment):
                 f'{group_id}/{project.label}')
 
         failed_count = 0
-        for redcap_project in redcap_projects.values():
+        for module, redcap_project in redcap_projects.items():
+            if (not redcap_project.label or not redcap_project.redcap_pid
+                    or not redcap_project.report_id):
+                log.error(
+                    'Incomplete REDCap project info in %s/metadata '
+                    'for module %s', group_id, module)
+                failed_count += 1
+                continue
+
             try:
-                redcap_params = self.__param_store.get_redcap_parameters_for_module(
+                redcap_params = self.__param_store.get_redcap_project_prameters(
                     base_path=self.__param_path,
                     pid=redcap_project.redcap_pid,
-                    module=redcap_project.label,
-                    fw_group=group_id,
-                    fw_project=project.label)
+                    report_id=redcap_project.report_id)
                 redcap_report_con = REDCapReportConnection.create_from(
                     redcap_params)
             except ParameterError as error:


### PR DESCRIPTION
Update retrieving REDCap report credentials from AWS parameter store.
Updated structure
 
- Url and API token for the REDCap project 
    - url – NACC REDCap instance API URL. 
       Parameter store path: /redcap/<instance>/pid_[REDCap project id]/url 
       e.g., “/redcap/aws/pid_19/url” 
     - token – API token for NACC gearbot user.  
        Parameter store path: /redcap/<instance>/pid_[REDCap project id]/token 
        e.g., “/redcap/aws/pid_19/token” 

- REDCap report id for each Flywheel center/project/module 
   - reportid – ID of the “Visits Ready for Flywheel Upload” report for the respective module. 
      Parameter store path:  
      /redcap/[instance]/[flywheel group]/[flywheel project]/[module]/reportid 
      e.g., “/redcap/aws/sample-center/ingest-enrollment/ptenrlv1/reportid” 
