### PR TITLE
redcap-fw-transfer gear updates

### DIFF
--- a/common/src/python/centers/center_group.py
+++ b/common/src/python/centers/center_group.py
@@ -145,8 +145,8 @@ class CenterGroup(CenterAdaptor):
             raise CenterError(
                 f"Unable to find metadata project for group {group.label}")
 
-        project_adaptor = ProjectAdaptor(project=meta_project, proxy=proxy)
-        metadata_info = project_adaptor.get_info()
+        meta_project = meta_project.reload()
+        metadata_info = meta_project.info
         if 'adcid' not in metadata_info:
             raise CenterError(
                 f"Expected group {group.label}/metadata.info to have ADCID")

--- a/common/src/python/inputs/parameter_store.py
+++ b/common/src/python/inputs/parameter_store.py
@@ -213,7 +213,7 @@ class ParameterStore:
         return self.get_parameters(param_type=REDCapParameters,
                                    parameter_path=param_path)
 
-    def get_redcap_project_parameters(
+    def get_redcap_report_params_for_project(
             self, *, base_path: str, pid: int,
             report_id: int) -> REDCapReportParameters:
         """Pulls URL and Token for the respective REDCap project from SSM

--- a/common/src/python/redcap/redcap_connection.py
+++ b/common/src/python/redcap/redcap_connection.py
@@ -186,7 +186,7 @@ class REDCapConnection:
 
         return response.text
 
-    def __export_field_names(self) -> List[Dict[str, str]]:
+    def export_field_names(self) -> List[Dict[str, str]]:
         """Get the export field names for the project variables.
 
         Returns:
@@ -203,7 +203,7 @@ class REDCapConnection:
 
         return self.request_json_value(data=data, message=message)
 
-    def __export_project_info(self) -> Dict[str, Any]:
+    def export_project_info(self) -> Dict[str, Any]:
         """Export the basic attributes of the project.
 
         Returns:

--- a/common/src/python/redcap/redcap_project.py
+++ b/common/src/python/redcap/redcap_project.py
@@ -346,3 +346,37 @@ class REDCapProject:
         return self.__redcap_con.request_text_value(data=data,
                                                     result_format=exp_format,
                                                     message=message)
+
+    def export_events(self) -> List[Dict[str, Any]]:
+        """Exports the events defined in the project.
+
+        Returns:
+            List[Dict[str, str]]: List of event info Dicts
+
+        Raises:
+          REDCapConnectionError if the response has an error.
+        """
+        message = "exporting events"
+        data = {'content': 'event'}
+
+        return self.__redcap_con.request_json_value(data=data, message=message)
+
+    def get_event_name_for_label(self, label: str) -> Optional[str]:
+        """Returns the unique REDCap event name for given label.
+
+        Returns:
+            Optional[str]: REDCap event name if found, else None
+        """
+
+        try:
+            events = self.export_events()
+        except REDCapConnectionError as error:
+            log.error('Failed to retrieve events for project %s - %s',
+                      self.title, error)
+            return None
+
+        for event in events:
+            if label == event['event_name'].lower():
+                return event['unique_event_name']
+
+        return None

--- a/common/src/python/redcap/redcap_project.py
+++ b/common/src/python/redcap/redcap_project.py
@@ -93,8 +93,8 @@ class REDCapProject:
     def create(cls, redcap_con: REDCapConnection) -> 'REDCapProject':
         """Get the REDCap project for this connection."""
 
-        project_info = redcap_con.__export_project_info()
-        field_names = redcap_con.__export_field_names()
+        project_info = redcap_con.export_project_info()
+        field_names = redcap_con.export_field_names()
 
         return REDCapProject(
             redcap_con=redcap_con,

--- a/common/src/python/redcap/redcap_project.py
+++ b/common/src/python/redcap/redcap_project.py
@@ -336,7 +336,7 @@ class REDCapProject:
 
         # If any filters specified, export only matching records.
         if filters:
-            data['filterLogic'] = ','.join(filters)
+            data['filterLogic'] = filters
 
         message = 'failed to export records'
         if exp_format.lower() == 'json':

--- a/gear/redcap_fw_transfer/src/docker/BUILD
+++ b/gear/redcap_fw_transfer/src/docker/BUILD
@@ -7,5 +7,5 @@ docker_image(
         ":manifest",
         "gear/redcap_fw_transfer/src/python/redcap_fw_transfer_app:bin",
     ],
-    image_tags=["0.0.16", "latest"],
+    image_tags=["0.0.17", "latest"],
 )

--- a/gear/redcap_fw_transfer/src/docker/BUILD
+++ b/gear/redcap_fw_transfer/src/docker/BUILD
@@ -7,5 +7,5 @@ docker_image(
         ":manifest",
         "gear/redcap_fw_transfer/src/python/redcap_fw_transfer_app:bin",
     ],
-    image_tags=["0.0.17", "latest"],
+    image_tags=["0.0.19", "latest"],
 )

--- a/gear/redcap_fw_transfer/src/docker/BUILD
+++ b/gear/redcap_fw_transfer/src/docker/BUILD
@@ -7,5 +7,5 @@ docker_image(
         ":manifest",
         "gear/redcap_fw_transfer/src/python/redcap_fw_transfer_app:bin",
     ],
-    image_tags=["0.0.19", "latest"],
+    image_tags=["0.0.20", "latest"],
 )

--- a/gear/redcap_fw_transfer/src/docker/manifest.json
+++ b/gear/redcap_fw_transfer/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "redcap-fw-transfer",
     "label": "REDCap to Flywheel Transfer",
     "description": "Gear to transfer from data from a REDCap project to the respective Flywheel project",
-    "version": "0.0.17",
+    "version": "0.0.19",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/redcap-fw-transfer:0.0.17"
+            "image": "naccdata/redcap-fw-transfer:0.0.19"
         },
         "flywheel": {
             "suite": "Import",

--- a/gear/redcap_fw_transfer/src/docker/manifest.json
+++ b/gear/redcap_fw_transfer/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "redcap-fw-transfer",
     "label": "REDCap to Flywheel Transfer",
     "description": "Gear to transfer from data from a REDCap project to the respective Flywheel project",
-    "version": "0.0.19",
+    "version": "0.0.20",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/redcap-fw-transfer:0.0.19"
+            "image": "naccdata/redcap-fw-transfer:0.0.20"
         },
         "flywheel": {
             "suite": "Import",

--- a/gear/redcap_fw_transfer/src/docker/manifest.json
+++ b/gear/redcap_fw_transfer/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "redcap-fw-transfer",
     "label": "REDCap to Flywheel Transfer",
     "description": "Gear to transfer from data from a REDCap project to the respective Flywheel project",
-    "version": "0.0.16",
+    "version": "0.0.17",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/redcap-fw-transfer:0.0.16"
+            "image": "naccdata/redcap-fw-transfer:0.0.17"
         },
         "flywheel": {
             "suite": "Import",

--- a/gear/redcap_fw_transfer/src/python/redcap_fw_transfer_app/main.py
+++ b/gear/redcap_fw_transfer/src/python/redcap_fw_transfer_app/main.py
@@ -173,7 +173,7 @@ def run(*, gear_context: GearToolkitContext, redcap_con: REDCapConnection,
                     )
                 events = [event]
                 extra_fields.extend(
-                    ['redcap_event_name', 'redcap_repeat_instance'])
+                    ['redcap_event_name', 'redcap_repeat_instance', 'redcap_repeat_instrument'])
 
             records_list = redcap_prj.export_records(
                 fields=fields, events=events, filters=filters)  # type: ignore

--- a/gear/redcap_fw_transfer/src/python/redcap_fw_transfer_app/main.py
+++ b/gear/redcap_fw_transfer/src/python/redcap_fw_transfer_app/main.py
@@ -169,7 +169,7 @@ def run(*, gear_context: GearToolkitContext, redcap_con: REDCapConnection,
                 event = redcap_prj.get_event_name_for_label(f'{module}-visit')
                 if not event:
                     raise GearExecutionError(
-                        'Cannot find event {module}-visit in project {redcap_prj.title}'
+                        f'Cannot find event {module}-visit in project {redcap_prj.title}'
                     )
                 events = [event]
                 extra_fields.extend(

--- a/gear/redcap_fw_transfer/src/python/redcap_fw_transfer_app/run.py
+++ b/gear/redcap_fw_transfer/src/python/redcap_fw_transfer_app/run.py
@@ -11,7 +11,7 @@ from centers.center_group import (
     REDCapFormProjectMetadata,
 )
 from flywheel.rest import ApiException
-from flywheel_adaptor.flywheel_proxy import FlywheelProxy, GroupAdaptor
+from flywheel_adaptor.flywheel_proxy import GroupAdaptor
 from flywheel_gear_toolkit import GearToolkitContext
 from gear_execution.gear_execution import (
     ClientWrapper,
@@ -22,7 +22,7 @@ from gear_execution.gear_execution import (
 )
 from inputs.context_parser import ConfigParseError, get_config
 from inputs.parameter_store import ParameterError, ParameterStore
-from redcap.redcap_connection import REDCapReportConnection
+from redcap.redcap_connection import REDCapConnection, REDCapReportConnection
 
 from redcap_fw_transfer_app.main import run
 
@@ -60,14 +60,13 @@ def get_destination_group_and_project(dest_container: Any) -> Tuple[str, str]:
 
 
 def get_redcap_projects_metadata(
-        *, fw_proxy: FlywheelProxy, group_adaptor: GroupAdaptor,
+        *, group_adaptor: GroupAdaptor,
         project_label: str) -> Dict[str, REDCapFormProjectMetadata]:
     """Retrieve the info on source REDCap projects to transfer the data from.
     REDCap->FW mapping info is included in each center's metadata project.
 
     Args:
-        fw_proxy: Flywheel proxy
-        group_adaptor: Flywhee adaptor for the center group
+        group_adaptor: Flywhee group adaptor
         project_label: Flywheel ingest project label to upload data
 
     Returns:
@@ -80,8 +79,7 @@ def get_redcap_projects_metadata(
     redcap_projects = {}
 
     try:
-        center_group = CenterGroup.create_from_group_adaptor(
-            adaptor=group_adaptor)
+        center_group = CenterGroup.get_center_group(adaptor=group_adaptor)
         center_metadata = center_group.get_project_info()
     except CenterError as error:
         raise GearExecutionError(
@@ -100,13 +98,14 @@ def get_redcap_projects_metadata(
         matches += 1
         log.info(
             'REDCap projects metadata found for center: %s, '
-            'study: %s, project: %s', group_adaptor.id, study, project_label)
+            'study: %s, project: %s', group_adaptor.label, study,
+            project_label)
         redcap_projects = project_metadata.redcap_projects
 
     if matches > 1:
         raise GearExecutionError(
             'More than one match found for project '
-            f'{project_label} in center {group_adaptor.id} metadata')
+            f'{project_label} in center {group_adaptor.label} metadata')
 
     return redcap_projects
 
@@ -156,7 +155,37 @@ class REDCapFlywheelTransferVisitor(GearExecutionEnvironment):
                                              parameter_store=parameter_store,
                                              param_path=param_path)
 
-    # pylint: disable=(too-many-locals)
+    def get_redcap_connection(
+        self, redcap_project: REDCapFormProjectMetadata
+    ) -> Optional[REDCapConnection]:
+        """Get API connection for the sepcified REDCap project.
+
+        Args:
+            redcap_project: REDCap project metadata
+
+        Returns:
+            REDCapConnection(optional): REDCap API connection if successful, else None
+        """
+        try:
+            if redcap_project.report_id:
+                redcap_params = self.__param_store.get_redcap_report_params_for_project(
+                    base_path=self.__param_path,
+                    pid=redcap_project.redcap_pid,
+                    report_id=redcap_project.report_id)
+                redcap_con = REDCapReportConnection.create_from(redcap_params)
+            else:
+                redcap_params = self.__param_store.get_redcap_parameters(
+                    base_path=self.__param_path, pid=redcap_project.redcap_pid)
+                redcap_con = REDCapConnection.create_from(redcap_params)
+        except ParameterError as error:
+            log.error(
+                'Error in retrieving REDCap project credentials '
+                'for project %s module %s: %s', redcap_project.redcap_pid,
+                redcap_project.label, error)
+            return None
+
+        return redcap_con
+
     def run(self, context: GearToolkitContext):
         """Runs the redcap_fw_transfer app.
 
@@ -177,8 +206,8 @@ class REDCapFlywheelTransferVisitor(GearExecutionEnvironment):
 
         group_id, project_id = get_destination_group_and_project(
             dest_container)
-        group = self.proxy.find_group(group_id)
-        if not group:
+        group_adaptor = self.proxy.find_group(group_id)
+        if not group_adaptor:
             raise GearExecutionError(f'Cannot find Flywheel group {group_id}')
         project = self.proxy.get_project_by_id(project_id)
         if not project:
@@ -186,9 +215,7 @@ class REDCapFlywheelTransferVisitor(GearExecutionEnvironment):
                 f'Cannot find Flywheel project {project_id}')
 
         redcap_projects = get_redcap_projects_metadata(
-            fw_proxy=self.proxy,
-            group_adaptor=group,
-            project_label=project.label)
+            group_adaptor=group_adaptor, project_label=project.label)
 
         if not redcap_projects:
             raise GearExecutionError(
@@ -196,41 +223,24 @@ class REDCapFlywheelTransferVisitor(GearExecutionEnvironment):
                 f'{group_id}/{project.label}')
 
         failed_count = 0
-        for module, redcap_project in redcap_projects.items():
-            if (not redcap_project.label or not redcap_project.redcap_pid
-                    or not redcap_project.report_id):
-                log.error(
-                    'Incomplete REDCap project info in %s/metadata '
-                    'for module %s', group_id, module)
+        for redcap_project in redcap_projects.values():
+            redcap_con = self.get_redcap_connection(redcap_project)
+            if not redcap_con:
                 failed_count += 1
                 continue
 
-            try:
-                redcap_params = self.__param_store.get_redcap_project_parameters(
-                    base_path=self.__param_path,
-                    pid=redcap_project.redcap_pid,
-                    report_id=redcap_project.report_id)
-                redcap_report_con = REDCapReportConnection.create_from(
-                    redcap_params)
-            except ParameterError as error:
-                log.error(
-                    'Error in retrieving REDCap report credentials '
-                    'for project %s module %s: %s', redcap_project.redcap_pid,
-                    redcap_project.label, error)
-                failed_count += 1
-                continue
-
+            module = redcap_project.label.lower()
             try:
                 run(gear_context=context,
-                    redcap_con=redcap_report_con,
+                    redcap_con=redcap_con,
                     redcap_pid=str(redcap_project.redcap_pid),
-                    module=redcap_project.label,
+                    module=module,
                     fw_group=group_id,
                     fw_project=project)
             except GearExecutionError as error:
                 log.error(
                     'Error in ingesting module %s from REDCap project %s: %s',
-                    redcap_project.label, redcap_project.redcap_pid, error)
+                    module, redcap_project.redcap_pid, error)
                 failed_count += 1
                 continue
 

--- a/gear/redcap_project_creation/src/docker/BUILD
+++ b/gear/redcap_project_creation/src/docker/BUILD
@@ -7,5 +7,5 @@ docker_image(
         ":manifest",
         "gear/redcap_project_creation/src/python/redcap_project_creation_app:bin",
     ],
-    image_tags=["0.0.1", "latest"],
+    image_tags=["0.0.2", "latest"],
 )

--- a/gear/redcap_project_creation/src/docker/manifest.json
+++ b/gear/redcap_project_creation/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "redcap-project-creation",
     "label": "REDCap Project Creation",
     "description": "A gear to create REDCap projects using the REDCap API",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/redcap-project-creation:0.0.1"
+            "image": "naccdata/redcap-project-creation:0.0.2"
         },
         "flywheel": {
             "suite": "NACC Admin Gears",

--- a/gear/redcap_project_creation/src/python/redcap_project_creation_app/main.py
+++ b/gear/redcap_project_creation/src/python/redcap_project_creation_app/main.py
@@ -4,6 +4,7 @@ import logging
 from typing import Dict, List, Optional, Tuple
 
 from centers.center_group import (
+    CenterError,
     CenterGroup,
     REDCapFormProjectMetadata,
     REDCapProjectInput,
@@ -140,9 +141,14 @@ def run(
 
             # Update REDCap project metadata in Flywheel
             if len(project_object.projects) > 0:
-                center_group = CenterGroup.create_from_group_adaptor(
-                    adaptor=group_adaptor)
-                center_group.add_redcap_project(project_object)
+                try:
+                    center_group = CenterGroup.get_center_group(
+                        adaptor=group_adaptor)
+                    center_group.add_redcap_project(project_object)
+                except CenterError as error:
+                    log.error('Failed to update REDCap project metadata for %s/%s',
+                              group_adaptor.label, project_lbl)
+
                 redcap_metadata.append(project_object)
 
     return errors, redcap_metadata


### PR DESCRIPTION
If REDCap report id is not available in Flywheel metadata, use jsonschema definition for the respective module to export the records from REDCap project.