### PR TITLE
redcap-fw-transfer gear updates

### DIFF
--- a/docs/redcap_fw_transfer/CHANGELOG.md
+++ b/docs/redcap_fw_transfer/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 All notable changes to this gear are documented in this file.
 
-## Unreleased
+
+## 0.1.0
+* Removes timestamp from uploaded filename (filename needs to match for error correction)
+* Always upload the CSV file to project level regardless of where the gear is invoked
+
+## 0.0.20
 
 * Adds this CHANGELOG
 

--- a/gear/redcap_fw_transfer/src/docker/BUILD
+++ b/gear/redcap_fw_transfer/src/docker/BUILD
@@ -7,5 +7,5 @@ docker_image(
         ":manifest",
         "gear/redcap_fw_transfer/src/python/redcap_fw_transfer_app:bin",
     ],
-    image_tags=["0.0.20", "latest"],
+    image_tags=["0.1.0", "latest"],
 )

--- a/gear/redcap_fw_transfer/src/docker/manifest.json
+++ b/gear/redcap_fw_transfer/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "redcap-fw-transfer",
     "label": "REDCap to Flywheel Transfer",
     "description": "Gear to transfer from data from a REDCap project to the respective Flywheel project",
-    "version": "0.0.20",
+    "version": "0.1.0",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/redcap-fw-transfer:0.0.20"
+            "image": "naccdata/redcap-fw-transfer:0.1.0"
         },
         "flywheel": {
             "suite": "Import",

--- a/gear/redcap_fw_transfer/src/python/redcap_fw_transfer_app/run.py
+++ b/gear/redcap_fw_transfer/src/python/redcap_fw_transfer_app/run.py
@@ -11,7 +11,7 @@ from centers.center_group import (
     REDCapFormProjectMetadata,
 )
 from flywheel.rest import ApiException
-from flywheel_adaptor.flywheel_proxy import GroupAdaptor
+from flywheel_adaptor.flywheel_proxy import GroupAdaptor, ProjectAdaptor
 from flywheel_gear_toolkit import GearToolkitContext
 from gear_execution.gear_execution import (
     ClientWrapper,
@@ -235,7 +235,8 @@ class REDCapFlywheelTransferVisitor(GearExecutionEnvironment):
                     redcap_pid=str(redcap_project.redcap_pid),
                     module=module,
                     fw_group=group_id,
-                    fw_project=project)
+                    prj_adaptor=ProjectAdaptor(project=project,
+                                               proxy=self.proxy))
             except GearExecutionError as error:
                 log.error(
                     'Error in ingesting module %s from REDCap project %s: %s',


### PR DESCRIPTION
* Removes timestamp from uploaded filename (filename needs to match for error correction)
* Always upload the CSV file to project level regardless of where the gear is invoked
