### PR TITLE
Support optional file

### DIFF
--- a/common/src/python/gear_execution/gear_execution.py
+++ b/common/src/python/gear_execution/gear_execution.py
@@ -171,20 +171,28 @@ class InputFileWrapper:
 
     @classmethod
     def create(cls, input_name: str,
-               context: GearToolkitContext) -> 'InputFileWrapper':
+               context: GearToolkitContext) -> Optional['InputFileWrapper']:
         """Creates the named InputFile.
+
+        Will return None if the named input is optional and no file is given.
 
         Args:
           input_name: the name of the input file
           context: the gear context
         Returns:
-          the input file object
+          the input file object. None, if the input is optional and not given
         Raises:
           GearExecutionError if there is no input with the name
         """
         file_input = context.get_input(input_name)
         if not file_input:
+            is_optional = context.manifest.get("inputs", {}).get(
+                input_name, {}).get("optional", False)
+            if is_optional:
+                return None
+
             raise GearExecutionError(f'Missing input file {input_name}')
+
         if file_input["base"] != "file":
             raise GearExecutionError(
                 f"The specified input {input_name} is not a file")

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -262,7 +262,7 @@ fw-beta gear config --show <project-dir>/src/docker
 ```
 
 >Defaults should already be set in `config.json` for any config or input keys that have them in the manifest.
-You may need to set these for your local run, which may be easy to do by editing the `config.json` file directly.
+You may need to set these for your local run, which may be easier to do by editing the `config.json` file directly.
 
 <i>For any config values that need a value</i> use the command
    
@@ -300,12 +300,15 @@ fw-beta gear run -p <project-dir>/src/docker
 ```
 
 this will build a file structure in `tmp/gear` using the image name.
