### PR TITLE
Remove default study_id from authorizations

### DIFF
--- a/common/src/python/users/authorizations.py
+++ b/common/src/python/users/authorizations.py
@@ -10,7 +10,7 @@ AuthNameType = Literal['submit-form', 'submit-dicom', 'submit-enrollment',
 
 class Authorizations(BaseModel):
     """Type class for authorizations."""
-    study_id: str = 'adrc'
+    study_id: str
     submit: List[DatatypeNameType]
     audit_data: bool
     approve_data: bool
@@ -41,7 +41,8 @@ class Authorizations(BaseModel):
         return self._activities
 
     @classmethod
-    def create_from_record(cls, activities: Sequence[str]) -> "Authorizations":
+    def create_from_record(cls, *, study_id: str,
+                           activities: Sequence[str]) -> "Authorizations":
         """Creates an Authorizations object directory access activities.
 
         Activities from the NACC directory are represented as a string
@@ -55,6 +56,7 @@ class Authorizations(BaseModel):
         - e: view reports
 
         Args:
+          study_id: the study ID for scope of authorizations
           activities: a string containing activities
         Returns:
           The Authorizations object
@@ -66,7 +68,8 @@ class Authorizations(BaseModel):
         if 'b' in activities:
             modalities.append('dicom')
 
-        return Authorizations(submit=modalities,
+        return Authorizations(study_id=study_id,
+                              submit=modalities,
                               audit_data=bool('c' in activities),
                               approve_data=('d' in activities),
                               view_reports=('e' in activities))

--- a/common/src/python/users/nacc_directory.py
+++ b/common/src/python/users/nacc_directory.py
@@ -102,7 +102,7 @@ class UserEntry(BaseModel):
             return None
 
         authorizations = Authorizations.create_from_record(
-            record["flywheel_access_activities"])
+            study_id='adrc', activities=record["flywheel_access_activities"])
 
         org_name = record['contact_company_name']
         center_id = record['adresearchctr']

--- a/common/test/python/centers/test_portal_metadata.py
+++ b/common/test/python/centers/test_portal_metadata.py
@@ -151,7 +151,7 @@ class TestStudyMetadataSerialization:
         assert 'study-name' in study_dump
         assert 'ingest-projects' in study_dump
         assert 'accepted-project' in study_dump
-        assert len(study_dump.keys()) == 4
+        assert len(study_dump.keys()) == 5
 
         try:
             model_object = StudyMetadata.model_validate(study_dump)

--- a/common/test/python/users/test_authorizations.py
+++ b/common/test/python/users/test_authorizations.py
@@ -97,7 +97,7 @@ class TestAuthorizations:
     # pylint: disable=(redefined-outer-name,no-self-use)
     def test_activities(self):
         """Test get_activities."""
-        authorizations = Authorizations(study_id='adrc',
+        authorizations = Authorizations(study_id='dummy',
                                         submit=['form', 'dicom'],
                                         audit_data=True,
                                         approve_data=True,
@@ -107,7 +107,7 @@ class TestAuthorizations:
             'view-reports'
         }
 
-        authorizations = Authorizations(study_id='adrc',
+        authorizations = Authorizations(study_id='dummy',
                                         submit=['form'],
                                         audit_data=True,
                                         approve_data=True,
@@ -119,51 +119,51 @@ class TestAuthorizations:
     # pylint: disable=(redefined-outer-name,no-self-use)
     def test_create_from_record(self):
         """Test create_from_record."""
-        authorizations = Authorizations.create_from_record(
+        authorizations = Authorizations.create_from_record(study_id='dummy',
             activities=['a', 'b', 'c', 'd', 'e'])
         assert authorizations == Authorizations(
-            study_id='adrc',
+            study_id='dummy',
             submit=['form', 'enrollment', 'dicom'],
             audit_data=True,
             approve_data=True,
             view_reports=True)
 
-        authorizations = Authorizations.create_from_record(
+        authorizations = Authorizations.create_from_record(study_id='dummy',
             activities=['a', 'b', 'c', 'd'])
         assert authorizations == Authorizations(
-            study_id='adrc',
+            study_id='dummy',
             submit=['form', 'enrollment', 'dicom'],
             audit_data=True,
             approve_data=True,
             view_reports=False)
 
-        authorizations = Authorizations.create_from_record(
+        authorizations = Authorizations.create_from_record(study_id='dummy',
             activities=['a', 'b', 'c'])
         assert authorizations == Authorizations(
-            study_id='adrc',
+            study_id='dummy',
             submit=['form', 'enrollment', 'dicom'],
             audit_data=True,
             approve_data=False,
             view_reports=False)
 
-        authorizations = Authorizations.create_from_record(
+        authorizations = Authorizations.create_from_record(study_id='dummy',
             activities=['a', 'b'])
         assert authorizations == Authorizations(
-            study_id='adrc',
+            study_id='dummy',
             submit=['form', 'enrollment', 'dicom'],
             audit_data=False,
             approve_data=False,
             view_reports=False)
 
-        authorizations = Authorizations.create_from_record(activities=['a'])
-        assert authorizations == Authorizations(study_id='adrc',
+        authorizations = Authorizations.create_from_record(study_id='dummy',activities=['a'])
+        assert authorizations == Authorizations(study_id='dummy',
                                                 submit=['form', 'enrollment'],
                                                 audit_data=False,
                                                 approve_data=False,
                                                 view_reports=False)
 
-        authorizations = Authorizations.create_from_record(activities=[])
-        assert authorizations == Authorizations(study_id='adrc',
+        authorizations = Authorizations.create_from_record(study_id='dummy',activities=[])
+        assert authorizations == Authorizations(study_id='dummy',
                                                 submit=[],
                                                 audit_data=False,
                                                 approve_data=False,
@@ -172,10 +172,10 @@ class TestAuthorizations:
     # pylint: disable=(redefined-outer-name,no-self-use)
     def test_create_from_record_invalid(self):
         """Test create_from_record with invalid input."""
-        authorizations = Authorizations.create_from_record(
+        authorizations = Authorizations.create_from_record(study_id='dummy',
             activities=['a', 'b', 'x'])
         assert authorizations == Authorizations(
-            study_id='adrc',
+            study_id='dummy',
             submit=['form', 'enrollment', 'dicom'],
             audit_data=False,
             approve_data=False,
@@ -184,8 +184,8 @@ class TestAuthorizations:
     # pylint: disable=(redefined-outer-name,no-self-use)
     def test_create_from_record_empty(self):
         """Test create_from_record with empty input."""
-        authorizations = Authorizations.create_from_record(activities=[])
-        assert authorizations == Authorizations(study_id='adrc',
+        authorizations = Authorizations.create_from_record(study_id='dummy',activities=[])
+        assert authorizations == Authorizations(study_id='dummy',
                                                 submit=[],
                                                 audit_data=False,
                                                 approve_data=False,

--- a/common/test/python/users/test_user_entry.py
+++ b/common/test/python/users/test_user_entry.py
@@ -51,6 +51,7 @@ class TestUserEntry:
                                                 last_name='puppy'),
                                 email='chip@theorg.org',
                                 authorizations=Authorizations(
+                                    study_id='adrc',
                                     submit=['form', 'enrollment'],
                                     audit_data=True,
                                     approve_data=True,
@@ -60,6 +61,7 @@ class TestUserEntry:
 
         assert entry.authorizations.audit_data
 
+        # assumes study_id is adrc
         entry2 = UserEntry.create_from_record({
             "contact_company_name":
             "the center",
@@ -103,6 +105,7 @@ class TestUserEntry:
                                                  last_name='puppy'),
                                  email='chip@theorg.org',
                                  authorizations=Authorizations(
+                                     study_id='dummy',
                                      submit=['form', 'enrollment'],
                                      audit_data=True,
                                      approve_data=True,


### PR DESCRIPTION
Removes the default Austorizations.study_id so that it has to be set when authorizations are created.
