### PR TITLE
Fix circular import; move redcap connection get_project to redcap project create

### DIFF
--- a/common/src/python/redcap/redcap_connection.py
+++ b/common/src/python/redcap/redcap_connection.py
@@ -7,8 +7,6 @@ import requests
 from inputs.parameter_store import REDCapParameters, REDCapReportParameters
 from requests import Response
 
-from redcap.redcap_project import REDCapProject
-
 
 class REDCapSuperUserConnection:
     """REDCap connection using super API token.
@@ -120,21 +118,6 @@ class REDCapConnection:
         """
         return REDCapConnection(token=parameters['token'],
                                 url=parameters['url'])
-
-    def get_project(self) -> 'REDCapProject':
-        """Get the REDCap project for this connection."""
-
-        project_info = self.__export_project_info()
-        field_names = self.__export_field_names()
-
-        return REDCapProject(
-            redcap_con=self,
-            pid=int(project_info['project_id']),
-            title=project_info['project_title'],
-            pk_field=field_names[0]['export_field_name'],
-            longitudinal=(project_info['is_longitudinal'] == 1),
-            repeating_ins=(
-                project_info['has_repeating_instruments_or_events'] == 1))
 
     def post_request(self,
                      *,

--- a/common/src/python/redcap/redcap_project.py
+++ b/common/src/python/redcap/redcap_project.py
@@ -89,6 +89,22 @@ class REDCapProject:
         self.__longitudinal = longitudinal
         self.__repeating_ins = repeating_ins
 
+    @classmethod
+    def create(cls, redcap_con: REDCapConnection) -> 'REDCapProject':
+        """Get the REDCap project for this connection."""
+
+        project_info = redcap_con.__export_project_info()
+        field_names = redcap_con.__export_field_names()
+
+        return REDCapProject(
+            redcap_con=redcap_con,
+            pid=int(project_info['project_id']),
+            title=project_info['project_title'],
+            pk_field=field_names[0]['export_field_name'],
+            longitudinal=(project_info['is_longitudinal'] == 1),
+            repeating_ins=(
+                project_info['has_repeating_instruments_or_events'] == 1))
+
     @property
     def pid(self) -> int:
         """Returns REDCap project ID."""

--- a/common/src/python/redcap/redcap_repository.py
+++ b/common/src/python/redcap/redcap_repository.py
@@ -87,7 +87,7 @@ class REDCapParametersRepository:
 
         redcap_con = REDCapConnection.create_from(redcap_params)
         try:
-            return redcap_con.get_project()
+            return REDCapProject.create(redcap_con)
         except REDCapConnectionError as error:
             log.error(error)
             return None

--- a/gear/form_qc_checker/src/python/form_qc_app/error_info.py
+++ b/gear/form_qc_checker/src/python/form_qc_app/error_info.py
@@ -13,6 +13,7 @@ from outputs.errors import (
 )
 from pydantic import BaseModel, ValidationError
 from redcap.redcap_connection import REDCapConnectionError, REDCapReportConnection
+from redcap.redcap_project import REDCapProject
 
 from form_qc_app.parser import Keys
 
@@ -160,7 +161,7 @@ class REDCapErrorStore(ErrorStore):
         if record_ids and self.__redcap_con:
             fields = list(ErrorDescription.__annotations__.keys())
             try:
-                redcap_prj = self.__redcap_con.get_project()
+                redcap_prj = REDCapProject.create(self.__redcap_con)
                 records_list = redcap_prj.export_records(record_ids=record_ids,
                                                          fields=fields)
                 for record in records_list:

--- a/gear/redcap_fw_transfer/src/python/redcap_fw_transfer_app/main.py
+++ b/gear/redcap_fw_transfer/src/python/redcap_fw_transfer_app/main.py
@@ -132,7 +132,7 @@ def run(*, gear_context: GearToolkitContext,
 
     try:
         records_list = redcap_con.get_report_records()
-        redcap_prj = redcap_con.get_project()
+        redcap_prj = REDCapProject.create(redcap_con)
     except REDCapConnectionError as error:
         raise GearExecutionError(error.message) from error
 

--- a/gear/redcap_project_creation/src/python/redcap_project_creation_app/main.py
+++ b/gear/redcap_project_creation/src/python/redcap_project_creation_app/main.py
@@ -16,6 +16,7 @@ from redcap.redcap_connection import (
     REDCapConnectionError,
     REDCapSuperUserConnection,
 )
+from redcap.redcap_project import REDCapProject
 
 log = logging.getLogger(__name__)
 
@@ -39,8 +40,8 @@ def setup_new_project_elements(parameter_store: ParameterStore, base_path: str,
     """
 
     try:
-        redcap_con = REDCapConnection(token=token, url=url)
-        redcap_prj = redcap_con.get_project()
+        redcap_prj = REDCapProject.create(
+            REDCapConnection(token=token, url=url))
         redcap_prj.add_gearbot_user_to_project()
     except REDCapConnectionError as error:
         log.error(error)


### PR DESCRIPTION
Fixes an issue with design of REDCapConnection to have a get_project method, which creates a circular dependency.

Moved get_project to a create method in REDCapProject