### PR TITLE
Form QC Checker: RxNorm API calls

### DIFF
--- a/common/src/python/rxnorm/BUILD
+++ b/common/src/python/rxnorm/BUILD
@@ -1,0 +1,1 @@
+python_sources(name="lib")

--- a/common/src/python/rxnorm/rxnorm_connection.py
+++ b/common/src/python/rxnorm/rxnorm_connection.py
@@ -1,0 +1,102 @@
+"""
+Module for connecting to the RxNorm API.
+https://lhncbc.nlm.nih.gov/RxNav/APIs/RxNormAPIs.html
+"""
+import json
+import requests
+
+from dataclasses import dataclass
+from json.decoder import JSONDecodeError
+from ratelimit import limits, sleep_and_retry
+from requests import Response
+
+
+def error_message(message: str, response: Response) -> str:
+    """Build an error message from the given message and HTTP response.
+
+    Returns:
+      The error string
+    """
+    return (f"Error: {message}\nHTTP Error:{response.status_code} "
+            f"{response.reason}: {response.text}")
+
+
+@dataclass
+class RxcuiStatus:
+    """ Enumeration for keeping track of valid Rxcui statuses returned by the API """
+    ACTIVE = "Active"
+    OBSOLETE = "Obsolete"
+    REMAPPED = "Remapped"
+    QUANTIFIED = "Quantified"
+    NOT_CURRENT = "NotCurrent"
+    UNKNOWN = "UNKNOWN"
+
+
+class RxNormConnectionError(Exception):
+    """Exception for errors that occur when connecting to the RxNorm. API"""
+
+
+class RxNormConnection:
+    """Manages a connection to the RxNorm API."""
+
+    @classmethod
+    def url(cls, path: str) -> str:
+        """Builds a URL for accessing a RxNorm endpoint.
+
+        Returns:
+          URL constructed by extending the RxNorm API path with the given string.
+        """
+        return f"https://rxnav.nlm.nih.gov/{path}"
+
+    @classmethod
+    @sleep_and_retry
+    @limits(calls=20, period=1)
+    def get_request(cls, path: str) -> Response:
+        """Posts a request to the RxNorm API.
+
+        NLM requires users send no more than 20 requests per second per IP address:
+        https://lhncbc.nlm.nih.gov/RxNav/TermsofService.html
+
+        Returns:
+          The response from posting the request.
+
+        Raises:
+          RxNormConnectionError if there is an error connecting to the API.
+        """
+        target_url = cls.url(path)
+        try:
+            response = requests.get(target_url)
+        except (requests.exceptions.SSLError,
+                requests.exceptions.ConnectionError) as error:
+            raise RxNormConnectionError(
+                message=f"Error connecting to {target_url} - {error}"
+            ) from error
+
+        return response
+
+    @classmethod
+    def get_rxcui_status(cls, rxcui: int) -> str:
+        """ Get the RxCUI status - uses the getRxcuiHistoryStatus endpoint:
+
+        https://lhncbc.nlm.nih.gov/RxNav/APIs/api-RxNorm.getRxcuiHistoryStatus.html
+
+        Args:
+            rxcui: int, the RXCUI
+
+        Returns:
+            RxcuiStatus: The RxcuiStatus
+        """
+        message = "Getting the RXCUI history status"
+        response = RxNormConnection.get_request(f'REST/rxcui/{rxcui}/historystatus.json')
+
+        if not response.ok:
+            raise RxNormConnectionError(
+                message = error_message(message=message,
+                                        response=response))
+
+        try:
+            history_record = json.loads(response.text)
+        except (JSONDecodeError, ValueError) as error:
+            raise RxNormConnectionError(message=message) from error
+
+        return history_record['rxcuiStatusHistory']['metaData']['status']

--- a/common/src/python/rxnorm/rxnorm_connection.py
+++ b/common/src/python/rxnorm/rxnorm_connection.py
@@ -34,6 +34,17 @@ class RxcuiStatus:
 
 class RxNormConnectionError(Exception):
     """Exception for errors that occur when connecting to the RxNorm API"""
+    def __init__(self, message: str) -> None:
+        super().__init__()
+        self._message = message
+
+    def __str__(self) -> str:
+        return self.message
+
+    @property
+    def message(self):
+        """The error message."""
+        return self._message
 
 
 class RxNormConnection:

--- a/common/src/python/rxnorm/rxnorm_connection.py
+++ b/common/src/python/rxnorm/rxnorm_connection.py
@@ -1,5 +1,5 @@
-"""
-Module for connecting to the RxNorm API.
+"""Module for connecting to the RxNorm API.
+
 https://lhncbc.nlm.nih.gov/RxNav/APIs/RxNormAPIs.html
 """
 import json
@@ -23,7 +23,8 @@ def error_message(message: str, response: Response) -> str:
 
 @dataclass
 class RxcuiStatus:
-    """Enumeration for keeping track of valid Rxcui statuses returned by the API"""
+    """Enumeration for keeping track of valid Rxcui statuses returned by the
+    API."""
     ACTIVE = "Active"
     OBSOLETE = "Obsolete"
     REMAPPED = "Remapped"
@@ -33,7 +34,8 @@ class RxcuiStatus:
 
 
 class RxNormConnectionError(Exception):
-    """Exception for errors that occur when connecting to the RxNorm API"""
+    """Exception for errors that occur when connecting to the RxNorm API."""
+
     def __init__(self, message: str) -> None:
         super().__init__()
         self._message = message
@@ -103,8 +105,7 @@ class RxNormConnection:
 
         if not response.ok:
             raise RxNormConnectionError(
-                message = error_message(message=message,
-                                        response=response))
+                message=error_message(message=message, response=response))
 
         try:
             history_record = json.loads(response.text)

--- a/common/src/python/rxnorm/rxnorm_connection.py
+++ b/common/src/python/rxnorm/rxnorm_connection.py
@@ -109,6 +109,7 @@ class RxNormConnection:
         try:
             history_record = json.loads(response.text)
         except (JSONDecodeError, ValueError) as error:
+            message = f"Error decoding RXCUI history status response to JSON: {error}"
             raise RxNormConnectionError(message=message) from error
 
         return history_record['rxcuiStatusHistory']['metaData']['status']

--- a/common/src/python/rxnorm/rxnorm_connection.py
+++ b/common/src/python/rxnorm/rxnorm_connection.py
@@ -3,10 +3,10 @@ Module for connecting to the RxNorm API.
 https://lhncbc.nlm.nih.gov/RxNav/APIs/RxNormAPIs.html
 """
 import json
-import requests
-
 from dataclasses import dataclass
-from json.decoder import JSONDecodeError
+from json import JSONDecodeError
+
+import requests
 from ratelimit import limits, sleep_and_retry
 from requests import Response
 
@@ -23,7 +23,7 @@ def error_message(message: str, response: Response) -> str:
 
 @dataclass
 class RxcuiStatus:
-    """ Enumeration for keeping track of valid Rxcui statuses returned by the API """
+    """Enumeration for keeping track of valid Rxcui statuses returned by the API"""
     ACTIVE = "Active"
     OBSOLETE = "Obsolete"
     REMAPPED = "Remapped"
@@ -33,7 +33,7 @@ class RxcuiStatus:
 
 
 class RxNormConnectionError(Exception):
-    """Exception for errors that occur when connecting to the RxNorm. API"""
+    """Exception for errors that occur when connecting to the RxNorm API"""
 
 
 class RxNormConnection:
@@ -87,7 +87,8 @@ class RxNormConnection:
             RxcuiStatus: The RxcuiStatus
         """
         message = "Getting the RXCUI history status"
-        response = RxNormConnection.get_request(f'REST/rxcui/{rxcui}/historystatus.json')
+        response = RxNormConnection.get_request(
+            f'REST/rxcui/{rxcui}/historystatus.json')
 
         if not response.ok:
             raise RxNormConnectionError(

--- a/common/test/python/rxnorm/BUILD
+++ b/common/test/python/rxnorm/BUILD
@@ -1,0 +1,1 @@
+python_tests(name="tests", )

--- a/common/test/python/rxnorm/test_rxnorm.py
+++ b/common/test/python/rxnorm/test_rxnorm.py
@@ -1,12 +1,12 @@
-""" Tests the RxNorm API, which is public so doesn't need any authorization """
+"""Tests the RxNorm API, which is public so doesn't need any authorization."""
 from rxnorm.rxnorm_connection import RxcuiStatus, RxNormConnection
 
 
 class TestRxNormConnection:
-    """ Tests the RxNormConnection class """
+    """Tests the RxNormConnection class."""
 
     def test_url_creation(self):
-        """ Test URL creation """
+        """Test URL creation."""
         assert RxNormConnection.url('REST/test/path') \
             == "https://rxnav.nlm.nih.gov/REST/test/path"
 
