### PR TITLE
Relax GUID_PATTERN to allow more cases

### DIFF
--- a/common/src/python/identifiers/model.py
+++ b/common/src/python/identifiers/model.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 
 from pydantic import BaseModel, Field, RootModel
 
-GUID_PATTERN = r"^NIH[a-zA-Z0-9]{10}$"
+GUID_PATTERN = r"^[a-zA-Z0-9]+$"
 NACCID_PATTERN = r"^NACC\d{6}$"
 
 


### PR DESCRIPTION
This replaces the restrictive GUID pattern with an alphanumeric nonempty string.