### PR TITLE
Add CHANGELOGs for all gears

### DIFF
--- a/docs/center_management/CHANGELOG.md
+++ b/docs/center_management/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this gear are documented in this file.
+
+## Unreleased
+
+* [#109](https://github.com/naccdata/flywheel-gear-extensions/pull/109) Moves the `add_study` behavior from `CenterGroup` to `StudyMapping`, keeping the project creation in `CenterGroup`
+* Adds this CHANGELOG
+
+## [1.0.1](https://github.com/naccdata/flywheel-gear-extensions/commit/aa620caf2b6ce8451bdccd1e3719ea2ddeb1d95c)
+
+* [#105](https://github.com/naccdata/flywheel-gear-extensions/pull/105) Fixes error introduced by changing YAML input pattern
+    * Removes `get_object_list` method that reads objects from a YAML file
+* [#106](https://github.com/naccdata/flywheel-gear-extensions/pull/106) Fixes group permissions exception
+    * Updates FW proxy call to `add_group` that can throw exception if user doesn't have permission to access the existing group
+
+## 1.0.0
+
+* [#101](https://github.com/naccdata/flywheel-gear-extensions/pull/101) Initial version; factored out from the project management gear
+    * Isolates center group creation in the center management gear
+    * Removes center management tasks from the project management gear

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -419,7 +419,7 @@ If you add new python dependencies
 
 ## Documenting and versioning
 
-All gear documentation and version tracking is stored under `docs/<gear-name>`, each with at minimum an `index.md` (for documentation) and a `CHANGELOG.md` (for tracking gear versions). The documentation only needs to be updated if new updates fundamentally change or deprecate previously documented features. The Changelog on the other hand should be updated consistently whenever any notable changes or bugfixes are added.
+All gear documentation and version tracking is stored under `docs/<gear-name>`, each with at minimum an `index.md` (for documentation) and a `CHANGELOG.md` (for tracking gear versions), and should be added for every new gear. The documentation only needs to be updated if new updates fundamentally change or deprecate previously documented features. The Changelog on the other hand should be updated consistently whenever any notable changes or bugfixes are added.
 
 The Changelogs loosely follow the convention described in [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the gears all follow semantic versioning. All working changes should be added under the **Unreleased** header, and if a PR is associated with the change, the PR should be linked as well. 
 

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -419,11 +419,11 @@ If you add new python dependencies
 
 ## Documenting and versioning
 
-All gear documentation and version tracking is stored under `docs/<gear-name>`, each with at minimum an `index.md` (for documentation) and a `CHANGELOG.md` (for tracking gear versions). These files should be updated whenver new or notable changes to the gear are added.
+All gear documentation and version tracking is stored under `docs/<gear-name>`, each with at minimum an `index.md` (for documentation) and a `CHANGELOG.md` (for tracking gear versions). The documentation only needs to be updated if new updates fundamentally change or deprecate previously documented features. The Changelog on the other hand should be updated consistently whenever any notable changes or bugfixes are added.
 
-The Changelogs loosely follow the convention described in [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the gears in general all follow semantic versioning. All working changes should be added under the **Unreleased** header, and if a PR is associated with the change, the PR should be linked as well. 
+The Changelogs loosely follow the convention described in [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the gears all follow semantic versioning. All working changes should be added under the **Unreleased** header, and if a PR is associated with the change, the PR should be linked as well. 
 
-Releases and version bumping are currently manually done. When releasing a new version of the gear, ensure the following have been updated:
+Releases and version bumping are currently done manually. When releasing a new version of the gear, ensure the following have been updated:
 
 * Increment the gear's image tag in the following files:
     * `src/docker/BUILD`: the `image_tags` field 

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -26,6 +26,7 @@ To add new code see the [Adding a New Gear](#adding-a-new-gear)
   - [Adding common code](#adding-common-code)
   - [Adding new dependencies](#adding-new-dependencies)
   - [Working with code](#working-with-code)
+  - [Documenting and versioning](#documenting-and-versioning)
 
 
 ## Getting Started
@@ -416,4 +417,17 @@ If you add new python dependencies
     pants check common::
     ```
 
+## Documenting and versioning
 
+All gear documentation and version tracking is stored under `docs/<gear-name>`, each with at minimum an `index.md` (for documentation) and a `CHANGELOG.md` (for tracking gear versions). These files should be updated whenver new or notable changes to the gear are added.
+
+The Changelogs loosely follow the convention described in [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the gears in general all follow semantic versioning. All working changes should be added under the **Unreleased** header, and if a PR is associated with the change, the PR should be linked as well. 
+
+Releases and version bumping are currently manually done. When releasing a new version of the gear, ensure the following have been updated:
+
+* Increment the gear's image tag in the following files:
+    * `src/docker/BUILD`: the `image_tags` field 
+    * `src/docker/manifest.json`: the `version` and `custom/gear-builder/image` fields
+* In the `CHANGELOG.md`, move all changes under the **Unreleased** header to a new header under the new release version
+
+See [this commit](https://github.com/naccdata/flywheel-gear-extensions/commit/fa3ff5ab5218282299b9c67665beacb90f5d8244) for an example of updating the version and image tags in the code.

--- a/docs/form_qc_checker/CHANGELOG.md
+++ b/docs/form_qc_checker/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to this gear are documented in this file.
+
+## Unreleased
+
+* Adds this CHANGELOG
+
+## 0.0.32
+
+* [#102](https://github.com/naccdata/flywheel-gear-extensions/pull/102) Form QC Checker updates
+	* Add functionality to update/reset failed visit info in subject metadata
+	* Updates how to access rule definitions in S3 - use `nacc-flywheel-gear` user credentials
+	* Update optional form validation for non-strict mode
+	* Update `FlywheelDatastore` class functionality - retrieve legacy module info from Flywheel admin group metadata project
+	* Check whether there's a failed previous visit before evaluating the current visit
+	* Move dataview creation/reading to FW proxy class
+
+## 0.0.31
+
+* [#100](https://github.com/naccdata/flywheel-gear-extensions/pull/100) Update to use `nacc-form-validator` v0.2.0
+
+## 0.0.30
+
+* [#89](https://github.com/naccdata/flywheel-gear-extensions/pull/89) Adds support for optional forms validation
+	* Uses `optional_forms.json` to define optional forms, and load correct definition file dependin on the value of the **mode** variable for the respective form
+
+## 0.0.29 and earlier
+
+* Undocumented

--- a/docs/form_qc_coordinator/CHANGELOG.md
+++ b/docs/form_qc_coordinator/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this gear are documented in this file.
+
+## Unreleased
+
+* [#91](https://github.com/naccdata/flywheel-gear-extensions/pull/91) Initial version - gear for coordinating QC checks for a participant
+* [#102](https://github.com/naccdata/flywheel-gear-extensions/pull/102) Form QC Checker updates
+* Adds this CHANGELOG

--- a/docs/identifier_lookup/CHANGELOG.md
+++ b/docs/identifier_lookup/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this gear are documented in this file.
+
+## Unreleased
+
+* [#30](https://github.com/naccdata/flywheel-gear-extensions/pull/30) Initial version - adds the identifier-lookup gear: reads a CSV with ADCID and PTID on each row, looks up NACCID, if NACCID exists, outputs row to file, if NACCID doesn't exist output error
+* [#29](https://github.com/naccdata/flywheel-gear-extensions/pull/29) Adds classes for capturing and outputting errors/alerts to CSV file
+* Adds this CHANGELOG

--- a/docs/identifier_provisioning/CHANGELOG.md
+++ b/docs/identifier_provisioning/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this gear are documented in this file.
+
+## Unreleased
+
+* Adds this CHANGELOG
+
+## 0.1.7
+
+* [#107](https://github.com/naccdata/flywheel-gear-extensions/pull/107) Improve enrollmenet errors
+	* Adds validation error handling to the creation of enrollment and transfer records
+	* Also adds code that allows dates to be parsed with more than one format
+
+## 0.1.3
+
+* Fixes error return value for provisioning run
+
+## 0.1.2 and earlier
+
+* Undocumented

--- a/docs/project_management/CHANGELOG.md
+++ b/docs/project_management/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this gear are documented in this file.
+
+## Unreleased
+
+* Adds this CHANGELOG
+
+## 1.0.2
+
+* [#105](https://github.com/naccdata/flywheel-gear-extensions/pull/105) Fixes error introduced by changing YAML input pattern
+    * Removes `get_object_list` method that reads objects from a YAML file
+
+## 1.0.0
+
+* [#101](https://github.com/naccdata/flywheel-gear-extensions/pull/101) Factors out center management gear from project management gear
+    * Isolates center group creation in the center management gear
+    * Removes center management tasks from the project management gear
+* [#103](https://github.com/naccdata/flywheel-gear-extensions/pull/103) Adds study modes
+	* Changes project management gear so that it can create studies with different pipeline patterns, namely `aggregation` and `distribution`
+
+## 0.0.32 and earlier
+
+* Undocumented

--- a/docs/pull_directory/CHANGELOG.md
+++ b/docs/pull_directory/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this gear are documented in this file.
+
+## Unreleased
+
+* Adds this CHANGELOG
+
+## 1.0.3 and earlier
+
+* Undocumented

--- a/docs/pull_metadata/CHANGELOG.md
+++ b/docs/pull_metadata/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this gear are documented in this file.
+
+## Unreleased
+
+* Adds this CHANGELOG
+
+## 0.0.10 and earlier
+
+* Undocumented

--- a/docs/push_template/CHANGELOG.md
+++ b/docs/push_template/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this gear are documented in this file.
+
+## Unreleased
+
+* Adds this CHANGELOG
+
+## 0.0.17 and earlier
+
+* Undocumented

--- a/docs/redcap_fw_transfer/CHANGELOG.md
+++ b/docs/redcap_fw_transfer/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this gear are documented in this file.
+
+## Unreleased
+
+* Adds this CHANGELOG
+
+## 0.0.16 and earlier
+
+* Undocumented

--- a/docs/redcap_project_creation/CHANGELOG.md
+++ b/docs/redcap_project_creation/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this gear are documented in this file.
+
+## Unreleased
+
+* [#96](https://github.com/naccdata/flywheel-gear-extensions/pull/96) Automates REDCap user management
+    * Adds the gearbot user with NACC developer permissions when creating a new project
+* [#108](https://github.com/naccdata/flywheel-gear-extensions/pull/108) Fixes an issue with the design of `REDCapConnection` to have a `get_project` method, which creates a circular dependency
+    * Moves `get_project` to a create method in `REDCapProject`
+* Adds this CHANGELOG
+* Initial version

--- a/docs/redcap_project_info_management/CHANGELOG.md
+++ b/docs/redcap_project_info_management/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this gear are documented in this file.
+
+## Unreleased
+
+* [#96](https://github.com/naccdata/flywheel-gear-extensions/pull/96) Automates REDCap user management
+	* Changed to retrieve any existing info before adding/updating new info
+* Adds this CHANGELOG
+
+## 0.0.8 and earlier
+
+* Undocumented
+

--- a/docs/user_management/CHANGELOG.md
+++ b/docs/user_management/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this gear are documented in this file.
+
+## Unreleased
+
+* Adds this CHANGELOG
+
+## 1.1.4 and earlier
+
+* Undocumented


### PR DESCRIPTION
Most of the CHANGELOGs are bare-bones but I tried to add detail where I could - ideally going forward these should be filled out alongside any updates to the corresponding gear. 