### PR TITLE
form-qc-checker updates

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -9,9 +9,6 @@ python_requirements(
         "ssm-parameter-store": {
             "dependencies": ["//:reqs#setuptools"]
         },
-        "flywheel-sdk": {
-            "dependencies": ["//:reqs#pandas"]
-        },
     },
 )
 

--- a/common/src/python/dates/form_dates.py
+++ b/common/src/python/dates/form_dates.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from typing import List
 
 DATE_FORMATS = ['%m/%d/%Y', '%m-%d-%Y', '%Y/%m/%d', '%Y-%m-%d']
+DATE_PATTERN = r"^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$"
 
 
 def parse_date(*, date_string: str, formats: List[str]) -> datetime:

--- a/common/src/python/flywheel_adaptor/subject_adaptor.py
+++ b/common/src/python/flywheel_adaptor/subject_adaptor.py
@@ -4,15 +4,15 @@ specialized subject wrappers."""
 import logging
 from typing import Any, Dict, List, Optional
 
+from dates.form_dates import DATE_PATTERN
 from flywheel.finder import Finder
 from flywheel.models.session import Session
 from flywheel.models.subject import Subject
+from keys.keys import MetadataKeys
 from pydantic import AliasGenerator, BaseModel, ConfigDict, Field, ValidationError
 from serialization.case import kebab_case
 
 log = logging.getLogger(__name__)
-
-DATE_PATTERN = r"^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$"
 
 
 class SubjectError(Exception):
@@ -98,7 +98,7 @@ class SubjectAdaptor:
         """
 
         module_info = self.info.get(module, {})
-        last_failed = module_info.get('failed', None)
+        last_failed = module_info.get(MetadataKeys.FAILED, None)
         if not last_failed:
             return None
 
@@ -119,7 +119,7 @@ class SubjectAdaptor:
         # make sure to load the existing metadata first and then modify
         # update_info() will replace everything under the top-level key
         module_info = self.info.get(module, {})
-        module_info['failed'] = failed_visit.model_dump()
+        module_info[MetadataKeys.FAILED] = failed_visit.model_dump()
         updates = {module: module_info}
         self._subject.update_info(updates)
 
@@ -133,7 +133,7 @@ class SubjectAdaptor:
         # make sure to load the existing metadata first and then modify
         # update_info() will replace everything under the top-level key
         module_info = self.info.get(module, {})
-        module_info['failed'] = {}
+        module_info[MetadataKeys.FAILED] = {}
         updates = {module: module_info}
         # Note: have to use update_info() here for reset to take effect
         # Using update() will not delete any exsisting data

--- a/common/src/python/keys/keys.py
+++ b/common/src/python/keys/keys.py
@@ -38,3 +38,14 @@ class DefaultValues:
     LEGACY_PRJ_LABEL = 'retrospective-form'
     ENROLLMENT_MODULE = 'ENROLLV1'
     GEARBOT_USER_ID = 'nacc-flywheel-gear@uw.edu'
+    NACC_GROUP_ID = 'nacc'
+    METADATA_PRJ_LBL = 'metadata'
+    ADMIN_PROJECT = 'project-admin'
+
+
+class MetadataKeys:
+    """Class to store metadata keys."""
+    LEGACY_KEY = 'legacy'
+    LEGACY_LBL = 'legacy_label'
+    LEGACY_ORDERBY = 'legacy_orderby'
+    FAILED = 'failed'

--- a/common/src/python/keys/keys.py
+++ b/common/src/python/keys/keys.py
@@ -29,6 +29,7 @@ class RuleLabels:
     TEMPORAL = 'temporalrules'
     NULLABLE = 'nullable'
     REQUIRED = 'required'
+    GDS = 'compute_gds'
 
 
 class DefaultValues:

--- a/docs/form_qc_checker/CHANGELOG.md
+++ b/docs/form_qc_checker/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 All notable changes to this gear are documented in this file.
 