@@ -15,9 +15,15 @@ class TestRxNormConnection:
         Test the get_rxcui_status method - uses same examples defined on
         https://lhncbc.nlm.nih.gov/RxNav/APIs/api-RxNorm.getRxcuiHistoryStatus.html
         """
-        assert RxNormConnection.get_rxcui_status(1801289) == RxcuiStatus.ACTIVE
-        assert RxNormConnection.get_rxcui_status(861765) == RxcuiStatus.OBSOLETE
-        assert RxNormConnection.get_rxcui_status(105048) == RxcuiStatus.REMAPPED
-        assert RxNormConnection.get_rxcui_status(1360201) == RxcuiStatus.QUANTIFIED
-        assert RxNormConnection.get_rxcui_status(3686) == RxcuiStatus.NOT_CURRENT
-        assert RxNormConnection.get_rxcui_status(0) == RxcuiStatus.UNKNOWN
+        assert RxNormConnection.get_rxcui_status(1801289) \
+            == RxcuiStatus.ACTIVE
+        assert RxNormConnection.get_rxcui_status(861765) \
+            == RxcuiStatus.OBSOLETE
+        assert RxNormConnection.get_rxcui_status(105048) \
+            == RxcuiStatus.REMAPPED
+        assert RxNormConnection.get_rxcui_status(1360201) \
+            == RxcuiStatus.QUANTIFIED
+        assert RxNormConnection.get_rxcui_status(3686) \
+            == RxcuiStatus.NOT_CURRENT
+        assert RxNormConnection.get_rxcui_status(0) \
+            == RxcuiStatus.UNKNOWN

--- a/common/test/python/rxnorm/test_rxnorm.py
+++ b/common/test/python/rxnorm/test_rxnorm.py
@@ -1,0 +1,30 @@
+""" Tests the RxNorm API, which is public so doesn't need any authorization """
+import json
+import pytest
+
+from json.decoder import JSONDecodeError
+from rxnorm.rxnorm_connection import (
+    RxNormConnection,
+    RxcuiStatus
+)
+
+
+class TestRxNormConnection:
+    """ Tests the RxNormConnection class """
+
+    def test_url_creation(self):
+        """ Test URL creation """
+        assert RxNormConnection.url('REST/test/path') \
+            == "https://rxnav.nlm.nih.gov/REST/test/path"
+
+    def test_get_rxcui_status(self):
+        """
+        Test the get_rxcui_status method - uses same examples defined on
+        https://lhncbc.nlm.nih.gov/RxNav/APIs/api-RxNorm.getRxcuiHistoryStatus.html
+        """
+        assert RxNormConnection.get_rxcui_status(1801289) == RxcuiStatus.ACTIVE
+        assert RxNormConnection.get_rxcui_status(861765) == RxcuiStatus.OBSOLETE
+        assert RxNormConnection.get_rxcui_status(105048) == RxcuiStatus.REMAPPED
+        assert RxNormConnection.get_rxcui_status(1360201) == RxcuiStatus.QUANTIFIED
+        assert RxNormConnection.get_rxcui_status(3686) == RxcuiStatus.NOT_CURRENT
+        assert RxNormConnection.get_rxcui_status(0) == RxcuiStatus.UNKNOWN

--- a/common/test/python/rxnorm/test_rxnorm.py
+++ b/common/test/python/rxnorm/test_rxnorm.py
@@ -1,12 +1,5 @@
 """ Tests the RxNorm API, which is public so doesn't need any authorization """
-import json
-import pytest
-
-from json.decoder import JSONDecodeError
-from rxnorm.rxnorm_connection import (
-    RxNormConnection,
-    RxcuiStatus
-)
+from rxnorm.rxnorm_connection import RxcuiStatus, RxNormConnection
 
 
 class TestRxNormConnection:

--- a/docs/form_qc_checker/CHANGELOG.md
+++ b/docs/form_qc_checker/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 All notable changes to this gear are documented in this file.
 
+## 1.0.4
+
+* Defines the `is_valid_rxcui` method in the `DataStoreHelper` class - adds the `rxnorm` common code to support this and future gears that may need to access the RxNorm API
+
 ## 1.0.0
