### PR TITLE
Fix-group-search

### DIFF
--- a/common/src/python/flywheel_adaptor/flywheel_proxy.py
+++ b/common/src/python/flywheel_adaptor/flywheel_proxy.py
@@ -203,7 +203,7 @@ class FlywheelProxy:
         if group_list:
             return group_list[0]
 
-        conflict = self.__fw.groups.find_first(f"label={group_label}")
+        conflict = self.__fw.groups.find_first(f"label='{group_label}'")
         if conflict:
             raise FlywheelError(
                 f"Group with label {group_label} exists: {conflict.id}")

--- a/common/src/python/flywheel_adaptor/flywheel_proxy.py
+++ b/common/src/python/flywheel_adaptor/flywheel_proxy.py
@@ -203,7 +203,8 @@ class FlywheelProxy:
         if group_list:
             return group_list[0]
 
-        conflict = self.__fw.groups.find_first(f"label='{group_label}'")
+        conflict = self.__fw.groups.find_first(
+            f"label=~^{group_label.replace(',','.')}$")
         if conflict:
             raise FlywheelError(
                 f"Group with label {group_label} exists: {conflict.id}")

--- a/common/test/python/projects/BUILD
+++ b/common/test/python/projects/BUILD
@@ -1,0 +1,1 @@
+python_tests(name="tests", )

--- a/common/test/python/projects/test_study.py
+++ b/common/test/python/projects/test_study.py
@@ -2,6 +2,7 @@
 from typing import Optional
 
 import pytest
+import yaml
 from projects.study import Center, Study, StudyVisitor
 
 
@@ -65,6 +66,19 @@ class TestCenter:
                         adcid=1)
         center.apply(visitor)
         assert visitor.center_name == "Dummy Center"
+
+    def test_create_from_yaml(self):
+        center_yaml = ("adcid: 16\n"
+                       "name: University of California, Davis\n"
+                       "center-id: ucdavis\n"
+                       "is-active: True")
+        center_gen = yaml.safe_load_all(center_yaml)
+        center = Center.create([*center_gen][0])
+        center2 = Center(tags=['adcid-16'],
+                         name="University of California, Davis",
+                         center_id='ucdavis',
+                         adcid=16)
+        assert center == center2
 
 
 class TestStudy:

--- a/gear/project_management/src/docker/BUILD
+++ b/gear/project_management/src/docker/BUILD
@@ -6,5 +6,5 @@ docker_image(
     dependencies=[
         ":manifest", "gear/project_management/src/python/project_app:bin"
     ],
-    image_tags=["0.0.29", "latest"],
+    image_tags=["0.0.32", "latest"],
 )

--- a/gear/project_management/src/docker/manifest.json
+++ b/gear/project_management/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "project-management",
     "label": "Project management",
     "description": "Creates and updates projects from project YAML file",
-    "version": "0.0.29",
+    "version": "0.0.32",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/project-management:0.0.29"
+            "image": "naccdata/project-management:0.0.32"
         },
         "flywheel": {
             "suite": "NACC Admin Gears",


### PR DESCRIPTION
Changes query to find groups by label to use a regex pattern as a workaround to a change in behavior of FW API. 
The issue is that center names may have commas in them, and the finder queries with commas are failing. (This change in behaviour has been reported to FW.)

The change is to use a regex that uses `.` in place of `,` and sets start and end boundaries on the label.

This branch also moves the study tests into a package specific test directory.

