### PR TITLE
Fix accepted templating

### DIFF
--- a/common/src/python/projects/template_project.py
+++ b/common/src/python/projects/template_project.py
@@ -51,10 +51,14 @@ class TemplateProject:
             log.error("template label doesn't match expected pattern")
             return None
 
-        datatype = match.group(datatype_group)
         stage = match.group(stage_group)
+        pattern = rf"^{stage}"
 
-        return rf"^{stage}-{datatype}"
+        datatype = match.group(datatype_group)
+        if datatype:
+            pattern = rf"^{pattern}-{datatype}"
+        
+        return pattern
 
     def copy_to(self,
                 destination: ProjectAdaptor,

--- a/docs/push_template/CHANGELOG.md
+++ b/docs/push_template/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this gear are documented in this file.
 
 ## Unreleased
 
+## 1.0.2
+
+* Fixes template pattern generation to handle template labels that don't have a
+  datatype (e.g., 'accepted-template')
+
 ## 1.0.1
 
 * Functionally the same as 1.0.0 but tweaks some build details

--- a/gear/push_template/src/docker/BUILD
+++ b/gear/push_template/src/docker/BUILD
@@ -6,5 +6,5 @@ docker_image(
     dependencies=[
         ":manifest", "gear/push_template/src/python/template_app:bin"
     ],
-    image_tags=["1.0.1", "latest"]
+    image_tags=["1.0.2", "latest"]
 )

--- a/gear/push_template/src/docker/manifest.json
+++ b/gear/push_template/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "push-template",
     "label": "Push Project Template",
     "description": "Pushes template projects to center projects",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/push-template:1.0.1"
+            "image": "naccdata/push-template:1.0.2"
         },
         "flywheel": {
             "suite": "NACC Admin Gears",


### PR DESCRIPTION
Fixes pattern generation for templates used to match project labels. Allows for template project labels that don't have a datatype.