+You need to use this directory in the run command.
 
 Then [run the gear](https://flywheel-io.gitlab.io/tools/app/cli/fw-beta/gear/run/)  with the command
 
 ```bash
-fw-beta gear run <project-dir>/src/docker
+fw-beta gear run tmp/gear/<gear-structure>
 ```
+
+where `<gear-structure>` is the directory indicated by the "prepare" command.
 
 As of `fw-beta` version 0.18.0 you can also pass docker arguments directly by using `--` followed by the args. See [Flywheel's usage docs](https://flywheel-io.gitlab.io/tools/app/cli/fw-beta/gear/run/#usage) for more information.
 

--- a/gear/csv_to_json_transformer/src/python/csv_app/run.py
+++ b/gear/csv_to_json_transformer/src/python/csv_app/run.py
@@ -54,6 +54,7 @@ class CsvToJsonVisitor(GearExecutionEnvironment):
 
         file_input = InputFileWrapper.create(input_name='input_file',
                                              context=context)
+        assert file_input, "create raises exception if missing expected input" 
 
         return CsvToJsonVisitor(client=client, file_input=file_input)
 

--- a/gear/csv_to_json_transformer/src/python/csv_app/run.py
+++ b/gear/csv_to_json_transformer/src/python/csv_app/run.py
@@ -54,7 +54,7 @@ class CsvToJsonVisitor(GearExecutionEnvironment):
 
         file_input = InputFileWrapper.create(input_name='input_file',
                                              context=context)
-        assert file_input, "create raises exception if missing expected input" 
+        assert file_input, "create raises exception if missing expected input"
 
         return CsvToJsonVisitor(client=client, file_input=file_input)
 

--- a/gear/form_qc_checker/src/python/form_qc_app/run.py
+++ b/gear/form_qc_checker/src/python/form_qc_app/run.py
@@ -64,6 +64,7 @@ class FormQCCheckerVisitor(GearExecutionEnvironment):
                                       parameter_store=parameter_store)
         file_input = InputFileWrapper.create(input_name='form_data_file',
                                              context=context)
+        assert file_input, "create raises exception if missing expected input" 
 
         rules_s3_bucket: str = get_config(gear_context=context,
                                           key='rules_s3_bucket',

--- a/gear/form_qc_checker/src/python/form_qc_app/run.py
+++ b/gear/form_qc_checker/src/python/form_qc_app/run.py
@@ -64,7 +64,7 @@ class FormQCCheckerVisitor(GearExecutionEnvironment):
                                       parameter_store=parameter_store)
         file_input = InputFileWrapper.create(input_name='form_data_file',
                                              context=context)
-        assert file_input, "create raises exception if missing expected input" 
+        assert file_input, "create raises exception if missing expected input"
 
         rules_s3_bucket: str = get_config(gear_context=context,
                                           key='rules_s3_bucket',

--- a/gear/form_qc_coordinator/src/python/form_qc_coordinator_app/run.py
+++ b/gear/form_qc_coordinator/src/python/form_qc_coordinator_app/run.py
@@ -156,6 +156,8 @@ class FormQCCoordinator(GearExecutionEnvironment):
 
         visits_file_input = InputFileWrapper.create(input_name='visits_file',
                                                     context=context)
+        assert visits_file_input, "create raises exception if missing"
+
         visits_file_path = visits_file_input.filepath
         visits_info = validate_input_data(visits_file_path,
                                           dest_container.label)

--- a/gear/identifier_lookup/src/python/identifier_app/run.py
+++ b/gear/identifier_lookup/src/python/identifier_app/run.py
@@ -83,7 +83,7 @@ class IdentifierLookupVisitor(GearExecutionEnvironment):
                                       parameter_store=parameter_store)
         file_input = InputFileWrapper.create(input_name='input_file',
                                              context=context)
-        assert file_input, "create raises exception if missing expected input" 
+        assert file_input, "create raises exception if missing expected input"
 
         admin_id = context.config.get("admin_group", "nacc")
         mode = context.config.get("identifiers_mode", "dev")

--- a/gear/identifier_lookup/src/python/identifier_app/run.py
+++ b/gear/identifier_lookup/src/python/identifier_app/run.py
@@ -83,6 +83,7 @@ class IdentifierLookupVisitor(GearExecutionEnvironment):
                                       parameter_store=parameter_store)
         file_input = InputFileWrapper.create(input_name='input_file',
                                              context=context)
+        assert file_input, "create raises exception if missing expected input" 
 
         admin_id = context.config.get("admin_group", "nacc")
         mode = context.config.get("identifiers_mode", "dev")

--- a/gear/identifier_provisioning/src/python/identifier_provisioning_app/run.py
+++ b/gear/identifier_provisioning/src/python/identifier_provisioning_app/run.py
@@ -51,6 +51,8 @@ class IdentifierProvisioningVisitor(GearExecutionEnvironment):
                                       parameter_store=parameter_store)
         file_input = InputFileWrapper.create(input_name='input_file',
                                              context=context)
+        assert file_input, "create raises exception if missing expected input" 
+
         admin_id = context.config.get("admin_group", "nacc")
         mode = context.config.get("identifiers_mode", "dev")
 

--- a/gear/identifier_provisioning/src/python/identifier_provisioning_app/run.py
+++ b/gear/identifier_provisioning/src/python/identifier_provisioning_app/run.py
@@ -51,7 +51,7 @@ class IdentifierProvisioningVisitor(GearExecutionEnvironment):
                                       parameter_store=parameter_store)
         file_input = InputFileWrapper.create(input_name='input_file',
                                              context=context)
-        assert file_input, "create raises exception if missing expected input" 
+        assert file_input, "create raises exception if missing expected input"
 
         admin_id = context.config.get("admin_group", "nacc")
         mode = context.config.get("identifiers_mode", "dev")


### PR DESCRIPTION
* Changes InputFileWrapper so that the create method returns None when the input is optional and missing.
  The method still raises an exception when the input is expected and missing.

* Adds non-None assertions on calls to InputfileWraper.create for expected inputs where exception would be raised if missing.