### PR TITLE
Remove csv.Sniffer

### DIFF
--- a/common/src/python/inputs/csv_reader.py
+++ b/common/src/python/inputs/csv_reader.py
@@ -2,7 +2,7 @@
 
 import abc
 from abc import ABC, abstractmethod
-from csv import DictReader, Error, Sniffer
+from csv import DictReader, Error
 from typing import Any, Dict, List, Optional, TextIO
 
 from outputs.errors import (
@@ -39,45 +39,43 @@ class CSVVisitor(ABC):
         return True
 
 
-def read_csv(input_file: TextIO, error_writer: ErrorWriter,
-             visitor: CSVVisitor) -> bool:
+def read_csv(input_file: TextIO,
+             error_writer: ErrorWriter,
+             visitor: CSVVisitor,
+             delimiter: str = ',') -> bool:
     """Reads CSV file and applies the visitor to each row.
 
     Args:
       input_file: the input stream for the CSV file
       error_writer: the ErrorWriter for the input file
       visitor: the visitor
+      delimiter: Expected delimiter for the CSV
     Returns:
       True if the input file was processed without error, False otherwise
     """
-    sniffer = Sniffer()
     csv_sample = input_file.read(1024)
     if not csv_sample:
         error_writer.write(empty_file_error())
         return False
 
-    try:
-        has_header = sniffer.has_header(csv_sample)
-    except Error as error:
-        error_writer.write(malformed_file_error(str(error)))
-        return False
+    input_file.seek(0)
 
-    if not has_header:
+    reader = DictReader(input_file, delimiter=delimiter)
+    if not reader.fieldnames:
         error_writer.write(missing_header_error())
         return False
-
-    input_file.seek(0)
-    detected_dialect = sniffer.sniff(csv_sample, delimiters=',')
-    reader = DictReader(input_file, dialect=detected_dialect)
-    assert reader.fieldnames, "File has header, reader should have fieldnames"
 
     success = visitor.visit_header(list(reader.fieldnames))
     if not success:
         return False
 
-    for record in reader:
-        row_success = visitor.visit_row(record, line_num=reader.line_num)
-        success = row_success and success
+    try:
+        for record in reader:
+            row_success = visitor.visit_row(record, line_num=reader.line_num)
+            success = row_success and success
+    except Error as error:
+        error_writer.write(malformed_file_error(str(error)))
+        return False
 
     return success
 

--- a/common/src/python/inputs/csv_reader.py
+++ b/common/src/python/inputs/csv_reader.py
@@ -9,6 +9,7 @@ from outputs.errors import (
     ErrorWriter,
     empty_file_error,
     malformed_file_error,
+    missing_header_error,
 )
 
 

--- a/common/src/python/inputs/csv_reader.py
+++ b/common/src/python/inputs/csv_reader.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, List, Optional, TextIO
 from outputs.errors import (
     ErrorWriter,
     empty_file_error,
-    invalid_header_error,
     malformed_file_error,
 )
 
@@ -65,9 +64,9 @@ def read_csv(input_file: TextIO,
         error_writer.write(missing_header_error())
         return False
 
+    # visitor should handle errors for invalid headers/rows
     success = visitor.visit_header(list(reader.fieldnames))
     if not success:
-        error_writer.write(invalid_header_error())
         return False
 
     try:

--- a/common/src/python/inputs/csv_reader.py
+++ b/common/src/python/inputs/csv_reader.py
@@ -8,8 +8,8 @@ from typing import Any, Dict, List, Optional, TextIO
 from outputs.errors import (
     ErrorWriter,
     empty_file_error,
+    invalid_header_error,
     malformed_file_error,
-    missing_header_error,
 )
 
 
@@ -67,6 +67,7 @@ def read_csv(input_file: TextIO,
 
     success = visitor.visit_header(list(reader.fieldnames))
     if not success:
+        error_writer.write(invalid_header_error())
         return False
 
     try:

--- a/common/src/python/outputs/errors.py
+++ b/common/src/python/outputs/errors.py
@@ -88,6 +88,13 @@ def missing_header_error() -> FileError:
                      message='No file header found')
 
 
+def invalid_header_error() -> FileError:
+    """Creates a FileError for an invalid header."""
+    return FileError(error_type='error',
+                     error_code='invalid-header',
+                     message='Invalid header')
+
+
 def missing_field_error(field: str) -> FileError:
     """Creates a FileError for a missing field in header."""
     return FileError(error_type='error',

--- a/common/src/python/outputs/errors.py
+++ b/common/src/python/outputs/errors.py
@@ -88,11 +88,12 @@ def missing_header_error() -> FileError:
                      message='No file header found')
 
 
-def invalid_header_error() -> FileError:
+def invalid_header_error(message: Optional[str] = None) -> FileError:
     """Creates a FileError for an invalid header."""
+    message = message if message else "Invalid header"
     return FileError(error_type='error',
                      error_code='invalid-header',
-                     message='Invalid header')
+                     message=message)
 
 
 def missing_field_error(field: str) -> FileError:

--- a/common/test/python/inputs/test_csv_reader.py
+++ b/common/test/python/inputs/test_csv_reader.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List
 
 import pytest
 from inputs.csv_reader import CSVVisitor, read_csv
-from outputs.errors import StreamErrorWriter
+from outputs.errors import StreamErrorWriter, invalid_header_error
 
 
 # pylint: disable=(redefined-outer-name)
@@ -91,14 +91,24 @@ class NonNumericHeaderVisitor(CSVVisitor):
     explicitly says the header cannot be numeric.
     """
 
-    def visit_header(self, header: List[str]) -> bool:
-        try:
-            for x in header:
-                float(x)
-        except ValueError:
-            return True
+    def __init__(self, error_writer: StreamErrorWriter):
+        """Initializer."""
+        self.__error_writer = error_writer
 
-        return False
+    def visit_header(self, header: List[str]) -> bool:
+        """Visit header - cannot contain numeric values."""
+
+        for x in header:
+            try:
+                float(x)
+            except ValueError:
+                continue
+
+            error = invalid_header_error(message="Header cannot be numeric")
+            self.__error_writer.write(error)
+            return False
+
+        return True
 
     def visit_row(self, row: Dict[str, Any], line_num: int) -> bool:
         return row is not None
@@ -128,16 +138,19 @@ class TestCSVReader:
     def test_invalid_header_stream(self, no_header_stream):
         """Test stream with invalid header row."""
         err_stream = StringIO()
+        error_writer = StreamErrorWriter(
+            stream=err_stream,
+            container_id='dummy',
+            fw_path='dummy-path')
+        visitor = NonNumericHeaderVisitor(error_writer)
+
         success = read_csv(input_file=no_header_stream,
-                           error_writer=StreamErrorWriter(
-                               stream=err_stream,
-                               container_id='dummy',
-                               fw_path='dummy-path'),
-                           visitor=NonNumericHeaderVisitor())
+                           error_writer=error_writer,
+                           visitor=visitor)
         assert not success
         assert not empty(err_stream)
         err_stream.seek(0)
         reader = csv.DictReader(err_stream, dialect='unix')
         assert reader.fieldnames
         row = next(reader)
-        assert row['message'] == 'Invalid header'
+        assert row['message'] == 'Header cannot be numeric'


### PR DESCRIPTION
Removes the csv.Sniffer. Tested in my other two gears (CSV Error Checks Importer + CSV splitter) and seemed fine, but the other gears that utilize `read_csv` should also be tested. 

The only functionality we can't really recreate is determining if something has a header, which I think can be ambiguous to begin with. I think it's fair to require that to be something that `visit_header` does; aside from the dummy tests, every implementation of `CSVVisitor` and `visit_header` expects _something_ from the headers. 

Another thing I noticed is that almost every implementation of CSVVisitor takes in an error writer as an initialization variable - it would require a larger refactor, but maybe we can make it part of the parent class? It would emphasize that it's the CSVVisitor's job to report errors regarding missing headers or invalid data that isn't otherwise easily generalized just from reading a CSV. 