### PR TITLE
Push Template Gear: Add distribution as stage

### DIFF
--- a/common/src/python/centers/center_group.py
+++ b/common/src/python/centers/center_group.py
@@ -34,7 +34,8 @@ class CenterGroup(CenterAdaptor):
                  proxy: FlywheelProxy) -> None:
         super().__init__(group=group, proxy=proxy)
         self.__datatypes: List[str] = []
-        self.__ingest_stages = ['ingest', 'retrospective', 'sandbox']
+        self.__ingest_stages = ['ingest', 'retrospective', 'sandbox',
+                                'distribution']
         self.__adcid = adcid
         self.__is_active = active
         self.__center_portal: Optional[ProjectAdaptor] = None

--- a/common/src/python/centers/center_group.py
+++ b/common/src/python/centers/center_group.py
@@ -319,6 +319,7 @@ class CenterGroup(CenterAdaptor):
                 template_project.copy_to(project,
                                          value_map={
                                              'adrc': self.label,
+                                             'adcid': self.adcid,
                                              'project_id': project.id,
                                              'site': self.proxy().get_site()
                                          })
@@ -351,6 +352,7 @@ class CenterGroup(CenterAdaptor):
             template.copy_to(project,
                              value_map={
                                  'adrc': self.label,
+                                 'adcid': self.adcid,
                                  'project_id': project.id,
                                  'site': self.proxy().get_site()
                              })

--- a/docs/push_template/CHANGELOG.md
+++ b/docs/push_template/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this gear are documented in this file.
 
 ## Unreleased
 
+## 1.0.3
+
+* Updates to support distribution projects
+
 ## 1.0.2
 
 * Fixes template pattern generation to handle template labels that don't have a

--- a/docs/push_template/CHANGELOG.md
+++ b/docs/push_template/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this gear are documented in this file.
 ## 1.0.3
 
 * Updates to support distribution projects
-* Adds `adcid` and URL to the projects's value map for replacement
+* Adds `adcid` and to the value map for template replacement
 
 ## 1.0.2
 

--- a/docs/push_template/CHANGELOG.md
+++ b/docs/push_template/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this gear are documented in this file.
 ## 1.0.3
 
 * Updates to support distribution projects
+* Adds `adcid` and URL to the projects's value map for replacement
 
 ## 1.0.2
 

--- a/docs/push_template/index.md
+++ b/docs/push_template/index.md
@@ -20,7 +20,7 @@ Concretely, the name should match the regex `^((\w+)-)?(\w+)-template$`.
 Note that the first group is optional, so possible names are `form-ingest-template` or `accepted-template`.
 The datatype names must match those used in the project description file used in the [project management script](../project_management/index.md).
 
-The stage names are hard-coded in the project management script, and are `ingest`, `accepted` and `retrospective`.
+The stage names are hard-coded in the project management script, and are `ingest`, `accepted` and `retrospective` for aggregation projects and `distribution` for distribution projects.
 
 Projects that are managed by the script should be in groups with a tag matching the regex `adcid-\d+`.
 For example, `adcid-14`.

--- a/gear/push_template/src/docker/BUILD
+++ b/gear/push_template/src/docker/BUILD
@@ -5,4 +5,4 @@ docker_image(name="push-template",
              dependencies=[
                  ":manifest", "gear/push_template/src/python/template_app:bin"
              ],
-             image_tags=["1.0.2", "latest"])
+             image_tags=["1.0.3", "latest"])

--- a/gear/push_template/src/docker/manifest.json
+++ b/gear/push_template/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "push-template",
     "label": "Push Project Template",
     "description": "Pushes template projects to center projects",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/push-template:1.0.2"
+            "image": "naccdata/push-template:1.0.3"
         },
         "flywheel": {
             "suite": "NACC Admin Gears",


### PR DESCRIPTION
Adds `distribution` as a pipeline stage to support pushing templates for distribution projects, also passes `adcid` for documentation substitutions. 

Tested on dummy template/project in sandbox:
* Template: https://naccdata.flywheel.io/#/projects/675334e4029195ae25270ac8
* Project: https://naccdata.flywheel.io/#/projects/67533497eb55638545a8e94f