+
 * Update to use nacc-form-validator [v0.3.0](https://github.com/naccdata/nacc-form-validator/releases/tag/v0.3.0)
 * Rename/refactor `FlywheelDatastore` class to `DatastoreHelper` to allow more general operations
 * Add `compute_gds` as a composite rule to match new GDS score validation

--- a/gear/form_qc_checker/src/docker/BUILD
+++ b/gear/form_qc_checker/src/docker/BUILD
@@ -6,5 +6,5 @@ docker_image(
     dependencies=[
         ":manifest", "gear/form_qc_checker/src/python/form_qc_app:bin"
     ],
-    image_tags=["1.0.3", "latest"],
+    image_tags=["1.0.4", "latest"],
 )

--- a/gear/form_qc_checker/src/docker/manifest.json
+++ b/gear/form_qc_checker/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "form-qc-checker",
     "label": "Form QC Checker",
     "description": "Gear to check form data as JSON with QC rule set",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/form-qc-checker:1.0.3"
+            "image": "naccdata/form-qc-checker:1.0.4"
         },
         "flywheel": {
             "suite": "Curation",

--- a/gear/form_qc_checker/src/python/form_qc_app/datastore.py
+++ b/gear/form_qc_checker/src/python/form_qc_app/datastore.py
@@ -9,6 +9,7 @@ from flywheel import Project
 from flywheel_adaptor.flywheel_proxy import FlywheelProxy
 from keys.keys import DefaultValues, FieldNames, MetadataKeys
 from nacc_form_validator.datastore import Datastore
+from rxnorm.rxnorm_connection import RxNormConnection, RxcuiStatus
 
 log = logging.getLogger(__name__)
 
@@ -248,16 +249,12 @@ class DatastoreHelper(Datastore):
 
     def is_valid_rxcui(self, drugid: int) -> bool:
         """Overriding the abstract method, check whether a given drug ID is
-        valid RXCUI. Check
-        https://www.nlm.nih.gov/research/umls/rxnorm/overview.html,
-        https://mor.nlm.nih.gov/RxNav/
+        valid RXCUI.
 
         Args:
-            drugid: provided drug ID
+            drugid: provided drug ID (rxcui to validate)
 
         Returns:
             bool: True if provided drug ID is valid, else False
         """
-
-        # TODO - implement validation
-        return False
+        return RxNormConnectionError.get_rxcui_status(drugid) == RxcuiStatus.ACTIVE

--- a/gear/form_qc_checker/src/python/form_qc_app/datastore.py
+++ b/gear/form_qc_checker/src/python/form_qc_app/datastore.py
@@ -9,7 +9,7 @@ from flywheel import Project
 from flywheel_adaptor.flywheel_proxy import FlywheelProxy
 from keys.keys import DefaultValues, FieldNames, MetadataKeys
 from nacc_form_validator.datastore import Datastore
-from rxnorm.rxnorm_connection import RxNormConnection, RxcuiStatus
+from rxnorm.rxnorm_connection import RxcuiStatus, RxNormConnection
 
 log = logging.getLogger(__name__)
 

--- a/gear/form_qc_checker/src/python/form_qc_app/datastore.py
+++ b/gear/form_qc_checker/src/python/form_qc_app/datastore.py
@@ -257,4 +257,4 @@ class DatastoreHelper(Datastore):
         Returns:
             bool: True if provided drug ID is valid, else False
         """
-        return RxNormConnectionError.get_rxcui_status(drugid) == RxcuiStatus.ACTIVE
+        return RxNormConnection.get_rxcui_status(drugid) == RxcuiStatus.ACTIVE

--- a/python-default.lock
+++ b/python-default.lock
@@ -25,6 +25,7 @@
 //     "pytest>=7.2.0",
 //     "python_dateutil>=2.5.3",
 //     "pyyaml==6.0",
+//     "ratelimit>=2.2.1",
 //     "requests-oauthlib>=2.0.0",
 //     "requests>=2.18.4",
 //     "setuptools>=68.2.2",
@@ -192,44 +193,44 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "a9c0955df0b52b43749d81bde159343a40ea2a3537a46049336fe8193871b18e",
-              "url": "https://files.pythonhosted.org/packages/38/03/e76ff94253472c6aa7942b3efc726ca8e9c62fdebf884e017633258b7ba4/boto3-1.35.53-py3-none-any.whl"
+              "hash": "20945912130cca1505f45819cd9b7183a0e376e91a1221a0b1f50c80d35fd7e2",
+              "url": "https://files.pythonhosted.org/packages/46/31/e185d967e7a311d1ed4d4eb03c1606bcd2b9cfcdc85cfe9c8183c1beafbd/boto3-1.35.69-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f4124548bb831e13504e805f2fbbfcee06df42fffea0655862c6eb9b95d6d1be",
-              "url": "https://files.pythonhosted.org/packages/12/c1/1dc34b322d2f022d190c34dd4aa7f1a242d73633c25061bf56bd1319fe05/boto3-1.35.53.tar.gz"
+              "hash": "40db86c7732a310b282f595251995ecafcbd62009a57e47a22683862e570cc7a",
+              "url": "https://files.pythonhosted.org/packages/b7/72/f80a131ac5e069b12975c1054243713c46617cc769dc78348e1d59a3f945/boto3-1.35.69.tar.gz"
             }
           ],
           "project_name": "boto3",
           "requires_dists": [
-            "botocore<1.36.0,>=1.35.53",
+            "botocore<1.36.0,>=1.35.69",
             "botocore[crt]<2.0a0,>=1.21.0; extra == \"crt\"",
             "jmespath<2.0.0,>=0.7.1",
             "s3transfer<0.11.0,>=0.10.0"
           ],
           "requires_python": ">=3.8",
-          "version": "1.35.53"
+          "version": "1.35.69"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "43172fe0f6950c6a5310856cd21664f5d8bf2a561d2969bf5694ba851a5fc905",
-              "url": "https://files.pythonhosted.org/packages/1b/5c/80e7c7c1341f5b9ca8d955e9f592b26e9602ccdb033c47520021bb86ebb5/boto3_stubs-1.35.53-py3-none-any.whl"
+              "hash": "50d0ffc55bd693d36fb572ead111ce63460deda2d508c4c03063bc98c216f929",
+              "url": "https://files.pythonhosted.org/packages/71/c6/cc6e8dd3d7bb9734ad678029b3a3756a8910c9ffe63c4f42d1088cf110ed/boto3_stubs-1.35.69-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "502b9c90b5a03e9fc7e12a6f1aeb8a4ce6caf169c32b23a902b3910ce4160a58",
-              "url": "https://files.pythonhosted.org/packages/ce/47/21e4109532648e8179df8cafd821d4012c06d57a838141e81f826bb25184/boto3_stubs-1.35.53.tar.gz"
+              "hash": "474157a3441dc420d0c5195cabf59c8262b76d6baa3e96faf3a3b50a98e13354",
+              "url": "https://files.pythonhosted.org/packages/84/9a/3e611a024617f53a6b5aa0a6ea4a533a68534cd42c193d48927cd5968525/boto3_stubs-1.35.69.tar.gz"
             }
           ],
           "project_name": "boto3-stubs",
           "requires_dists": [
             "boto3-stubs-full; extra == \"full\"",
-            "boto3==1.35.53; extra == \"boto3\"",
+            "boto3==1.35.69; extra == \"boto3\"",
             "botocore-stubs",
-            "botocore==1.35.53; extra == \"boto3\"",
+            "botocore==1.35.69; extra == \"boto3\"",
             "mypy-boto3-accessanalyzer<1.36.0,>=1.35.0; extra == \"accessanalyzer\"",
             "mypy-boto3-accessanalyzer<1.36.0,>=1.35.0; extra == \"all\"",
             "mypy-boto3-account<1.36.0,>=1.35.0; extra == \"account\"",
@@ -302,6 +303,8 @@
             "mypy-boto3-batch<1.36.0,>=1.35.0; extra == \"batch\"",
             "mypy-boto3-bcm-data-exports<1.36.0,>=1.35.0; extra == \"all\"",
             "mypy-boto3-bcm-data-exports<1.36.0,>=1.35.0; extra == \"bcm-data-exports\"",
+            "mypy-boto3-bcm-pricing-calculator<1.36.0,>=1.35.0; extra == \"all\"",
+            "mypy-boto3-bcm-pricing-calculator<1.36.0,>=1.35.0; extra == \"bcm-pricing-calculator\"",
             "mypy-boto3-bedrock-agent-runtime<1.36.0,>=1.35.0; extra == \"all\"",
             "mypy-boto3-bedrock-agent-runtime<1.36.0,>=1.35.0; extra == \"bedrock-agent-runtime\"",
             "mypy-boto3-bedrock-agent<1.36.0,>=1.35.0; extra == \"all\"",
@@ -310,6 +313,8 @@
             "mypy-boto3-bedrock-runtime<1.36.0,>=1.35.0; extra == \"bedrock-runtime\"",
             "mypy-boto3-bedrock<1.36.0,>=1.35.0; extra == \"all\"",
             "mypy-boto3-bedrock<1.36.0,>=1.35.0; extra == \"bedrock\"",
+            "mypy-boto3-billing<1.36.0,>=1.35.0; extra == \"all\"",
+            "mypy-boto3-billing<1.36.0,>=1.35.0; extra == \"billing\"",
             "mypy-boto3-billingconductor<1.36.0,>=1.35.0; extra == \"all\"",
             "mypy-boto3-billingconductor<1.36.0,>=1.35.0; extra == \"billingconductor\"",
             "mypy-boto3-braket<1.36.0,>=1.35.0; extra == \"all\"",
@@ -407,6 +412,8 @@
             "mypy-boto3-connect<1.36.0,>=1.35.0; extra == \"connect\"",
             "mypy-boto3-connectcampaigns<1.36.0,>=1.35.0; extra == \"all\"",
             "mypy-boto3-connectcampaigns<1.36.0,>=1.35.0; extra == \"connectcampaigns\"",
+            "mypy-boto3-connectcampaignsv2<1.36.0,>=1.35.0; extra == \"all\"",
+            "mypy-boto3-connectcampaignsv2<1.36.0,>=1.35.0; extra == \"connectcampaignsv2\"",
             "mypy-boto3-connectcases<1.36.0,>=1.35.0; extra == \"all\"",
             "mypy-boto3-connectcases<1.36.0,>=1.35.0; extra == \"connectcases\"",
             "mypy-boto3-connectparticipant<1.36.0,>=1.35.0; extra == \"all\"",
@@ -750,6 +757,10 @@
             "mypy-boto3-networkmanager<1.36.0,>=1.35.0; extra == \"networkmanager\"",
             "mypy-boto3-networkmonitor<1.36.0,>=1.35.0; extra == \"all\"",
             "mypy-boto3-networkmonitor<1.36.0,>=1.35.0; extra == \"networkmonitor\"",
+            "mypy-boto3-notifications<1.36.0,>=1.35.0; extra == \"all\"",
+            "mypy-boto3-notifications<1.36.0,>=1.35.0; extra == \"notifications\"",
+            "mypy-boto3-notificationscontacts<1.36.0,>=1.35.0; extra == \"all\"",
+            "mypy-boto3-notificationscontacts<1.36.0,>=1.35.0; extra == \"notificationscontacts\"",
             "mypy-boto3-oam<1.36.0,>=1.35.0; extra == \"all\"",
             "mypy-boto3-oam<1.36.0,>=1.35.0; extra == \"oam\"",
             "mypy-boto3-omics<1.36.0,>=1.35.0; extra == \"all\"",
@@ -770,6 +781,8 @@
             "mypy-boto3-outposts<1.36.0,>=1.35.0; extra == \"outposts\"",
             "mypy-boto3-panorama<1.36.0,>=1.35.0; extra == \"all\"",
             "mypy-boto3-panorama<1.36.0,>=1.35.0; extra == \"panorama\"",
+            "mypy-boto3-partnercentral-selling<1.36.0,>=1.35.0; extra == \"all\"",
+            "mypy-boto3-partnercentral-selling<1.36.0,>=1.35.0; extra == \"partnercentral-selling\"",
             "mypy-boto3-payment-cryptography-data<1.36.0,>=1.35.0; extra == \"all\"",
             "mypy-boto3-payment-cryptography-data<1.36.0,>=1.35.0; extra == \"payment-cryptography-data\"",
             "mypy-boto3-payment-cryptography<1.36.0,>=1.35.0; extra == \"all\"",
@@ -1021,19 +1034,19 @@
             "typing-extensions>=4.1.0; python_version < \"3.12\""
           ],
           "requires_python": ">=3.8",
-          "version": "1.35.53"
+          "version": "1.35.69"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "12869640f2f9fab3152ea312a6906d5bc6ae15522cc74b6367ee1c273269a28b",
-              "url": "https://files.pythonhosted.org/packages/7f/1e/65687ed2cbc57ba64a5e1100e769d8cccd8532cfba66695e2815ca775b97/botocore-1.35.53-py3-none-any.whl"
+              "hash": "cad8d9305f873404eee4b197d84e60a40975d43cbe1ab63abe893420ddfe6e3c",
+              "url": "https://files.pythonhosted.org/packages/d2/b6/5ce018ab9f8058aa821aeed8fb34557bd6454a62a974c26172d34c31edef/botocore-1.35.69-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e610ae076ad1eaed5680d3990493659bbabdffd67b15c61d8373a23e4bc41062",
-              "url": "https://files.pythonhosted.org/packages/48/c9/d5a1f5ad4024eda0d5d1b4103d28085c13cf42ca377fc141f7df4ad1cec9/botocore-1.35.53.tar.gz"
+              "hash": "f9f23dd76fb247d9b0e8d411d2995e6f847fc451c026f1e58e300f815b0b36eb",
+              "url": "https://files.pythonhosted.org/packages/55/75/aaaa22f737b7a5251f2ab24f5860b1bfc55050a77b91524474bcaadb3070/botocore-1.35.69.tar.gz"
             }
           ],
           "project_name": "botocore",
@@ -1045,19 +1058,19 @@
             "urllib3<1.27,>=1.25.4; python_version < \"3.10\""
           ],
           "requires_python": ">=3.8",
-          "version": "1.35.53"
+          "version": "1.35.69"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "09c65f0dd2a91a6d9915bca483d14645efdf0d267971fcedd0d87d474d66071b",
-              "url": "https://files.pythonhosted.org/packages/e9/1f/15ea0badb9955614d50d0c5f8cf23212c53c654eea526094c9136322d757/botocore_stubs-1.35.53-py3-none-any.whl"
+              "hash": "157d2cf77550f01a0ed4e6ca57a52f8e7155a4910dc9595fea24714d09e6c6f0",
+              "url": "https://files.pythonhosted.org/packages/91/40/1266a65f330de171d26663bfa27bdf2b90ebde1322b3fb145c19544dc37e/botocore_stubs-1.35.69-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ba85b7f233527abfb60fae3e121519e5b748b0486756a0d4cfccfcc3dd47e649",
-              "url": "https://files.pythonhosted.org/packages/2f/dc/b4f7de0b3dae8087e7ce4e2877beedcdf4d6bf702d33b5deb4b3fa3fce65/botocore_stubs-1.35.53.tar.gz"
+              "hash": "f1d1106ba4c299fc78cc6e8cc9dac681e70bbe1c2a0188006e13bbdb18d8895e",
+              "url": "https://files.pythonhosted.org/packages/c2/68/0689fbfe3ff44cf78488b4fd1104c7e260724207a922695abf30409deb92/botocore_stubs-1.35.69.tar.gz"
             }
           ],
           "project_name": "botocore-stubs",
@@ -1067,7 +1080,7 @@
             "typing-extensions>=4.1.0; python_version < \"3.9\""
           ],
           "requires_python": ">=3.8",
-          "version": "1.35.53"
+          "version": "1.35.69"
         },
         {
           "artifacts": [
@@ -1423,8 +1436,8 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "19897fe965d2d9d0156b6de085b15f323354ba1f84eb0cddf161b15992bea19a",
-              "url": "https://files.pythonhosted.org/packages/46/ce/233ee362272e901603e90b7b5332596122c15543bcd190612c3bc4e5007a/flywheel_sdk-19.2.0-py2.py3-none-any.whl"
+              "hash": "6b965c14b0dab3a6b88e6feb3468cfaa6b2b32b1bfb599cdb19a9ba406c8541e",
+              "url": "https://files.pythonhosted.org/packages/66/47/08f54e21457cbaf10e3df1e614b9efdd7ae9fb9853e7983572b2532854f9/flywheel_sdk-19.3.0-py2.py3-none-any.whl"
             }
           ],
           "project_name": "flywheel-sdk",
@@ -1438,7 +1451,7 @@
             "urllib3>=2.2.1"
           ],
           "requires_python": null,
-          "version": "19.2.0"
+          "version": "19.3.0"
         },
         {
           "artifacts": [
@@ -1499,8 +1512,8 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "0c7fae1e97bb92052a47f24c83edf294dbcd695d96547f44345d824d08336b46",
-              "url": "https://files.pythonhosted.org/packages/0a/18/e87cdae8f8821a5f9684facf7e6ad116d826cac673700d0edc112778dae2/fw_utils-5.0.3-py3-none-any.whl"
+              "hash": "dac94e7f446537c70f3643177ccadfbf7acc9eae6cb6d41e622c60baa8be2eab",
+              "url": "https://files.pythonhosted.org/packages/52/63/fda39664ffed8e47ee07946d9e32f6e075bfb321e71d5217ac9513ace98f/fw_utils-5.0.4-py3-none-any.whl"
             }
           ],
           "project_name": "fw-utils",
@@ -1510,8 +1523,8 @@
             "tzdata>=2022",
             "tzlocal>=4.1"
           ],
-          "requires_python": "<4.0,>=3.8",
-          "version": "5.0.3"
+          "requires_python": "<4.0,>=3.9",
+          "version": "5.0.4"
         },
         {
           "artifacts": [
@@ -1576,13 +1589,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "27b59625743b85577a8c0e10e55b50b5368a4f2cfe8cc7bcfa9cf00829c2682f",
-              "url": "https://files.pythonhosted.org/packages/06/89/b161908e2f51be56568184aeb4a880fd287178d176fd1c860d2217f41106/httpcore-1.0.6-py3-none-any.whl"
+              "hash": "a3fff8f43dc260d5bd363d9f9cf1830fa3a458b332856f34282de498ed420edd",
+              "url": "https://files.pythonhosted.org/packages/87/f5/72347bc88306acb359581ac4d52f23c0ef445b57157adedb9aee0cd689d2/httpcore-1.0.7-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "73f6dbd6eb8c21bbf7ef8efad555481853f5f6acdeaff1edb0694289269ee17f",
-              "url": "https://files.pythonhosted.org/packages/b6/44/ed0fa6a17845fb033bd885c03e842f08c1b9406c86a2e60ac1ae1b9206a6/httpcore-1.0.6.tar.gz"
+              "hash": "8551cb62a169ec7162ac7be8d4817d561f60e08eaa485234898414bb5a8a0b4c",
+              "url": "https://files.pythonhosted.org/packages/6a/41/d7d0a89eb493922c37d343b607bc1b5da7f5be7e383740b4753ad8943e90/httpcore-1.0.7.tar.gz"
             }
           ],
           "project_name": "httpcore",
@@ -1595,7 +1608,7 @@
             "trio<1.0,>=0.22.0; extra == \"trio\""
           ],
           "requires_python": ">=3.8",
-          "version": "1.0.6"
+          "version": "1.0.7"
         },
         {
           "artifacts": [
@@ -1845,13 +1858,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "8e25401f7d7910e19a732b417e0d503ef86cf4de9114a273dd62679a42f3be1c",
-              "url": "https://files.pythonhosted.org/packages/c3/4f/b9624a14e397234fa2b9345d64357d08ba2f49ff1b1eb4a083c6a7329ed5/moto-5.0.18-py2.py3-none-any.whl"
+              "hash": "1235b2ae3666459c9cc44504a5e73d35f4959b45e5876b2f6df2e5f4889dfb4f",
+              "url": "https://files.pythonhosted.org/packages/5f/6e/5f57cadb57a9663e7d92f05078c7e61ad83131f569ed07dc166a58f08500/moto-5.0.21-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8a7ad2f53a2e6cc9db2ff65c0e0d4b5d7e78bc00b825c9e1ff6cc394371e76e9",
-              "url": "https://files.pythonhosted.org/packages/b4/c0/6637d2d8e113d909ac794944e041928ba7d43c3b540a896501776a6024e2/moto-5.0.18.tar.gz"
+              "hash": "52f63291daeff9444ef5eb14fbf69b24264567b79f184ae6aee4945d09845f06",
+              "url": "https://files.pythonhosted.org/packages/72/ba/00bda1f06b85dc579583d68ef87497215d4ce5b8ec116e68beaff9fc37ce/moto-5.0.21.tar.gz"
             }
           ],
           "project_name": "moto",
@@ -1877,7 +1890,7 @@
             "aws-xray-sdk!=0.96,>=0.93; extra == \"server\"",
             "aws-xray-sdk!=0.96,>=0.93; extra == \"xray\"",
             "boto3>=1.9.201",
-            "botocore>=1.14.0",
+            "botocore!=1.35.45,!=1.35.46,>=1.14.0",
             "cfn-lint>=0.40.0; extra == \"all\"",
             "cfn-lint>=0.40.0; extra == \"cloudformation\"",
             "cfn-lint>=0.40.0; extra == \"proxy\"",
@@ -1958,7 +1971,7 @@
             "xmltodict"
           ],
           "requires_python": ">=3.8",
-          "version": "5.0.18"
+          "version": "5.0.21"
         },
         {
           "artifacts": [
@@ -1981,54 +1994,54 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "8e00ea6fc82e8a804433d3e9cedaa1051a1422cb6e443011590c14d2dea59146",
-              "url": "https://files.pythonhosted.org/packages/70/77/0ad9efe25482009873f9660d29a40a8c41a6f0e8b541195e3c95c70684c5/numpy-2.1.2-cp311-cp311-musllinux_1_2_aarch64.whl"
+              "hash": "15cb89f39fa6d0bdfb600ea24b250e5f1a3df23f901f51c8debaa6a5d122b2f0",
+              "url": "https://files.pythonhosted.org/packages/7d/84/4de0b87d5a72f45556b2a8ee9fc8801e8518ec867fc68260c1f5dcb3903f/numpy-2.1.3-cp311-cp311-musllinux_1_2_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "faa88bc527d0f097abdc2c663cddf37c05a1c2f113716601555249805cf573f1",
-              "url": "https://files.pythonhosted.org/packages/02/69/9f05c4ecc75fabf297b17743996371b4c3dfc4d92e15c5c38d8bb3db8d74/numpy-2.1.2-cp311-cp311-macosx_11_0_arm64.whl"
+              "hash": "973faafebaae4c0aaa1a1ca1ce02434554d67e628b8d805e61f874b84e136b09",
+              "url": "https://files.pythonhosted.org/packages/09/ac/61d07930a4993dd9691a6432de16d93bbe6aa4b1c12a5e573d468eefc1ca/numpy-2.1.3-cp311-cp311-macosx_14_0_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "13602b3174432a35b16c4cfb5de9a12d229727c3dd47a6ce35111f2ebdf66ff4",
-              "url": "https://files.pythonhosted.org/packages/06/13/f5d87a497c16658e9af8920449b0b5692b469586b8231340c672962071c5/numpy-2.1.2-cp311-cp311-macosx_14_0_x86_64.whl"
+              "hash": "aa08e04e08aaf974d4458def539dece0d28146d866a39da5639596f4921fd761",
+              "url": "https://files.pythonhosted.org/packages/25/ca/1166b75c21abd1da445b97bf1fa2f14f423c6cfb4fc7c4ef31dccf9f6a94/numpy-2.1.3.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "e2b49c3c0804e8ecb05d59af8386ec2f74877f7ca8fd9c1e00be2672e4d399b1",
-              "url": "https://files.pythonhosted.org/packages/23/69/538317f0d925095537745f12aced33be1570bbdc4acde49b33748669af96/numpy-2.1.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "762479be47a4863e261a840e8e01608d124ee1361e48b96916f38b119cfda04a",
+              "url": "https://files.pythonhosted.org/packages/27/2f/21b94664f23af2bb52030653697c685022119e0dc93d6097c3cb45bce5f9/numpy-2.1.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "c82af4b2ddd2ee72d1fc0c6695048d457e00b3582ccde72d8a1c991b808bb20f",
-              "url": "https://files.pythonhosted.org/packages/34/4e/f95c99217bf77bbfaaf660d693c10bd0dc03b6032d19316d316088c9e479/numpy-2.1.2-cp311-cp311-macosx_14_0_arm64.whl"
+              "hash": "576a1c1d25e9e02ed7fa5477f30a127fe56debd53b8d2c89d5578f9857d03ca9",
+              "url": "https://files.pythonhosted.org/packages/47/7c/864cb966b96fce5e63fcf25e1e4d957fe5725a635e5f11fe03f39dd9d6b5/numpy-2.1.3-cp311-cp311-macosx_14_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "13532a088217fa624c99b843eeb54640de23b3414b14aa66d023805eb731066c",
-              "url": "https://files.pythonhosted.org/packages/4b/d1/8a730ea07f4a37d94f9172f4ce1d81064b7a64766b460378be278952de75/numpy-2.1.2.tar.gz"
+              "hash": "bc6f24b3d1ecc1eebfbf5d6051faa49af40b03be1aaa781ebdadcbc090b4539b",
+              "url": "https://files.pythonhosted.org/packages/7a/f0/80811e836484262b236c684a75dfc4ba0424bc670e765afaa911468d9f39/numpy-2.1.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1ebec5fd716c5a5b3d8dfcc439be82a8407b7b24b230d0ad28a81b61c2f4659a",
-              "url": "https://files.pythonhosted.org/packages/6c/89/691ac07429ac061b344d5e37fa8e94be51a6017734aea15f2d9d7c6d119a/numpy-2.1.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "4d1167c53b93f1f5d8a139a742b3c6f4d429b54e74e6b57d0eff40045187b15d",
+              "url": "https://files.pythonhosted.org/packages/ad/81/c8167192eba5247593cd9d305ac236847c2912ff39e11402e72ae28a4985/numpy-2.1.3-cp311-cp311-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b42a1a511c81cc78cbc4539675713bbcf9d9c3913386243ceff0e9429ca892fe",
-              "url": "https://files.pythonhosted.org/packages/aa/9c/9a6ec3ae89cd0648d419781284308f2956d2a61d932b5ac9682c956a171b/numpy-2.1.2-cp311-cp311-macosx_10_9_x86_64.whl"
+              "hash": "c80e4a09b3d95b4e1cac08643f1152fa71a0a821a2d4277334c88d54b2219a41",
+              "url": "https://files.pythonhosted.org/packages/da/74/5a60003fc3d8a718d830b08b654d0eea2d2db0806bab8f3c2aca7e18e010/numpy-2.1.3-cp311-cp311-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2cbba4b30bf31ddbe97f1c7205ef976909a93a66bb1583e983adbd155ba72ac2",
-              "url": "https://files.pythonhosted.org/packages/af/03/863fe7062c2106d3c151f7df9353f2ae2237c1dd6900f127a3eb1f24cb1b/numpy-2.1.2-cp311-cp311-musllinux_1_1_x86_64.whl"
+              "hash": "17ee83a1f4fef3c94d16dc1802b998668b5419362c8a4f4e8a491de1b41cc3ee",
+              "url": "https://files.pythonhosted.org/packages/fa/81/ce213159a1ed8eb7d88a2a6ef4fbdb9e4ffd0c76b866c350eb4e3c37e640/numpy-2.1.3-cp311-cp311-musllinux_1_1_x86_64.whl"
             }
           ],
           "project_name": "numpy",
           "requires_dists": [],
           "requires_python": ">=3.10",
-          "version": "2.1.2"
+          "version": "2.1.3"
         },
         {
           "artifacts": [
@@ -2057,19 +2070,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124",
-              "url": "https://files.pythonhosted.org/packages/08/aa/cc0199a5f0ad350994d660967a8efb233fe0416e4639146c089643407ce6/packaging-24.1-py3-none-any.whl"
+              "hash": "09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759",
+              "url": "https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002",
-              "url": "https://files.pythonhosted.org/packages/51/65/50db4dda066951078f0a96cf12f4b9ada6e4b811516bf0262c0f4f7064d4/packaging-24.1.tar.gz"
+              "hash": "c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f",
+              "url": "https://files.pythonhosted.org/packages/d0/63/68dbb6eb2de9cb10ee4c9c14a0148804425e13c4fb20d61cce69f53106da/packaging-24.2.tar.gz"
             }
           ],
           "project_name": "packaging",
           "requires_dists": [],
           "requires_python": ">=3.8",
-          "version": "24.1"
+          "version": "24.2"
         },
         {
           "artifacts": [
@@ -2289,83 +2302,87 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "f048cec7b26778210e28a0459867920654d48e5e62db0958433636cde4254f12",
-              "url": "https://files.pythonhosted.org/packages/df/e4/ba44652d562cbf0bf320e0f3810206149c8a4e99cdbf66da82e97ab53a15/pydantic-2.9.2-py3-none-any.whl"
+              "hash": "a8d20db84de64cf4a7d59e899c2caf0fe9d660c7cfc482528e7020d7dd189a7e",
+              "url": "https://files.pythonhosted.org/packages/e0/fc/fda48d347bd50a788dd2a0f318a52160f911b86fc2d8b4c86f4d7c9bceea/pydantic-2.10.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d155cef71265d1e9807ed1c32b4c8deec042a44a50a4188b25ac67ecd81a9c0f",
-              "url": "https://files.pythonhosted.org/packages/a9/b7/d9e3f12af310e1120c21603644a1cd86f59060e040ec5c3a80b8f05fae30/pydantic-2.9.2.tar.gz"
+              "hash": "a4daca2dc0aa429555e0656d6bf94873a7dc5f54ee42b1f5873d666fb3f35560",
+              "url": "https://files.pythonhosted.org/packages/c4/bd/7fc610993f616d2398958d0028d15eaf53bde5f80cb2edb7aa4f1feaf3a7/pydantic-2.10.1.tar.gz"
             }
           ],
           "project_name": "pydantic",
           "requires_dists": [
             "annotated-types>=0.6.0",
             "email-validator>=2.0.0; extra == \"email\"",
-            "pydantic-core==2.23.4",
-            "typing-extensions>=4.12.2; python_version >= \"3.13\"",
-            "typing-extensions>=4.6.1; python_version < \"3.13\"",
-            "tzdata; (python_version >= \"3.9\" and sys_platform == \"win32\") and extra == \"timezone\""
+            "pydantic-core==2.27.1",
+            "typing-extensions>=4.12.2",
+            "tzdata; (python_version >= \"3.9\" and platform_system == \"Windows\") and extra == \"timezone\""
           ],
           "requires_python": ">=3.8",
-          "version": "2.9.2"
+          "version": "2.10.1"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "d5f7a395a8cf1621939692dba2a6b6a830efa6b3cee787d82c7de1ad2930de64",
-              "url": "https://files.pythonhosted.org/packages/13/46/7bee6d32b69191cd649bbbd2361af79c472d72cb29bb2024f0b6e350ba06/pydantic_core-2.23.4-cp311-cp311-musllinux_1_1_x86_64.whl"
+              "hash": "d1b26e1dff225c31897696cab7d4f0a315d4c0d9e8666dbffdb28216f3b17fdc",
+              "url": "https://files.pythonhosted.org/packages/8d/c8/b4139b2f78579960353c4cd987e035108c93a78371bb19ba0dc1ac3b3220/pydantic_core-2.27.1-cp311-cp311-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d97683ddee4723ae8c95d1eddac7c192e8c552da0c73a925a89fa8649bf13eea",
-              "url": "https://files.pythonhosted.org/packages/13/a5/1df8541651de4455e7d587cf556201b4f7997191e110bca3b589218745a5/pydantic_core-2.23.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+              "hash": "7f7059ca8d64fea7f238994c97d91f75965216bcbe5f695bb44f354893f11d52",
+              "url": "https://files.pythonhosted.org/packages/01/de/df51b3bac9820d38371f5a261020f505025df732ce566c2a2e7970b84c8c/pydantic_core-2.27.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6f783e0ec4803c787bcea93e13e9932edab72068f68ecffdf86a99fd5918878b",
-              "url": "https://files.pythonhosted.org/packages/1b/aa/98e190f8745d5ec831f6d5449344c48c0627ac5fed4e5340a44b74878f8e/pydantic_core-2.23.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl"
+              "hash": "258c57abf1188926c774a4c94dd29237e77eda19462e5bb901d88adcab6af919",
+              "url": "https://files.pythonhosted.org/packages/05/72/257b5824d7988af43460c4e22b63932ed651fe98804cc2793068de7ec554/pydantic_core-2.27.1-cp311-cp311-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1b84d168f6c48fabd1f2027a3d1bdfe62f92cade1fb273a5d68e621da0e44e6d",
-              "url": "https://files.pythonhosted.org/packages/1d/9a/b634442e1253bc6889c87afe8bb59447f106ee042140bd57680b3b113ec7/pydantic_core-2.23.4-cp311-cp311-macosx_11_0_arm64.whl"
+              "hash": "a5a8e19d7c707c4cadb8c18f5f60c843052ae83c20fa7d44f41594c644a1d330",
+              "url": "https://files.pythonhosted.org/packages/1c/00/0804e84a78b7fdb394fff4c4f429815a10e5e0993e6ae0e0b27dd20379ee/pydantic_core-2.27.1-cp311-cp311-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "216f9b2d7713eb98cb83c80b9c794de1f6b7e3145eef40400c62e86cee5f4e1e",
-              "url": "https://files.pythonhosted.org/packages/44/31/a3899b5ce02c4316865e390107f145089876dff7e1dfc770a231d836aed8/pydantic_core-2.23.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "ac3b20653bdbe160febbea8aa6c079d3df19310d50ac314911ed8cc4eb7f8cb8",
+              "url": "https://files.pythonhosted.org/packages/27/39/46fe47f2ad4746b478ba89c561cafe4428e02b3573df882334bd2964f9cb/pydantic_core-2.27.1-cp311-cp311-macosx_10_12_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "77733e3892bb0a7fa797826361ce8a9184d25c8dffaec60b7ffe928153680ba8",
-              "url": "https://files.pythonhosted.org/packages/5d/30/890a583cd3f2be27ecf32b479d5d615710bb926d92da03e3f7838ff3e58b/pydantic_core-2.23.4-cp311-cp311-macosx_10_12_x86_64.whl"
+              "hash": "84286494f6c5d05243456e04223d5a9417d7f443c3b76065e75001beb26f88de",
+              "url": "https://files.pythonhosted.org/packages/34/ac/a2537958db8299fbabed81167d58cc1506049dba4163433524e06a7d9f4c/pydantic_core-2.27.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "df49e7a0861a8c36d089c1ed57d308623d60416dab2647a4a17fe050ba85de0e",
-              "url": "https://files.pythonhosted.org/packages/75/9a/7816295124a6b08c24c96f9ce73085032d8bcbaf7e5a781cd41aa910c891/pydantic_core-2.23.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "acc07b2cfc5b835444b44a9956846b578d27beeacd4b52e45489e93276241025",
+              "url": "https://files.pythonhosted.org/packages/4a/c1/3e38cd777ef832c4fdce11d204592e135ddeedb6c6f525478a53d1c7d3e5/pydantic_core-2.27.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ff02b6d461a6de369f07ec15e465a88895f3223eb75073ffea56b84d9331f607",
-              "url": "https://files.pythonhosted.org/packages/a9/8f/89c1405176903e567c5f99ec53387449e62f1121894aa9fc2c4fdc51a59b/pydantic_core-2.23.4-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+              "hash": "a3cb37038123447cf0f3ea4c74751f6a9d7afef0eb71aa07bf5f652b5e6a132c",
+              "url": "https://files.pythonhosted.org/packages/5f/84/7db66eb12a0dc88c006abd6f3cbbf4232d26adfd827a28638c540d8f871d/pydantic_core-2.27.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d0776dea117cf5272382634bd2a5c1b6eb16767c223c6a5317cd3e2a757c61a0",
-              "url": "https://files.pythonhosted.org/packages/ae/35/b6e00b6abb2acfee3e8f85558c02a0822e9a8b2f2d812ea8b9079b118ba0/pydantic_core-2.23.4-cp311-cp311-musllinux_1_1_aarch64.whl"
+              "hash": "bed0f8a0eeea9fb72937ba118f9db0cb7e90773462af7962d382445f3005e5a4",
+              "url": "https://files.pythonhosted.org/packages/5f/d9/c01d19da8f9e9fbdb2bf99f8358d145a312590374d0dc9dd8dbe484a9cde/pydantic_core-2.27.1-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "996a38a83508c54c78a5f41456b0103c30508fed9abcad0a59b876d7398f25fd",
-              "url": "https://files.pythonhosted.org/packages/d5/a5/1a194447d0da1ef492e3470680c66048fef56fc1f1a25cafbea4bc1d1c48/pydantic_core-2.23.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+              "hash": "35c14ac45fcfdf7167ca76cc80b2001205a8d5d16d80524e13508371fb8cdd9c",
+              "url": "https://files.pythonhosted.org/packages/73/c3/78ed6b7f3278a36589bcdd01243189ade7fc9b26852844938b4d7693895b/pydantic_core-2.27.1-cp311-cp311-musllinux_1_1_armv7l.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2584f7cf844ac4d970fba483a717dbe10c1c1c96a969bf65d61ffe94df1b2863",
-              "url": "https://files.pythonhosted.org/packages/e2/aa/6b6a9b9f8537b872f552ddd46dd3da230367754b6f707b8e1e963f515ea3/pydantic_core-2.23.4.tar.gz"
+              "hash": "4fefee876e07a6e9aad7a8c8c9f85b0cdbe7df52b8a9552307b09050f7512c7e",
+              "url": "https://files.pythonhosted.org/packages/7a/69/b9952829f80fd555fe04340539d90e000a146f2a003d3fcd1e7077c06c71/pydantic_core-2.27.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "62a763352879b84aa31058fc931884055fd75089cccbd9d58bb6afd01141b235",
+              "url": "https://files.pythonhosted.org/packages/a6/9f/7de1f19b6aea45aeb441838782d68352e71bfa98ee6fa048d5041991b33e/pydantic_core-2.27.1.tar.gz"
             }
           ],
           "project_name": "pydantic-core",
@@ -2373,7 +2390,7 @@
             "typing-extensions!=4.7.0,>=4.6.0"
           ],
           "requires_python": ">=3.8",
-          "version": "2.23.4"
+          "version": "2.27.1"
         },
         {
           "artifacts": [
@@ -2506,6 +2523,19 @@
           "requires_dists": [],
           "requires_python": ">=3.6",
           "version": "6.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "af8a9b64b821529aca09ebaf6d8d279100d766f19e90b5059ac6a718ca6dee42",
+              "url": "https://files.pythonhosted.org/packages/ab/38/ff60c8fc9e002d50d48822cc5095deb8ebbc5f91a6b8fdd9731c87a147c9/ratelimit-2.2.1.tar.gz"
+            }
+          ],
+          "project_name": "ratelimit",
+          "requires_dists": [],
+          "requires_python": null,
+          "version": "2.2.1"
         },
         {
           "artifacts": [
@@ -2650,81 +2680,81 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "d8761c3c891cc51e90bc9926d6d2f59b27beaf86c74622c8979380a29cc23ac3",
-              "url": "https://files.pythonhosted.org/packages/f1/e8/ad5da336cd42adbdafe0ecd40dcecdae01fd3d703c621c7637615a008d3a/rpds_py-0.20.1-cp311-cp311-musllinux_1_2_x86_64.whl"
+              "hash": "9e20da3957bdf7824afdd4b6eeb29510e83e026473e04952dca565170cd1ecc8",
+              "url": "https://files.pythonhosted.org/packages/cf/40/4ae09a07e4531278e6bee41ef3e4f166c23468135afc2c6c98917bfc28e6/rpds_py-0.21.0-cp311-cp311-musllinux_1_2_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "42cbde7789f5c0bcd6816cb29808e36c01b960fb5d29f11e052215aa85497c93",
-              "url": "https://files.pythonhosted.org/packages/06/31/3bd721575671f22a37476c2d7b9e34bfa5185bdcee09f7fedde3b29f3adb/rpds_py-0.20.1-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+              "hash": "d2132377f9deef0c4db89e65e8bb28644ff75a18df5293e132a8d67748397b9f",
+              "url": "https://files.pythonhosted.org/packages/22/9b/2a6eeab4e6752adba751cfee19bdf35d11e1073509f74883cbf14d42d682/rpds_py-0.21.0-cp311-cp311-musllinux_1_2_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8ba6f89cac95c0900d932c9efb7f0fb6ca47f6687feec41abcb1bd5e2bd45535",
-              "url": "https://files.pythonhosted.org/packages/10/e1/8dde6174e7ac5b9acd3269afca2e17719bc7e5088c68f44874d2ad9e4560/rpds_py-0.20.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+              "hash": "ed6378c9d66d0de903763e7706383d60c33829581f0adff47b6535f1802fa6db",
+              "url": "https://files.pythonhosted.org/packages/23/80/afdf96daf9b27d61483ef05b38f282121db0e38f5fd4e89f40f5c86c2a4f/rpds_py-0.21.0.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "842c19a6ce894493563c3bd00d81d5100e8e57d70209e84d5491940fdb8b9e3a",
-              "url": "https://files.pythonhosted.org/packages/18/c0/13f1bce9c901511e5e4c0b77a99dbb946bb9a177ca88c6b480e9cb53e304/rpds_py-0.20.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "0a9e0759e7be10109645a9fddaaad0619d58c9bf30a3f248a2ea57a7c417173a",
+              "url": "https://files.pythonhosted.org/packages/3c/19/6e51a141fe6f017d07b7d899b10a4af9e0f268deffacc1107d70fcd9257b/rpds_py-0.21.0-cp311-cp311-musllinux_1_2_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "4a916087371afd9648e1962e67403c53f9c49ca47b9680adbeef79da3a7811b0",
-              "url": "https://files.pythonhosted.org/packages/19/51/a3cc1a5238acfc2582033e8934d034301f9d4931b9bf7c7ccfabc4ca0880/rpds_py-0.20.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "8a7ff941004d74d55a47f916afc38494bd1cfd4b53c482b77c03147c91ac0ac3",
+              "url": "https://files.pythonhosted.org/packages/51/25/a286abda9da7820c971a0b1abcf1d31fb81c44a1088a128ad26c77206622/rpds_py-0.21.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6c8e9340ce5a52f95fa7d3b552b35c7e8f3874d74a03a8a69279fd5fca5dc751",
-              "url": "https://files.pythonhosted.org/packages/20/22/3eeb0385f33251b4fd0f728e6a3801dc8acc05e714eb7867cefe635bf4ab/rpds_py-0.20.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+              "hash": "40c91c6e34cf016fa8e6b59d75e3dbe354830777fcfd74c58b279dceb7975b75",
+              "url": "https://files.pythonhosted.org/packages/55/83/347932db075847f4f8172c3b53ad70fe725edd9058f0d4098080ad45e3bc/rpds_py-0.21.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e1791c4aabd117653530dccd24108fa03cc6baf21f58b950d0a73c3b3b29a350",
-              "url": "https://files.pythonhosted.org/packages/25/cb/8e919951f55d109d658f81c9b49d0cc3b48637c50792c5d2e77032b8c5da/rpds_py-0.20.1.tar.gz"
+              "hash": "5145282a7cd2ac16ea0dc46b82167754d5e103a05614b724457cffe614f25bd8",
+              "url": "https://files.pythonhosted.org/packages/7a/1e/9c3c0463fe142456dcd9e9be0ffd15b66a77adfcdf3ecf94fa2b12d95fcb/rpds_py-0.21.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0b581f47257a9fce535c4567782a8976002d6b8afa2c39ff616edf87cbeff712",
-              "url": "https://files.pythonhosted.org/packages/68/11/d3f84c69de2b2086be3d6bd5e9d172825c096b13842ab7e5f8f39f06035b/rpds_py-0.20.1-cp311-cp311-macosx_11_0_arm64.whl"
+              "hash": "5555db3e618a77034954b9dc547eae94166391a98eb867905ec8fcbce1308d95",
+              "url": "https://files.pythonhosted.org/packages/80/61/615929ea79f5fd0b3aca000411a33bcc1753607ccc1af0ce7b05b56e6e56/rpds_py-0.21.0-cp311-cp311-macosx_10_12_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "762703bdd2b30983c1d9e62b4c88664df4a8a4d5ec0e9253b0231171f18f6d75",
-              "url": "https://files.pythonhosted.org/packages/a0/2e/a6ded84019a05b8f23e0fe6a632f62ae438a8c5e5932d3dfc90c73418414/rpds_py-0.20.1-cp311-cp311-macosx_10_12_x86_64.whl"
+              "hash": "97ef67d9bbc3e15584c2f3c74bcf064af36336c10d2e21a2131e123ce0f924c9",
+              "url": "https://files.pythonhosted.org/packages/a5/f5/28e89dda55b731d78cbfea284dc9789d265a8a06523f0adf60e9b05cade7/rpds_py-0.21.0-cp311-cp311-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "200a23239781f46149e6a415f1e870c5ef1e712939fe8fa63035cd053ac2638e",
-              "url": "https://files.pythonhosted.org/packages/cd/8c/3c87471a44bd4114e2b0aec90f298f6caaac4e8db6af904d5dd2279f5c61/rpds_py-0.20.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl"
+              "hash": "de609a6f1b682f70bb7163da745ee815d8f230d97276db049ab447767466a09d",
+              "url": "https://files.pythonhosted.org/packages/e1/fd/f1fd7e77fef8e5a442ce7fd80ba957730877515fe18d7195f646408a60ce/rpds_py-0.21.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "58b1d5dd591973d426cbb2da5e27ba0339209832b2f3315928c9790e13f159e8",
-              "url": "https://files.pythonhosted.org/packages/d0/9b/95073fe3e0f130e6d561e106818b6568ef1f2df3352e7f162ab912da837c/rpds_py-0.20.1-cp311-cp311-musllinux_1_2_aarch64.whl"
+              "hash": "4ab2c2a26d2f69cdf833174f4d9d86118edc781ad9a8fa13970b527bf8236027",
+              "url": "https://files.pythonhosted.org/packages/e4/ef/eb90feb3e384543c48e2f867551075c43a429aa4c9a44e9c4bd71f4f786b/rpds_py-0.21.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6b73c67850ca7cae0f6c56f71e356d7e9fa25958d3e18a64927c2d930859b8e4",
-              "url": "https://files.pythonhosted.org/packages/de/4c/7ab3669e02bb06fedebcfd64d361b7168ba39dfdf385e4109440f2e7927b/rpds_py-0.20.1-cp311-cp311-musllinux_1_2_i686.whl"
+              "hash": "4e8921a259f54bfbc755c5bbd60c82bb2339ae0324163f32868f63f0ebb873d9",
+              "url": "https://files.pythonhosted.org/packages/ed/e7/8ea2d3d3398266c5c8ddd957d86003493b6d14f8f158b726dd09c8f43dee/rpds_py-0.21.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
             }
           ],
           "project_name": "rpds-py",
           "requires_dists": [],
-          "requires_python": ">=3.8",
-          "version": "0.20.1"
+          "requires_python": ">=3.9",
+          "version": "0.21.0"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "263ed587a5803c6c708d3ce44dc4dfedaab4c1a32e8329bab818933d79ddcf5d",
-              "url": "https://files.pythonhosted.org/packages/e5/c0/b0fba8259b61c938c9733da9346b9f93e00881a9db22aafdd72f6ae0ec05/s3transfer-0.10.3-py3-none-any.whl"
+              "hash": "244a76a24355363a68164241438de1b72f8781664920260c48465896b712a41e",
+              "url": "https://files.pythonhosted.org/packages/66/05/7957af15543b8c9799209506df4660cba7afc4cf94bfb60513827e96bed6/s3transfer-0.10.4-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "4f50ed74ab84d474ce614475e0b8d5047ff080810aac5d01ea25231cfc944b0c",
-              "url": "https://files.pythonhosted.org/packages/a0/a8/e0a98fd7bd874914f0608ef7c90ffde17e116aefad765021de0f012690a2/s3transfer-0.10.3.tar.gz"
+              "hash": "29edc09801743c21eb5ecbc617a152df41d3c287f67b615f73e5f750583666a7",
+              "url": "https://files.pythonhosted.org/packages/c0/0a/1cdbabf9edd0ea7747efdf6c9ab4e7061b085aa7f9bfc36bb1601563b069/s3transfer-0.10.4.tar.gz"
             }
           ],
           "project_name": "s3transfer",
@@ -2733,19 +2763,19 @@
             "botocore[crt]<2.0a.0,>=1.33.2; extra == \"crt\""
           ],
           "requires_python": ">=3.8",
-          "version": "0.10.3"
+          "version": "0.10.4"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "f2504966861356aa38616760c0f66568e535562374995367b4e69c7143cf6bcd",
-              "url": "https://files.pythonhosted.org/packages/90/12/282ee9bce8b58130cb762fbc9beabd531549952cac11fc56add11dcb7ea0/setuptools-75.3.0-py3-none-any.whl"
+              "hash": "ce74b49e8f7110f9bf04883b730f4765b774ef3ef28f722cce7c273d253aaf7d",
+              "url": "https://files.pythonhosted.org/packages/55/21/47d163f615df1d30c094f6c8bbb353619274edccf0327b185cc2493c2c33/setuptools-75.6.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "fba5dd4d766e97be1b1681d98712680ae8f2f26d7881245f2ce9e40714f1a686",
-              "url": "https://files.pythonhosted.org/packages/ed/22/a438e0caa4576f8c383fa4d35f1cc01655a46c75be358960d815bfbb12bd/setuptools-75.3.0.tar.gz"
+              "hash": "8199222558df7c86216af4f84c30e9b34a61d8ba19366cc914424cdbd28252f6",
+              "url": "https://files.pythonhosted.org/packages/43/54/292f26c208734e9a7f067aea4a7e282c080750c4546559b58e2e45413ca0/setuptools-75.6.0.tar.gz"
             }
           ],
           "project_name": "setuptools",
@@ -2753,26 +2783,25 @@
             "build[virtualenv]>=1.0.3; extra == \"test\"",
             "filelock>=3.4.0; extra == \"test\"",
             "furo; extra == \"doc\"",
-            "importlib-metadata>=6; python_version < \"3.10\" and extra == \"core\"",
-            "importlib-metadata>=7.0.2; python_version < \"3.10\" and extra == \"type\"",
-            "importlib-resources>=5.10.2; python_version < \"3.9\" and extra == \"core\"",
+            "importlib_metadata>=6; python_version < \"3.10\" and extra == \"core\"",
+            "importlib_metadata>=7.0.2; python_version < \"3.10\" and extra == \"type\"",
             "ini2toml[lite]>=0.14; extra == \"test\"",
             "jaraco.collections; extra == \"core\"",
             "jaraco.develop>=7.21; (python_version >= \"3.9\" and sys_platform != \"cygwin\") and extra == \"test\"",
             "jaraco.develop>=7.21; sys_platform != \"cygwin\" and extra == \"type\"",
             "jaraco.envs>=2.2; extra == \"test\"",
-            "jaraco.functools; extra == \"core\"",
+            "jaraco.functools>=4; extra == \"core\"",
             "jaraco.packaging>=9.3; extra == \"doc\"",
             "jaraco.path>=3.2.0; extra == \"test\"",
             "jaraco.test>=5.5; extra == \"test\"",
             "jaraco.text>=3.7; extra == \"core\"",
             "jaraco.tidelift>=1.4; extra == \"doc\"",
-            "more-itertools; extra == \"core\"",
-            "more-itertools>=8.8; extra == \"core\"",
-            "mypy==1.12.*; extra == \"type\"",
+            "more_itertools; extra == \"core\"",
+            "more_itertools>=8.8; extra == \"core\"",
+            "mypy<1.14,>=1.12; extra == \"type\"",
             "packaging; extra == \"core\"",
-            "packaging>=23.2; extra == \"test\"",
-            "packaging>=24; extra == \"core\"",
+            "packaging>=24.2; extra == \"core\"",
+            "packaging>=24.2; extra == \"test\"",
             "pip>=19.1; extra == \"test\"",
             "platformdirs>=4.2.2; extra == \"core\"",
             "pygments-github-lexers==0.0.5; extra == \"doc\"",
@@ -2790,7 +2819,7 @@
             "pytest-timeout; extra == \"test\"",
             "pytest-xdist>=3; extra == \"test\"",
             "rst.linker>=1.9; extra == \"doc\"",
-            "ruff>=0.5.2; sys_platform != \"cygwin\" and extra == \"check\"",
+            "ruff>=0.7.0; sys_platform != \"cygwin\" and extra == \"check\"",
             "sphinx-favicon; extra == \"doc\"",
             "sphinx-inline-tabs; extra == \"doc\"",
             "sphinx-lint; extra == \"doc\"",
@@ -2805,8 +2834,8 @@
             "wheel>=0.43.0; extra == \"core\"",
             "wheel>=0.44.0; extra == \"test\""
           ],
-          "requires_python": ">=3.8",
-          "version": "75.3.0"
+          "requires_python": ">=3.9",
+          "version": "75.6.0"
         },
         {
           "artifacts": [
@@ -2998,19 +3027,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "d34c5a82f531af95bb550927136ff5b737a1ed3087f90a59d545591dfde5b4cc",
-              "url": "https://files.pythonhosted.org/packages/a4/15/983b535b1f76db52f3b428ef079aa3013c71a8b7aaab98edee4a1b2ab647/types_s3transfer-0.10.3-py3-none-any.whl"
+              "hash": "22ac1aabc98f9d7f2928eb3fb4d5c02bf7435687f0913345a97dd3b84d0c217d",
+              "url": "https://files.pythonhosted.org/packages/73/de/38872bc9414018e223a4c7193bc2f7ed5ef8ab7a01ab3bb8d7de4f3c2720/types_s3transfer-0.10.4-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f761b2876ac4c208e6c6b75cdf5f6939009768be9950c545b11b0225e7703ee7",
-              "url": "https://files.pythonhosted.org/packages/41/60/3e58d63d1aea14a1c86eb89d717b1e2a3fcf1cc6bd1ae9dd21ab0ba14e8d/types_s3transfer-0.10.3.tar.gz"
+              "hash": "03123477e3064c81efe712bf9d372c7c72f2790711431f9baa59cf96ea607267",
+              "url": "https://files.pythonhosted.org/packages/dd/8f/5cf8bea1470f9d0af8a8a8e232bc9d94eb2b8c040f1c19e673fcd3ba488c/types_s3transfer-0.10.4.tar.gz"
             }
           ],
           "project_name": "types-s3transfer",
           "requires_dists": [],
           "requires_python": ">=3.8",
-          "version": "0.10.3"
+          "version": "0.10.4"
         },
         {
           "artifacts": [
@@ -3102,13 +3131,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "208a2e31a4a54c8b3d2244f2079ca1d3851629a7a7d546646059c64fb746023a",
-              "url": "https://files.pythonhosted.org/packages/2a/f5/4bda0c186b4503ab7df3eaf64c80bab2a230232e140bd83604d103244c39/werkzeug-3.1.0-py3-none-any.whl"
+              "hash": "54b78bf3716d19a65be4fceccc0d1d7b89e608834989dfae50ea87564639213e",
+              "url": "https://files.pythonhosted.org/packages/52/24/ab44c871b0f07f491e5d2ad12c9bd7358e527510618cb1b803a88e986db1/werkzeug-3.1.3-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6f2a0d38f25ba5a75c36c45b4ae350c7a23b57e3b974e9eb2d6851f2c648c00d",
-              "url": "https://files.pythonhosted.org/packages/d4/09/a3137f4decac87db077c9edd03a23f85462db89d898caa10223dad4d9af2/werkzeug-3.1.0.tar.gz"
+              "hash": "60723ce945c19328679790e3282cc758aa4a6040e4bb330f53d30fa546d44746",
+              "url": "https://files.pythonhosted.org/packages/9f/69/83029f1f6300c5fb2471d621ab06f6ec6b3324685a2ce0f9777fd4a8b71e/werkzeug-3.1.3.tar.gz"
             }
           ],
           "project_name": "werkzeug",
@@ -3117,7 +3146,7 @@
             "watchdog>=2.3; extra == \"watchdog\""
           ],
           "requires_python": ">=3.9",
-          "version": "3.1.0"
+          "version": "3.1.3"
         },
         {
           "artifacts": [
@@ -3164,6 +3193,7 @@
     "pytest>=7.2.0",
     "python_dateutil>=2.5.3",
     "pyyaml==6.0",
+    "ratelimit>=2.2.1",
     "requests-oauthlib>=2.0.0",
     "requests>=2.18.4",
     "setuptools>=68.2.2",

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ typing-extensions>=4.8.0 # only needed for python < 3.12
 types-PyYAML>=6.0.12
 urllib3 >= 2.2.1
 nacc_form_validator@ https://github.com/naccdata/nacc-form-validator/releases/download/v0.3.0/nacc_form_validator-0.3.0-py3-none-any.whl
+ratelimit>=2.2.1


### PR DESCRIPTION
Defines the previously undefined `DatastoreHelper.is_valid_rxcui`, which is mainly done through the newly added `rxnorm` common code.

I tried to set this up similar to how other external connections were set up but let me know if any design changes are needed. It should be easy to extend if we need any other API calls to NLM. 

Also high-level dump of the updated dependencies:
```
==                    Upgraded dependencies                     ==

  boto3                          1.35.53      -->   1.35.69
  boto3-stubs                    1.35.53      -->   1.35.69
  botocore                       1.35.53      -->   1.35.69
  botocore-stubs                 1.35.53      -->   1.35.69
  flywheel-sdk                   19.2.0       -->   19.3.0
  fw-utils                       5.0.3        -->   5.0.4
  httpcore                       1.0.6        -->   1.0.7
  moto                           5.0.18       -->   5.0.21
  numpy                          2.1.2        -->   2.1.3
  packaging                      24.1         -->   24.2
  pydantic                       2.9.2        -->   2.10.1
  pydantic-core                  2.23.4       -->   2.27.1
  rpds-py                        0.20.1       -->   0.21.0
  s3transfer                     0.10.3       -->   0.10.4
  setuptools                     75.3.0       -->   75.6.0
  types-s3transfer               0.10.3       -->   0.10.4
  werkzeug                       3.1.0        -->   3.1.3
                                                                  
==                      Added dependencies                      ==

  ratelimit                      2.2.1
```