-## Unreleased
-
-* Adds this CHANGELOG
+## 1.0.0
+* Update to use nacc-form-validator [v0.3.0](https://github.com/naccdata/nacc-form-validator/releases/tag/v0.3.0)
+* Rename/refactor `FlywheelDatastore` class to `DatastoreHelper` to allow more general operations
+* Add `compute_gds` as a composite rule to match new GDS score validation
 
 ## 0.0.32
 

--- a/gear/form_qc_checker/src/docker/BUILD
+++ b/gear/form_qc_checker/src/docker/BUILD
@@ -6,5 +6,5 @@ docker_image(
     dependencies=[
         ":manifest", "gear/form_qc_checker/src/python/form_qc_app:bin"
     ],
-    image_tags=["0.0.32", "latest"],
+    image_tags=["0.0.34", "latest"],
 )

--- a/gear/form_qc_checker/src/docker/BUILD
+++ b/gear/form_qc_checker/src/docker/BUILD
@@ -6,5 +6,5 @@ docker_image(
     dependencies=[
         ":manifest", "gear/form_qc_checker/src/python/form_qc_app:bin"
     ],
-    image_tags=["0.0.34", "latest"],
+    image_tags=["1.0.0", "latest"],
 )

--- a/gear/form_qc_checker/src/docker/manifest.json
+++ b/gear/form_qc_checker/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "form-qc-checker",
     "label": "Form QC Checker",
     "description": "Gear to check form data as JSON with QC rule set",
-    "version": "0.0.34",
+    "version": "1.0.0",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/form-qc-checker:0.0.34"
+            "image": "naccdata/form-qc-checker:1.0.0"
         },
         "flywheel": {
             "suite": "Curation",

--- a/gear/form_qc_checker/src/docker/manifest.json
+++ b/gear/form_qc_checker/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "form-qc-checker",
     "label": "Form QC Checker",
     "description": "Gear to check form data as JSON with QC rule set",
-    "version": "0.0.32",
+    "version": "0.0.34",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/form-qc-checker:0.0.32"
+            "image": "naccdata/form-qc-checker:0.0.34"
         },
         "flywheel": {
             "suite": "Curation",

--- a/gear/form_qc_checker/src/python/form_qc_app/error_info.py
+++ b/gear/form_qc_checker/src/python/form_qc_app/error_info.py
@@ -2,7 +2,7 @@
 
 import logging
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, ClassVar, Dict, List, Optional, Tuple
 
 from keys.keys import FieldNames, RuleLabels
 from outputs.errors import (
@@ -49,7 +49,7 @@ class ErrorStore(ABC):
     """Base class to retrieve NACC QC checks information from a database."""
 
     # List of error cheks by error code
-    __errors_list: Dict[str, ErrorDescription] = {}
+    __errors_list: ClassVar[Dict[str, ErrorDescription]] = {}
 
     def __init__(self, preload: bool = False) -> None:
         """

--- a/gear/form_qc_checker/src/python/form_qc_app/error_info.py
+++ b/gear/form_qc_checker/src/python/form_qc_app/error_info.py
@@ -18,7 +18,7 @@ from redcap.redcap_project import REDCapProject
 
 log = logging.getLogger(__name__)
 
-COMPOSITE_RULES = [RuleLabels.COMPAT, RuleLabels.TEMPORAL]
+COMPOSITE_RULES = [RuleLabels.COMPAT, RuleLabels.TEMPORAL, RuleLabels.GDS]
 
 
 class ErrorDescription(BaseModel):

--- a/gear/form_qc_checker/src/python/form_qc_app/error_info.py
+++ b/gear/form_qc_checker/src/python/form_qc_app/error_info.py
@@ -409,16 +409,17 @@ class ErrorComposer():
             if error.rule != error.schema_path[1]:
                 continue
 
-            if error.rule not in code_shema:
-                if not replace_nullable_with_required(error.rule, code_shema):
-                    log.warning(
-                        'NACC error code not found '
-                        'for variable %s rule %s - %s', field, error.rule,
-                        error.schema_path)
-                    self.__write_qc_error_no_code(error_obj=error,
-                                                  field=field,
-                                                  line_number=line_number)
-                    continue
+            if (error.rule not in code_shema
+                    and not replace_nullable_with_required(
+                        error.rule, code_shema)):
+                log.warning(
+                    'NACC error code not found '
+                    'for variable %s rule %s - %s', field, error.rule,
+                    error.schema_path)
+                self.__write_qc_error_no_code(error_obj=error,
+                                              field=field,
+                                              line_number=line_number)
+                continue
 
             if is_composite_rule(error.rule):
                 checks = code_shema[error.rule]

--- a/gear/form_qc_checker/src/python/form_qc_app/main.py
+++ b/gear/form_qc_checker/src/python/form_qc_app/main.py
@@ -45,8 +45,8 @@ from redcap.redcap_connection import REDCapReportConnection
 from s3.s3_client import S3BucketReader
 
 from form_qc_app.csv_visitor import FormQCCSVVisitor, read_first_data_row
+from form_qc_app.datastore import DatastoreHelper
 from form_qc_app.error_info import ErrorComposer, ErrorStore, REDCapErrorStore
-from form_qc_app.flywheel_datastore import FlywheelDatastore
 from form_qc_app.parser import Parser, ParserException
 
 log = logging.getLogger(__name__)
@@ -556,10 +556,12 @@ def run(*,
                     error_writer=error_writer,
                     strict=strict)
 
-                datastore = FlywheelDatastore(proxy=proxy,
-                                              group_id=file.parents.group,
-                                              project=project,
-                                              legacy_label=legacy_label)
+                datastore = DatastoreHelper(pk_field=pk_field,
+                                            orderby=date_field,
+                                            proxy=proxy,
+                                            group_id=file.parents.group,
+                                            project=project,
+                                            legacy_label=legacy_label)
 
                 error_store = REDCapErrorStore(redcap_con=redcap_connection)
 

--- a/gear/form_qc_checker/src/python/form_qc_app/parser.py
+++ b/gear/form_qc_checker/src/python/form_qc_app/parser.py
@@ -18,7 +18,6 @@ class ParserException(Exception):
     """Raised when an error occurs during loading rule definitions."""
 
 
-# pylint: disable=(too-few-public-methods)
 class Parser:
     """Class to load the validation rules definitions as python objects."""
 

--- a/gear/form_qc_checker/src/python/form_qc_app/run.py
+++ b/gear/form_qc_checker/src/python/form_qc_app/run.py
@@ -86,7 +86,7 @@ class FormQCCheckerVisitor(GearExecutionEnvironment):
         try:
             redcap_con = REDCapReportConnection.create_from(redcap_params)
         except REDCapConnectionError as error:
-            raise GearExecutionError(error)
+            raise GearExecutionError(error) from error
 
         return FormQCCheckerVisitor(client=client,
                                     file_input=file_input,

--- a/mypy-stubs/src/python/flywheel/models/file_entry.pyi
+++ b/mypy-stubs/src/python/flywheel/models/file_entry.pyi
@@ -49,3 +49,9 @@ class FileEntry:
     @tags.setter
     def tags(self, tags: List[str]):
         ...
+
+    def add_tag(self, tag, **kwargs):
+        ...
+
+    def delete_tag(self, tag, **kwargs):
+        ...

--- a/mypy-stubs/src/python/flywheel/models/file_entry.pyi
+++ b/mypy-stubs/src/python/flywheel/models/file_entry.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from flywheel.models.container_parents import ContainerParents
 
@@ -40,4 +40,12 @@ class FileEntry:
         ...
 
     def reload(self) -> FileEntry:
+        ...
+
+    @property
+    def tags(self) -> List[str]:
+        ...
+
+    @tags.setter
+    def tags(self, tags: List[str]):
         ...

--- a/python-default.lock
+++ b/python-default.lock
@@ -17,7 +17,7 @@
 //     "fw-client>=0.7.0",
 //     "fw-utils>=3",
 //     "moto[s3,ses,ssm]>=5.0.15",
-//     "nacc_form_validator@ https://github.com/naccdata/nacc-form-validator/releases/download/v0.2.0/nacc_form_validator-0.2.0-py3-none-any.whl",
+//     "nacc_form_validator@ https://github.com/naccdata/nacc-form-validator/releases/download/v0.3.0/nacc_form_validator-0.3.0-py3-none-any.whl",
 //     "pandas-stubs>=2.0.3",
 //     "pandas>=2.1.1",
 //     "pydantic>=2.5.2",
@@ -192,44 +192,44 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "a839ce09a844d92e0039f95851e88da9df80c89ebb4c7818b3e78247fd97a8a7",
-              "url": "https://files.pythonhosted.org/packages/36/e4/8e8b3c706e6af031142d9a80379a13688c73d1953f458bc34fe185d34649/boto3-1.35.46-py3-none-any.whl"
+              "hash": "b660c649a27a6b47a34f6f858f5bd7c3b0a798a16dec8dda7cbebeee80fd1f60",
+              "url": "https://files.pythonhosted.org/packages/ce/4e/181f3fb8bb54b34a6cfa1e36f9088f66ce8f00c8bf5d1d78a07db9193f9a/boto3-1.35.49-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "c9bab807b372d5b076d6aeb1d6513131fa0b74e32d8895128f8568b6521296ea",
-              "url": "https://files.pythonhosted.org/packages/c6/ca/37365724ca403689722cb4eb2771f41102d9aa7a191ddaf530ecb8412ff4/boto3-1.35.46.tar.gz"
+              "hash": "ddecb27f5699ca9f97711c52b6c0652c2e63bf6c2bfbc13b819b4f523b4d30ff",
+              "url": "https://files.pythonhosted.org/packages/73/c6/a18789b17138bc4f3001bfee42c07f85b9432475f5e8188c5699d481a376/boto3-1.35.49.tar.gz"
             }
           ],
           "project_name": "boto3",
           "requires_dists": [
-            "botocore<1.36.0,>=1.35.46",
+            "botocore<1.36.0,>=1.35.49",
             "botocore[crt]<2.0a0,>=1.21.0; extra == \"crt\"",
             "jmespath<2.0.0,>=0.7.1",
             "s3transfer<0.11.0,>=0.10.0"
           ],
           "requires_python": ">=3.8",
-          "version": "1.35.46"
+          "version": "1.35.49"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "5b2887214d0953e7e6d5aeb4276e3b9e3cc3fb7375ef39a9da8aaa0c3e48b223",
-              "url": "https://files.pythonhosted.org/packages/30/dc/9989a8e57d44566bec5ef0f7af624811deda3a90569986812284e055afe9/boto3_stubs-1.35.46-py3-none-any.whl"
+              "hash": "daad87dcff906f7c09dde4ef3c252e2c47b6e1e8e669f5a8311658ac0d1182c0",
+              "url": "https://files.pythonhosted.org/packages/1a/2c/4aeef75df96a34ec9d975642bd8c283c15be758506afcf08d9edba0c4c29/boto3_stubs-1.35.49-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a5bddda9eaa277b615d9e394f42f51d97e6652166db6810f645cc52a4f4efccb",
-              "url": "https://files.pythonhosted.org/packages/83/b7/1e890d341fc0a66c8dd6a2ed2dfa077b4b1c41e3bb2081f8d78b1c482eb1/boto3_stubs-1.35.46.tar.gz"
+              "hash": "2a2e08ba2383df6f478127f9754a02a590131249b40c59d7c6ca9fce76906785",
+              "url": "https://files.pythonhosted.org/packages/a2/31/0692d10cc2b82a30bff37f7522ab85bf7c97e6284922f04ffde0693f6c04/boto3_stubs-1.35.49.tar.gz"
             }
           ],
           "project_name": "boto3-stubs",
           "requires_dists": [
             "boto3-stubs-full; extra == \"full\"",
-            "boto3==1.35.46; extra == \"boto3\"",
+            "boto3==1.35.49; extra == \"boto3\"",
             "botocore-stubs",
-            "botocore==1.35.46; extra == \"boto3\"",
+            "botocore==1.35.49; extra == \"boto3\"",
             "mypy-boto3-accessanalyzer<1.36.0,>=1.35.0; extra == \"accessanalyzer\"",
             "mypy-boto3-accessanalyzer<1.36.0,>=1.35.0; extra == \"all\"",
             "mypy-boto3-account<1.36.0,>=1.35.0; extra == \"account\"",
@@ -744,8 +744,6 @@
             "mypy-boto3-networkmanager<1.36.0,>=1.35.0; extra == \"networkmanager\"",
             "mypy-boto3-networkmonitor<1.36.0,>=1.35.0; extra == \"all\"",
             "mypy-boto3-networkmonitor<1.36.0,>=1.35.0; extra == \"networkmonitor\"",
-            "mypy-boto3-nimble<1.36.0,>=1.35.0; extra == \"all\"",
-            "mypy-boto3-nimble<1.36.0,>=1.35.0; extra == \"nimble\"",
             "mypy-boto3-oam<1.36.0,>=1.35.0; extra == \"all\"",
             "mypy-boto3-oam<1.36.0,>=1.35.0; extra == \"oam\"",
             "mypy-boto3-omics<1.36.0,>=1.35.0; extra == \"all\"",
@@ -1017,19 +1015,19 @@
             "typing-extensions>=4.1.0; python_version < \"3.12\""
           ],
           "requires_python": ">=3.8",
-          "version": "1.35.46"
+          "version": "1.35.49"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "8bbc9a55cae65a8db7f2e33ff087f4dbfc13fce868e8e3c5273ce9af367a555a",
-              "url": "https://files.pythonhosted.org/packages/30/03/6935c80460ec7b9ede45cb0cda79610fb6834f26d9cfc74939a46d677b22/botocore-1.35.46-py3-none-any.whl"
+              "hash": "aed4d3643afd702920792b68fbe712a8c3847993820d1048cd238a6469354da1",
+              "url": "https://files.pythonhosted.org/packages/e3/3f/7c932ed4f6884b37e9a5bd3b37f88b35fa89491d635ab5b2cfeb8b800f95/botocore-1.35.49-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8c0ff5fdd611a28f5752189d171c69690dbc484fa06d74376890bb0543ec3dc1",
-              "url": "https://files.pythonhosted.org/packages/df/6a/79967e8ad76bb2095fd1033492e4c42bc7e04b89e88dfa9a811c936757aa/botocore-1.35.46.tar.gz"
+              "hash": "07d0c1325fdbfa49a4a054413dbdeab0a6030449b2aa66099241af2dac48afd8",
+              "url": "https://files.pythonhosted.org/packages/16/c3/20c4d7df35b7a93a4999c881beaf38dbf91fd7c82c28d876c3cdd0959fe3/botocore-1.35.49.tar.gz"
             }
           ],
           "project_name": "botocore",
@@ -1041,19 +1039,19 @@
             "urllib3<1.27,>=1.25.4; python_version < \"3.10\""
           ],
           "requires_python": ">=3.8",
-          "version": "1.35.46"
+          "version": "1.35.49"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "218ba6da1d76eb372d86e444bd0c6af006e613404cf37e4c754ce0734ef6f131",
-              "url": "https://files.pythonhosted.org/packages/32/ce/93517c7d9bcae123fc2d088b71852650bef01a8049938231d9b49a41c8fe/botocore_stubs-1.35.46-py3-none-any.whl"
+              "hash": "367ce067e003de7e9b76320f551ba4fc8369a4b7ef10210f6071d3593fea2605",
+              "url": "https://files.pythonhosted.org/packages/b0/92/b895334118b3856f463bcda3deeb2fbe5f6052d962921704d4cd1d538b7e/botocore_stubs-1.35.49-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6d9c521b774e62bcbaa383755f10b6cb720202eb357b0b191a195b538b19b817",
-              "url": "https://files.pythonhosted.org/packages/e5/c0/9b01b93a06e03a186c7c40e6e5b24d15dd6799b5fe3805e51ced34d4c9f7/botocore_stubs-1.35.46.tar.gz"
+              "hash": "c5006e31d77e290eca215e6a71292ea7b029b54900310ed0f87da8e844f1db38",
+              "url": "https://files.pythonhosted.org/packages/b4/91/a60415d7ed02a13c920a42237be617547820761670e223539b0e061639fe/botocore_stubs-1.35.49.tar.gz"
             }
           ],
           "project_name": "botocore-stubs",
@@ -1063,7 +1061,7 @@
             "typing-extensions>=4.1.0; python_version < \"3.9\""
           ],
           "requires_python": ">=3.8",
-          "version": "1.35.46"
+          "version": "1.35.49"
         },
         {
           "artifacts": [
@@ -1960,8 +1958,8 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "1c4589aa076d201bddb987f9de5876f6d4126ed6d87cee26838701c177cbab95",
-              "url": "https://github.com/naccdata/nacc-form-validator/releases/download/v0.2.0/nacc_form_validator-0.2.0-py3-none-any.whl"
+              "hash": "e271c54377d48441d36acb52c5304aff63a30bb70182ea59770f45d2ada1108f",
+              "url": "https://github.com/naccdata/nacc-form-validator/releases/download/v0.3.0/nacc_form_validator-0.3.0-py3-none-any.whl"
             }
           ],
           "project_name": "nacc-form-validator",
@@ -1971,7 +1969,7 @@
             "types-python-dateutil>=2.9.0.20240316"
           ],
           "requires_python": "==3.11.*",
-          "version": "0.2.0"
+          "version": "0.3.0"
         },
         {
           "artifacts": [
@@ -2864,19 +2862,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "0f32b7bd435180bf8baed59033b1e6366850c1148b4fbfb85f7a02da23ab97b7",
-              "url": "https://files.pythonhosted.org/packages/fe/10/b217b540f121a8f73267267547784690f321c44f9440fefc5ed311c8ff94/types_awscrt-0.22.4-py3-none-any.whl"
+              "hash": "517d9d06f19cf58d778ca90ad01e52e0489466bf70dcf78c7f47f74fdf151a60",
+              "url": "https://files.pythonhosted.org/packages/fc/05/155d84a2a73083bf3243584ae90d9710eac7d31f54362e35ca413bdaba39/types_awscrt-0.23.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1364a06002facfbbddde72596f873ff4b3d1329f3b5d9db0a2804c3c9bf584de",
-              "url": "https://files.pythonhosted.org/packages/eb/81/41439443fea29b3e1dac7e2456072bab8813b85d5510987db45804a911a7/types_awscrt-0.22.4.tar.gz"
+              "hash": "3fd1edeac923d1956c0e907c973fb83bda465beae7f054716b371b293f9b5fdc",
+              "url": "https://files.pythonhosted.org/packages/dd/23/7de2052a76ec03cdc56cb425efbcb80e9d779a188cd1ae44e8524c717c35/types_awscrt-0.23.0.tar.gz"
             }
           ],
           "project_name": "types-awscrt",
           "requires_dists": [],
           "requires_python": ">=3.8",
-          "version": "0.22.4"
+          "version": "0.23.0"
         },
         {
           "artifacts": [
@@ -3098,13 +3096,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "02c9eb92b7d6c06f31a782811505d2157837cea66aaede3e217c7c27c039476c",
-              "url": "https://files.pythonhosted.org/packages/4b/84/997bbf7c2bf2dc3f09565c6d0b4959fefe5355c18c4096cfd26d83e0785b/werkzeug-3.0.4-py3-none-any.whl"
+              "hash": "1bc0c2310d2fbb07b1dd1105eba2f7af72f322e1e455f2f93c993bee8c8a5f17",
+              "url": "https://files.pythonhosted.org/packages/6c/69/05837f91dfe42109203ffa3e488214ff86a6d68b2ed6c167da6cdc42349b/werkzeug-3.0.6-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "34f2371506b250df4d4f84bfe7b0921e4762525762bbd936614909fe25cd7306",
-              "url": "https://files.pythonhosted.org/packages/0f/e2/6dbcaab07560909ff8f654d3a2e5a60552d937c909455211b1b36d7101dc/werkzeug-3.0.4.tar.gz"
+              "hash": "a8dd59d4de28ca70471a34cba79bed5f7ef2e036a76b3ab0835474246eb41f8d",
+              "url": "https://files.pythonhosted.org/packages/d4/f9/0ba83eaa0df9b9e9d1efeb2ea351d0677c37d41ee5d0f91e98423c7281c9/werkzeug-3.0.6.tar.gz"
             }
           ],
           "project_name": "werkzeug",
@@ -3113,7 +3111,7 @@
             "watchdog>=2.3; extra == \"watchdog\""
           ],
           "requires_python": ">=3.8",
-          "version": "3.0.4"
+          "version": "3.0.6"
         },
         {
           "artifacts": [

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,4 +22,4 @@ ssm-parameter-store>=19.11.0
 typing-extensions>=4.8.0 # only needed for python < 3.12
 types-PyYAML>=6.0.12
 urllib3 >= 2.2.1
-nacc_form_validator@ https://github.com/naccdata/nacc-form-validator/releases/download/v0.2.0/nacc_form_validator-0.2.0-py3-none-any.whl
+nacc_form_validator@ https://github.com/naccdata/nacc-form-validator/releases/download/v0.3.0/nacc_form_validator-0.3.0-py3-none-any.whl


### PR DESCRIPTION
* Update to use nacc-form-validator [v0.3.0](https://github.com/naccdata/nacc-form-validator/releases/tag/v0.3.0)
* Rename/refactor `FlywheelDatastore` class to `DatastoreHelper` to allow more general operations
* Add `compute_gds` as a composite rule to match new GDS score validation