### PR TITLE
Study mapping refactor

### DIFF
--- a/gear/center_management/src/python/center_app/main.py
+++ b/gear/center_management/src/python/center_app/main.py
@@ -68,3 +68,4 @@ def run(*,
         admin_access = admin_group.get_user_access()
         if admin_access:
             center_group.add_permissions(admin_access)
+            center_group.add_center_portal()


### PR DESCRIPTION
Moves the `add_study` behavior from `CenterGroup` to `StudyMapping`, keeping the project creation in `CenterGroup`.