### PR TITLE
Error metadata updates

### DIFF
--- a/common/src/python/enrollment/enrollment_transfer.py
+++ b/common/src/python/enrollment/enrollment_transfer.py
@@ -91,7 +91,7 @@ class EnrollmentRecord(BaseModel):
     transfer_to: Optional[TransferRecord] = None
 
     def query_object(self) -> IdentifierQueryObject:
-        """Creates an object for creating identifiers in the respository.
+        """Creates an object for creating identifiers in the repository.
 
         Returns:
           the identifier query object to use in batch identifier creation
@@ -107,7 +107,7 @@ def has_value(row: Dict[str, Any], variable: str, value: int) -> bool:
     Args:
       row: dictionary for a data row
       variable: the variable name
-      value: the expected valute
+      value: the expected value
     Returns:
       True if the variable has the value. False, otherwise.
     """
@@ -122,7 +122,7 @@ def is_new_enrollment(row: Dict[str, Any]) -> bool:
     Returns:
       True if the row represents a new enrollment. False, otherwise.
     """
-    return has_value(row, 'enrltype', 1)
+    return has_value(row, FieldNames.ENRLTYPE, 1)
 
 
 def previously_enrolled(row: Dict[str, Any]) -> bool:
@@ -133,7 +133,7 @@ def previously_enrolled(row: Dict[str, Any]) -> bool:
     Returns:
       True if the row represents a previous enrollment. False, otherwise.
     """
-    return has_value(row, 'prevenrl', 1)
+    return has_value(row, FieldNames.PREVENRL, 1)
 
 
 def guid_available(row: Dict[str, Any]) -> bool:
@@ -144,7 +144,7 @@ def guid_available(row: Dict[str, Any]) -> bool:
     Returns:
       True if the row indicates the GUID is available
     """
-    return has_value(row, 'guidavail', 1)
+    return has_value(row, FieldNames.GUIDAVAIL, 1)
 
 
 def has_known_naccid(row: Dict[str, Any]) -> bool:
@@ -155,7 +155,7 @@ def has_known_naccid(row: Dict[str, Any]) -> bool:
     Returns:
       True if the row represents a known NACCID. False, otherwise.
     """
-    return has_value(row, 'naccidknwn', 1)
+    return has_value(row, FieldNames.NACCIDKWN, 1)
 
 
 def existing_participant_error(field: str,

--- a/common/src/python/flywheel_adaptor/flywheel_proxy.py
+++ b/common/src/python/flywheel_adaptor/flywheel_proxy.py
@@ -1310,7 +1310,7 @@ class ProjectAdaptor:
         return SubjectAdaptor(self._project.add_subject(label=label))
 
     def find_subject(self, label: str) -> Optional[SubjectAdaptor]:
-        """Finds the suject with the label.
+        """Finds the subject with the label.
 
         Args:
           label: the subject label

--- a/common/src/python/flywheel_adaptor/flywheel_proxy.py
+++ b/common/src/python/flywheel_adaptor/flywheel_proxy.py
@@ -511,7 +511,7 @@ class FlywheelProxy:
 
         Note: this will replace any existing apps.
 
-        Note: temporary fix using FWCliennt because flywheel-sdk doesn't manage
+        Note: temporary fix using FWClient because flywheel-sdk doesn't manage
         type of viewer_apps.
 
         Args:
@@ -593,7 +593,7 @@ class FlywheelProxy:
         """Find the first Job matching the search string.
 
         Args:
-            search_str: paramets to search (e.g. 'state=failed')
+            search_str: parameters to search (e.g. 'state=failed')
 
         Returns:
             Job: Flywheel Job object if found, else None
@@ -615,7 +615,7 @@ class FlywheelProxy:
             log.warning(error)
             return None
 
-    def get_matching_aquisition_files_info(
+    def get_matching_acquisition_files_info(
             self,
             *,
             container_id: str,

--- a/common/src/python/keys/keys.py
+++ b/common/src/python/keys/keys.py
@@ -21,6 +21,7 @@ class FieldNames:
     PREVENRL = 'prevenrl'
     C2C2T = 'rmmodec2c2t'
     ENRLTYPE = 'enrltype'
+    GUIDAVAIL = 'guidavail'
 
 
 class RuleLabels:

--- a/common/src/python/outputs/errors.py
+++ b/common/src/python/outputs/errors.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, List, Literal, Optional, TextIO
 from flywheel.file_spec import FileSpec
 from flywheel.rest import ApiException
 from flywheel_adaptor.flywheel_proxy import ProjectAdaptor
-from keys.keys import SysErrorCodes
+from keys.keys import FieldNames, SysErrorCodes
 from pydantic import BaseModel, ConfigDict, Field
 
 from outputs.outputs import CSVWriter, convert_json_to_csv_stream
@@ -401,3 +401,25 @@ def update_error_log_and_qc_metadata(*, error_log_name: str,
         return False
 
     return True
+
+
+def get_error_log_name(*, module: str, input_data: Dict[str, Any],
+                       naming_template: Dict[str, str]) -> Optional[str]:
+    """Derive error log name based on visit data.
+
+    Args:
+        module: module label
+        input_data: input visit record
+        naming_template: naming template for module
+
+    Returns:
+        str (optional): error log name or None
+    """
+    ptid = input_data.get(naming_template.get('ptid', FieldNames.PTID))
+    visitdate = input_data.get(
+        naming_template.get('visitdate', FieldNames.DATE_COLUMN))
+
+    if not ptid or not visitdate:
+        return None
+
+    return f'{ptid}_{visitdate}_{module.lower()}_errors.log'

--- a/common/src/python/outputs/errors.py
+++ b/common/src/python/outputs/errors.py
@@ -7,6 +7,7 @@ from datetime import datetime as dt
 from logging import Logger
 from typing import Any, Dict, List, Literal, Optional, TextIO
 
+from dates.form_dates import DEFAULT_DATE_FORMAT, convert_date
 from flywheel.file_spec import FileSpec
 from flywheel.rest import ApiException
 from flywheel_adaptor.flywheel_proxy import ProjectAdaptor
@@ -440,4 +441,9 @@ def get_error_log_name(*, module: str, input_data: Dict[str, Any],
     if not ptid or not visitdate:
         return None
 
-    return f'{ptid}_{visitdate}_{module.lower()}_qc-status.log'
+    normalized_date = convert_date(date_string=visitdate,
+                                   date_format=DEFAULT_DATE_FORMAT)
+    if not normalized_date:
+        return None
+
+    return f'{ptid}_{normalized_date}_{module.lower()}_qc-status.log'

--- a/common/src/python/outputs/errors.py
+++ b/common/src/python/outputs/errors.py
@@ -375,7 +375,7 @@ def update_error_log_and_qc_metadata(*,
                                      gear_name: str,
                                      state: str,
                                      errors: List[Dict[str, Any]],
-                                     copy_metadata: bool = True) -> bool:
+                                     reset_metadata: bool = False) -> bool:
     """Update project level error log file and store error metadata in
     file.info.qc.
 
@@ -385,7 +385,7 @@ def update_error_log_and_qc_metadata(*,
         gear_name: gear that generated errors
         state: gear execution status [PASS|FAIL|NA]
         errors: list of error objects, expected to be JSON dicts
-        copy_metadata: copy metadata from previous gears, set to False for first gear
+        reset_metadata: reset metadata from previous runs, set to True for first gear
 
     Returns:
         bool: True if metadata update is successful, else False
@@ -398,7 +398,7 @@ def update_error_log_and_qc_metadata(*,
     # append to existing error details if any
     if current_log:
         current_log = current_log.reload()
-        if copy_metadata and current_log.info:
+        if current_log.info and not reset_metadata:
             info = current_log.info
         contents = (current_log.read()).decode('utf-8')  # type: ignore
 

--- a/common/src/python/outputs/errors.py
+++ b/common/src/python/outputs/errors.py
@@ -239,7 +239,7 @@ def partially_failed_file_error() -> FileError:
         error_type='error',
         error_code='partially-failed',
         message=('Some records in this file did not pass validation, '
-                 'check the respective record level error log'))
+                 'check the respective record level qc status'))
 
 
 class ErrorWriter(ABC):
@@ -436,18 +436,28 @@ def update_error_log_and_qc_metadata(*,
     return True
 
 
-def get_error_log_name(*, module: str, input_data: Dict[str, Any],
-                       naming_template: Dict[str, str]) -> Optional[str]:
+def get_error_log_name(
+        *,
+        module: str,
+        input_data: Dict[str, Any],
+        naming_template: Optional[Dict[str, str]] = None) -> Optional[str]:
     """Derive error log name based on visit data.
 
     Args:
         module: module label
         input_data: input visit record
-        naming_template: naming template for module
+        naming_template (optional): error log naming template for module
 
     Returns:
         str (optional): error log name or None
     """
+
+    if not naming_template:
+        naming_template = {
+            "ptid": FieldNames.PTID,
+            "visitdate": FieldNames.DATE_COLUMN
+        }
+
     ptid = input_data.get(naming_template.get('ptid', FieldNames.PTID))
     visitdate = input_data.get(
         naming_template.get('visitdate', FieldNames.DATE_COLUMN))

--- a/common/src/python/outputs/errors.py
+++ b/common/src/python/outputs/errors.py
@@ -398,7 +398,7 @@ def update_error_log_and_qc_metadata(*,
     # append to existing error details if any
     if current_log:
         current_log = current_log.reload()
-        if current_log.info and not reset_metadata:
+        if current_log.info and 'qc' in current_log.info and not reset_metadata:
             info = current_log.info
         contents = (current_log.read()).decode('utf-8')  # type: ignore
 

--- a/common/src/python/outputs/errors.py
+++ b/common/src/python/outputs/errors.py
@@ -125,13 +125,11 @@ def empty_field_error(field: str | set[str],
                       message: Optional[str] = None) -> FileError:
     """Creates a FileError for empty field(s)."""
     error_message = message if message else f'Required field(s) {field} cannot be blank'
-    location = CSVLocation(line=line,
-                           column_name=str(field)) if line else JSONLocation(
-                               key_path=str(field))
 
     return FileError(error_type='error',
                      error_code='empty-field',
-                     location=location,
+                     location=CSVLocation(line=line, column_name=str(field))
+                     if line else JSONLocation(key_path=str(field)),
                      message=error_message)
 
 
@@ -391,7 +389,7 @@ def update_error_log_and_qc_metadata(*,
         bool: True if metadata update is successful, else False
     """
 
-    info = {"qc": {}}
+    info: Dict[str, Any] = {"qc": {}}
     contents = ''
 
     current_log = destination_prj.get_file(error_log_name)

--- a/common/src/python/outputs/errors.py
+++ b/common/src/python/outputs/errors.py
@@ -36,6 +36,7 @@ class FileError(BaseModel):
     pipeline."""
     model_config = ConfigDict(populate_by_name=True)
 
+    timestamp: Optional[str] = None
     error_type: Literal['alert', 'error'] = Field(serialization_alias='type')
     error_code: str = Field(serialization_alias='code')
     location: Optional[CSVLocation | JSONLocation] = None
@@ -44,7 +45,6 @@ class FileError(BaseModel):
     value: Optional[str] = None
     expected: Optional[str] = None
     message: str
-    timestamp: Optional[str] = None
     ptid: Optional[str] = None
     visitnum: Optional[str] = None
 

--- a/common/src/python/outputs/outputs.py
+++ b/common/src/python/outputs/outputs.py
@@ -76,15 +76,15 @@ class ListJSONWriter(JSONWriter):
         return self.__objects
 
 
-def write_csv_to_stream(headers: List[str], data: List[Dict[str, Any]],
-                        filename: str) -> StringIO:
+def write_csv_to_stream(headers: List[str], data: List[Dict[str,
+                                                            Any]]) -> StringIO:
     """Takes a header and data pair and uses CSVWriter to write the CSV
     contents to a StringIO stream.
 
     Args:
         headers: The header values
         data: The data values, expected to be a list of JSON dicts
-        filename: The filename
+
     Returns:
         StringIO object containing the contents.
     """
@@ -92,5 +92,33 @@ def write_csv_to_stream(headers: List[str], data: List[Dict[str, Any]],
     writer = CSVWriter(stream, headers)
     for row in data:
         writer.write(row)
+
+    return stream
+
+
+def convert_json_to_csv_stream(data: List[Dict[str, Any]],
+                               fieldnames: List[str],
+                               header: bool = True) -> StringIO:
+    """Convert the list of JSON dicts to a CSV stream. Adding header is
+    optional.
+
+    Args:
+        data: the data values, expected to be a list of JSON dicts
+        fieldnames: list of keys for the dict
+        header: whether to add CSV header or not (default is True)
+
+    Returns:
+        StringIO object containing the contents.
+    """
+    stream = StringIO()
+    writer = DictWriter(stream,
+                        fieldnames=fieldnames,
+                        dialect='unix',
+                        quoting=QUOTE_MINIMAL)
+
+    if header:
+        writer.writeheader()
+
+    writer.writerows(data)
 
     return stream

--- a/common/src/python/uploads/uploader.py
+++ b/common/src/python/uploads/uploader.py
@@ -1,6 +1,5 @@
 import json
 import logging
-from abc import ABC, abstractmethod
 from datetime import datetime
 from string import Template
 from typing import Any, Dict, List, Literal, Optional, TypedDict
@@ -79,20 +78,7 @@ class UploadTemplateInfo(BaseModel):
     filename: LabelTemplate
 
 
-class RecordUploader(ABC):
-
-    @abstractmethod
-    def upload(self, records: Dict[str, List[Dict[str, Any]]]) -> bool:
-        """Uploads the records to acquisitions under the subject.
-
-        Args:
-          records: map from subject to list of records
-        Returns:
-          True if the file for each record is saved. False, otherwise.
-        """
-
-
-class JSONUploader(RecordUploader):
+class JSONUploader:
     """Generalizes upload of a record to an acquisition as JSON."""
 
     def __init__(self,
@@ -137,7 +123,7 @@ class JSONUploader(RecordUploader):
         return success
 
 
-class FormJSONUploader(RecordUploader):
+class FormJSONUploader:
 
     def __init__(self, project: ProjectAdaptor, module: str) -> None:
         self.__project = project

--- a/common/src/python/uploads/uploader.py
+++ b/common/src/python/uploads/uploader.py
@@ -237,7 +237,10 @@ class FormJSONUploader(RecordUploader):
         if not qc_gear_metadata:
             return False
 
-        info = {}
+        info = error_log_file.info if (error_log_file.info
+                                       and 'qc' in error_log_file.info) else {
+                                           'qc': {}
+                                       }
         info['qc'][DefaultValues.QC_GEAR] = qc_gear_metadata
 
         try:

--- a/common/src/python/utils/utils.py
+++ b/common/src/python/utils/utils.py
@@ -2,13 +2,10 @@
 
 import json
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
-from flywheel.file_spec import FileSpec
 from flywheel.models.file_entry import FileEntry
 from flywheel.rest import ApiException
-from flywheel_adaptor.flywheel_proxy import ProjectAdaptor
-from outputs.outputs import convert_json_to_csv_stream
 
 log = logging.getLogger(__name__)
 
@@ -63,70 +60,6 @@ def update_file_info_metadata(file: FileEntry,
         file.update_info(info)
     except ApiException as error:
         log.error('Error in setting file %s metadata - %s', file.name, error)
-        return False
-
-    return True
-
-
-def update_qc_error_metadata(error_log_name: str,
-                             destination_prj: ProjectAdaptor, gear_name: str,
-                             state: str, errors: List[Dict[str, Any]],
-                             fieldnames: List[str]) -> bool:
-    """Update error log file and store error metadata in file.info.qc.
-
-    Args:
-        error_log_name: error log file name
-        destination_prj: Flywheel project adaptor
-        gear_name: gear that generated errors
-        state: gear execution status [PASS|FAIL|NA]
-        errors: list of error objects, expected to be JSON dicts
-        fieldnames: list of error metadata fields (keys for the dict)
-
-    Returns:
-        bool: True if metadata update is successful, else False
-    """
-
-    header = True
-    contents = ''
-
-    current_log = destination_prj.get_file(error_log_name)
-    # append to existing error details if any
-    if current_log:
-        contents = current_log.read() + '\n'
-        header = False
-
-    if errors:
-        contents += convert_json_to_csv_stream(data=errors,
-                                               fieldnames=fieldnames,
-                                               header=header).getvalue()
-
-    error_file_spec = FileSpec(name=error_log_name,
-                               contents=contents,
-                               content_type='text')
-    try:
-        destination_prj.upload_file(error_file_spec)
-        destination_prj.reload()
-        new_file = destination_prj.get_file(error_log_name)
-    except ApiException as error:
-        log.error(f'Failed to upload file {error_log_name} to '
-                  f'{destination_prj.group}/{destination_prj.label}: {error}')
-        return False
-
-    try:
-        info = {
-            "qc": {
-                gear_name: {
-                    "validation": {
-                        "state": state.upper(),
-                        "data": errors
-                    }
-                }
-            }
-        }
-        new_file.update_info(info)
-    except ApiException as error:
-        log.error('Error in setting QC metadata in file %s - %s',
-                  error_log_name, error)
         return False
 
     return True

--- a/common/src/python/utils/utils.py
+++ b/common/src/python/utils/utils.py
@@ -2,10 +2,13 @@
 
 import json
 import logging
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
+from flywheel.file_spec import FileSpec
 from flywheel.models.file_entry import FileEntry
 from flywheel.rest import ApiException
+from flywheel_adaptor.flywheel_proxy import ProjectAdaptor
+from outputs.outputs import convert_json_to_csv_stream
 
 log = logging.getLogger(__name__)
 
@@ -60,6 +63,70 @@ def update_file_info_metadata(file: FileEntry,
         file.update_info(info)
     except ApiException as error:
         log.error('Error in setting file %s metadata - %s', file.name, error)
+        return False
+
+    return True
+
+
+def update_qc_error_metadata(error_log_name: str,
+                             destination_prj: ProjectAdaptor, gear_name: str,
+                             state: str, errors: List[Dict[str, Any]],
+                             fieldnames: List[str]) -> bool:
+    """Update error log file and store error metadata in file.info.qc.
+
+    Args:
+        error_log_name: error log file name
+        destination_prj: Flywheel project adaptor
+        gear_name: gear that generated errors
+        state: gear execution status [PASS|FAIL|NA]
+        errors: list of error objects, expected to be JSON dicts
+        fieldnames: list of error metadata fields (keys for the dict)
+
+    Returns:
+        bool: True if metadata update is successful, else False
+    """
+
+    header = True
+    contents = ''
+
+    current_log = destination_prj.get_file(error_log_name)
+    # append to existing error details if any
+    if current_log:
+        contents = current_log.read() + '\n'
+        header = False
+
+    if errors:
+        contents += convert_json_to_csv_stream(data=errors,
+                                               fieldnames=fieldnames,
+                                               header=header).getvalue()
+
+    error_file_spec = FileSpec(name=error_log_name,
+                               contents=contents,
+                               content_type='text')
+    try:
+        destination_prj.upload_file(error_file_spec)
+        destination_prj.reload()
+        new_file = destination_prj.get_file(error_log_name)
+    except ApiException as error:
+        log.error(f'Failed to upload file {error_log_name} to '
+                  f'{destination_prj.group}/{destination_prj.label}: {error}')
+        return False
+
+    try:
+        info = {
+            "qc": {
+                gear_name: {
+                    "validation": {
+                        "state": state.upper(),
+                        "data": errors
+                    }
+                }
+            }
+        }
+        new_file.update_info(info)
+    except ApiException as error:
+        log.error('Error in setting QC metadata in file %s - %s',
+                  error_log_name, error)
         return False
 
     return True

--- a/docs/form_qc_checker/CHANGELOG.md
+++ b/docs/form_qc_checker/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this gear are documented in this file.
 
+## 1.2.0
+* Update error reporting - move error metadata to visit error log files stored at project level.
+  
 ## 1.1.7
 
 * Changes module label to uppercase for looking up previous visits in Flywheel

--- a/docs/form_qc_coordinator/CHANGELOG.md
+++ b/docs/form_qc_coordinator/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this gear are documented in this file.
 
+## 0.1.0
+* Update error reporting - move error metadata to visit error log files stored at project level.
+  
 ## 0.0.3
 * Updates QC gear configs
   

--- a/docs/form_transformer/CHANGELOG.md
+++ b/docs/form_transformer/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this gear are documented in this file.
 
+## 1.0.5
+* Update error reporting - move error metadata to visit error log files stored at project level.
+  
 ## 1.0.2
 - Removes GearBot client
 - Change acquisition file naming schema

--- a/docs/identifier_lookup/CHANGELOG.md
+++ b/docs/identifier_lookup/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this gear are documented in this file.
 
+## 0.1.0
+* Update error reporting - move error metadata to visit error log files stored at project level.
+  
 ## 0.0.5
 * Changes `identifier_mode` gear config to `database_mode`
   

--- a/docs/identifier_provisioning/CHANGELOG.md
+++ b/docs/identifier_provisioning/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this gear are documented in this file.
 
+## 1.0.1
+* Update error reporting - move error metadata to visit error log files stored at project level.
+  
 ## 1.0.0
 * Changes enrollment session and acquisition labels and JSON filename
 * Changes `identifier_mode` gear config to `database_mode`

--- a/gear/apoe_transformer/test/python/test_apoe_transformer.py
+++ b/gear/apoe_transformer/test/python/test_apoe_transformer.py
@@ -47,7 +47,8 @@ class TestAPOETransformerCSVVisitor:
         errors = list_handler.get_logs()
         assert len(errors) == 8
         for error in errors:
-            assert error['message'].startswith('Missing required field(s)')
+            assert error['message'].startswith(
+                'Missing one or more required field(s)')
             assert error['message'].endswith('in the header')
 
     def test_visit_row(self, visitor, apoe_headers):

--- a/gear/csv_center_splitter/src/python/csv_center_splitter_app/main.py
+++ b/gear/csv_center_splitter/src/python/csv_center_splitter_app/main.py
@@ -177,8 +177,7 @@ def run(*,
                  f"ADCID {adcid} with project ID {project.id}")  # type: ignore
 
         contents = write_csv_to_stream(headers=visitor.headers,
-                                       data=data,
-                                       filename=filename).getvalue()
+                                       data=data).getvalue()
         file_spec = FileSpec(name=filename,
                              contents=contents,
                              content_type="text/csv",

--- a/gear/csv_center_splitter/test/python/test_csv_center_splitter.py
+++ b/gear/csv_center_splitter/test/python/test_csv_center_splitter.py
@@ -62,8 +62,8 @@ class TestCSVVisitorCenterSplitter:
 
         errors = visitor.error_writer.errors()
         assert len(errors) == 2
-        assert errors[0][
-            'message'] == 'Missing required field(s) adcid in the header'
+        assert errors[0]['message'].startswith(
+            "Missing one or more required field(s)")
 
     def test_visit_row(self, visitor):
         """Test the visit_row method, also checks that split_data property is

--- a/gear/csv_subject_splitter/src/python/csv_app/main.py
+++ b/gear/csv_subject_splitter/src/python/csv_app/main.py
@@ -64,8 +64,8 @@ class CSVSplitVisitor(CSVVisitor):
                 found_all = False
 
         if not found_all:
-            self.__error_writer.write(
-                empty_field_error(empty_fields, line_num))
+            self.__error_writer.write(empty_field_error(
+                empty_fields, line_num))
             return False
 
         subject_lbl = row[FieldNames.NACCID]

--- a/gear/csv_subject_splitter/src/python/csv_app/main.py
+++ b/gear/csv_subject_splitter/src/python/csv_app/main.py
@@ -57,12 +57,15 @@ class CSVSplitVisitor(CSVVisitor):
         """
 
         found_all = True
+        empty_fields = set()
         for field in self.__req_fields:
             if field not in row or not row[field]:
+                empty_fields.add(field)
                 found_all = False
-                self.__error_writer.write(empty_field_error(field, line_num))
 
         if not found_all:
+            self.__error_writer.write(
+                empty_field_error(empty_fields, line_num))
             return False
 
         subject_lbl = row[FieldNames.NACCID]

--- a/gear/form_qc_checker/src/docker/BUILD
+++ b/gear/form_qc_checker/src/docker/BUILD
@@ -6,5 +6,5 @@ docker_image(
     dependencies=[
         ":manifest", "gear/form_qc_checker/src/python/form_qc_app:bin"
     ],
-    image_tags=["1.1.19", "latest"],
+    image_tags=["1.1.21", "latest"],
 )

--- a/gear/form_qc_checker/src/docker/BUILD
+++ b/gear/form_qc_checker/src/docker/BUILD
@@ -6,5 +6,5 @@ docker_image(
     dependencies=[
         ":manifest", "gear/form_qc_checker/src/python/form_qc_app:bin"
     ],
-    image_tags=["1.1.7", "latest"],
+    image_tags=["1.1.17", "latest"],
 )

--- a/gear/form_qc_checker/src/docker/BUILD
+++ b/gear/form_qc_checker/src/docker/BUILD
@@ -6,5 +6,5 @@ docker_image(
     dependencies=[
         ":manifest", "gear/form_qc_checker/src/python/form_qc_app:bin"
     ],
-    image_tags=["1.1.22", "latest"],
+    image_tags=["1.2.0", "latest"],
 )

--- a/gear/form_qc_checker/src/docker/BUILD
+++ b/gear/form_qc_checker/src/docker/BUILD
@@ -6,5 +6,5 @@ docker_image(
     dependencies=[
         ":manifest", "gear/form_qc_checker/src/python/form_qc_app:bin"
     ],
-    image_tags=["1.1.21", "latest"],
+    image_tags=["1.1.22", "latest"],
 )

--- a/gear/form_qc_checker/src/docker/BUILD
+++ b/gear/form_qc_checker/src/docker/BUILD
@@ -6,5 +6,5 @@ docker_image(
     dependencies=[
         ":manifest", "gear/form_qc_checker/src/python/form_qc_app:bin"
     ],
-    image_tags=["1.1.17", "latest"],
+    image_tags=["1.1.19", "latest"],
 )

--- a/gear/form_qc_checker/src/docker/manifest.json
+++ b/gear/form_qc_checker/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "form-qc-checker",
     "label": "Form QC Checker",
     "description": "Gear to check form data as JSON with QC rule set",
-    "version": "1.1.21",
+    "version": "1.1.22",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/form-qc-checker:1.1.21"
+            "image": "naccdata/form-qc-checker:1.1.22"
         },
         "flywheel": {
             "suite": "Curation",

--- a/gear/form_qc_checker/src/docker/manifest.json
+++ b/gear/form_qc_checker/src/docker/manifest.json
@@ -77,10 +77,13 @@
             "type": "string",
             "default": "nacc"
         },
-        "tag": {
-            "description": "The tag to be added on input file upon job completion.",
-            "type": "string",
-            "default": "form-qc-checker"
+        "error_log_template": {
+            "description": "the template for deriving error log name <ptid>_<visitdate>_<module>_errors.log",
+            "type": "object",
+            "default": {
+                "ptid": "ptid",
+                "visitdate": "visitdate"
+            }
         }
     },
     "command": "/bin/run"

--- a/gear/form_qc_checker/src/docker/manifest.json
+++ b/gear/form_qc_checker/src/docker/manifest.json
@@ -68,7 +68,7 @@
             "default": "retrospective-form"
         },
         "date_field": {
-            "description": "Variable name of the visit date field for the module (used to sort the participant visits)",
+            "description": "Variable name of the visit date field for the module",
             "type": "string",
             "default": "visitdate"
         },

--- a/gear/form_qc_checker/src/docker/manifest.json
+++ b/gear/form_qc_checker/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "form-qc-checker",
     "label": "Form QC Checker",
     "description": "Gear to check form data as JSON with QC rule set",
-    "version": "1.1.7",
+    "version": "1.1.17",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/form-qc-checker:1.1.7"
+            "image": "naccdata/form-qc-checker:1.1.17"
         },
         "flywheel": {
             "suite": "Curation",
@@ -76,14 +76,6 @@
             "description": "Name of the admin group",
             "type": "string",
             "default": "nacc"
-        },
-        "error_log_template": {
-            "description": "the template for deriving error log name <ptid>_<visitdate>_<module>_errors.log",
-            "type": "object",
-            "default": {
-                "ptid": "ptid",
-                "visitdate": "visitdate"
-            }
         }
     },
     "command": "/bin/run"

--- a/gear/form_qc_checker/src/docker/manifest.json
+++ b/gear/form_qc_checker/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "form-qc-checker",
     "label": "Form QC Checker",
     "description": "Gear to check form data as JSON with QC rule set",
-    "version": "1.1.19",
+    "version": "1.1.21",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/form-qc-checker:1.1.19"
+            "image": "naccdata/form-qc-checker:1.1.21"
         },
         "flywheel": {
             "suite": "Curation",

--- a/gear/form_qc_checker/src/docker/manifest.json
+++ b/gear/form_qc_checker/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "form-qc-checker",
     "label": "Form QC Checker",
     "description": "Gear to check form data as JSON with QC rule set",
-    "version": "1.1.17",
+    "version": "1.1.19",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/form-qc-checker:1.1.17"
+            "image": "naccdata/form-qc-checker:1.1.19"
         },
         "flywheel": {
             "suite": "Curation",

--- a/gear/form_qc_checker/src/docker/manifest.json
+++ b/gear/form_qc_checker/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "form-qc-checker",
     "label": "Form QC Checker",
     "description": "Gear to check form data as JSON with QC rule set",
-    "version": "1.1.22",
+    "version": "1.2.0",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/form-qc-checker:1.1.22"
+            "image": "naccdata/form-qc-checker:1.2.0"
         },
         "flywheel": {
             "suite": "Curation",

--- a/gear/form_qc_checker/src/python/form_qc_app/datastore.py
+++ b/gear/form_qc_checker/src/python/form_qc_app/datastore.py
@@ -151,7 +151,7 @@ class DatastoreHelper(Datastore):
         if qc_gear:
             filters += f',file.info.qc.{qc_gear}.validation.state=PASS'
 
-        visits = self.__proxy.get_matching_aquisition_files_info(
+        visits = self.__proxy.get_matching_acquisition_files_info(
             container_id=subject.id,
             dv_title=title,
             columns=columns,

--- a/gear/form_qc_checker/src/python/form_qc_app/enrollment.py
+++ b/gear/form_qc_checker/src/python/form_qc_app/enrollment.py
@@ -5,12 +5,12 @@
 # Currently only enrollment module is submitted as a CSV file,
 # and does not require optional forms check.
 # Need to change the way we load rule definitions if we
-# have to support optional forms chek for CSV inputs.
+# have to support optional forms check for CSV inputs.
 
 from csv import Dialect, DictReader, Error, Sniffer
 from typing import Any, Dict, List, Mapping, Optional, TextIO
 
-from flywheel import Project
+from flywheel_adaptor.flywheel_proxy import ProjectAdaptor
 from gear_execution.gear_execution import GearExecutionError, InputFileWrapper
 from inputs.csv_reader import CSVVisitor
 from keys.keys import FieldNames
@@ -21,6 +21,7 @@ from outputs.errors import (
     malformed_file_error,
     missing_field_error,
     missing_header_error,
+    partially_failed_file_error,
     unknown_field_error,
 )
 
@@ -35,13 +36,16 @@ class EnrollmentFormVisitor(CSVVisitor):
     Requires the input CSV has primary-key column and module column.
     """
 
-    def __init__(self, pk_field: str, error_writer: ListErrorWriter) -> None:
+    def __init__(self, pk_field: str, date_field: str,
+                 error_writer: ListErrorWriter) -> None:
         """
         Args:
           pk_field: primary key field for the project/module
+          date_field: visit date field for the module
           error_writer: the error output writer
         """
         self.__pk_field = pk_field
+        self.__date_field = date_field
         self.__error_writer = error_writer
         self.__header: Optional[List[str]] = None
         self.__reader: Optional[DictReader] = None
@@ -83,8 +87,9 @@ class EnrollmentFormVisitor(CSVVisitor):
         self.__dialect = dialect
 
     def visit_header(self, header: List[str]) -> bool:
-        """Validates the header fields in file. If the header doesn't have
-        `<primary key>`, formver, writes an error.
+        """Validates the header fields in file. If the header doesn't have.
+
+        <primary key field>, <date field>, or formver, writes an error.
 
         Args:
           header: the list of header names
@@ -93,7 +98,9 @@ class EnrollmentFormVisitor(CSVVisitor):
           True if required fields occur in the header, False otherwise
         """
 
-        expected_columns = {self.__pk_field, FieldNames.FORMVER}
+        expected_columns = {
+            self.__pk_field, self.__date_field, FieldNames.FORMVER
+        }
         if not set(expected_columns).issubset(set(header)):
             self.__error_writer.write(missing_field_error(expected_columns))
             return False
@@ -122,6 +129,11 @@ class EnrollmentFormVisitor(CSVVisitor):
         if not row.get(FieldNames.FORMVER):
             self.__error_writer.write(
                 empty_field_error(FieldNames.FORMVER, line_num))
+            return False
+
+        if not row.get(self.__date_field):
+            self.__error_writer.write(
+                empty_field_error(self.__date_field, line_num))
             return False
 
         return True
@@ -183,14 +195,19 @@ class CSVFileProcessor(FileProcessor):
     enrollment form processing).
     """
 
-    def __init__(self, *, pk_field: str, module: str,
-                 error_writer: ListErrorWriter) -> None:
+    def __init__(self, *, pk_field: str, module: str, date_field: str,
+                 project: ProjectAdaptor, error_writer: ListErrorWriter,
+                 gear_name: str) -> None:
         super().__init__(pk_field=pk_field,
                          module=module,
-                         error_writer=error_writer)
+                         date_field=date_field,
+                         project=project,
+                         error_writer=error_writer,
+                         gear_name=gear_name)
 
-    def validate_input(self, *, input_wrapper: InputFileWrapper,
-                       project: Optional[Project]) -> Optional[Dict[str, Any]]:
+    def validate_input(
+            self, *,
+            input_wrapper: InputFileWrapper) -> Optional[Dict[str, Any]]:
         """Validates a CSV input file. Check whether all required fields are
         present in the header and the first data row.
 
@@ -203,6 +220,7 @@ class CSVFileProcessor(FileProcessor):
         """
 
         enrl_visitor = EnrollmentFormVisitor(pk_field=self._pk_field,
+                                             date_field=self._date_field,
                                              error_writer=self._error_writer)
 
         with open(input_wrapper.filepath, mode='r',
@@ -245,27 +263,36 @@ class CSVFileProcessor(FileProcessor):
             validator: Helper class for validating a input record
 
         Returns:
-            bool: True if all records passed NACC data quality checks, else False
+            bool: True if input passed validation
 
         Raises:
-            GearExecutionError: if errors occured while processing the input file
+            GearExecutionError: if errors occurred while processing the input file
         """
 
         if not self.__csv_reader or not self.__csv_reader.fieldnames:
-            raise GearExecutionError('Failed to intialize the CSV reader')
+            raise GearExecutionError('Failed to initialize the CSV reader')
 
         unknown_fields = set(self.__csv_reader.fieldnames).difference(
             set(validator.get_validation_schema().keys()))
 
         if unknown_fields:
-            for unknown_field in unknown_fields:
-                self._error_writer.write(unknown_field_error(unknown_field))
+            self._error_writer.write(unknown_field_error(unknown_fields))
             return False
 
         passed_all = True
         for row in self.__csv_reader:
-            if not validator.process_data_record(
-                    record=row, line_number=self.__csv_reader.line_num - 1):
-                passed_all = False
+            self._error_writer.clear()  # clear the errors for previous record
+            valid = validator.process_data_record(
+                record=row, line_number=self.__csv_reader.line_num - 1)
+            passed_all = passed_all and valid
+            if not self.update_visit_error_log(input_record=row,
+                                               qc_passed=valid):
+                raise GearExecutionError(
+                    'Failed to update error log for record '
+                    f'{row[self._pk_field]}/{row[self._date_field]}')
+
+        if not passed_all:
+            self._error_writer.clear()
+            self._error_writer.write(partially_failed_file_error())
 
         return passed_all

--- a/gear/form_qc_checker/src/python/form_qc_app/enrollment.py
+++ b/gear/form_qc_checker/src/python/form_qc_app/enrollment.py
@@ -289,7 +289,7 @@ class CSVFileProcessor(FileProcessor):
                                                qc_passed=valid):
                 raise GearExecutionError(
                     'Failed to update error log for record '
-                    f'{row[self._pk_field]}/{row[self._date_field]}')
+                    f'{row[self._pk_field]}, {row[self._date_field]}')
 
         if not passed_all:
             self._error_writer.clear()

--- a/gear/form_qc_checker/src/python/form_qc_app/enrollment.py
+++ b/gear/form_qc_checker/src/python/form_qc_app/enrollment.py
@@ -285,8 +285,8 @@ class CSVFileProcessor(FileProcessor):
             valid = validator.process_data_record(
                 record=row, line_number=self.__csv_reader.line_num - 1)
             passed_all = passed_all and valid
-            if not self.update_visit_error_log(input_record=row,
-                                               qc_passed=valid, reset_metadata=True):
+            if not self.update_visit_error_log(
+                    input_record=row, qc_passed=valid, reset_metadata=True):
                 raise GearExecutionError(
                     'Failed to update error log for record '
                     f'{row[self._pk_field]}, {row[self._date_field]}')

--- a/gear/form_qc_checker/src/python/form_qc_app/enrollment.py
+++ b/gear/form_qc_checker/src/python/form_qc_app/enrollment.py
@@ -286,7 +286,7 @@ class CSVFileProcessor(FileProcessor):
                 record=row, line_number=self.__csv_reader.line_num - 1)
             passed_all = passed_all and valid
             if not self.update_visit_error_log(input_record=row,
-                                               qc_passed=valid):
+                                               qc_passed=valid, reset_metadata=True):
                 raise GearExecutionError(
                     'Failed to update error log for record '
                     f'{row[self._pk_field]}, {row[self._date_field]}')

--- a/gear/form_qc_checker/src/python/form_qc_app/main.py
+++ b/gear/form_qc_checker/src/python/form_qc_app/main.py
@@ -239,11 +239,10 @@ def run(  # noqa: C901
 
     valid = file_processor.process_input(validator=validator)
 
-    error_log_template = gear_context.config.get(
-        'error_log_template', {
-            "ptid": FieldNames.PTID,
-            "visitdate": FieldNames.DATE_COLUMN
-        })
+    error_log_template = {
+        "ptid": FieldNames.PTID,
+        "visitdate": FieldNames.DATE_COLUMN
+    }
 
     log_file_name = get_error_log_name(module=module,
                                        input_data=input_data,

--- a/gear/form_qc_checker/src/python/form_qc_app/main.py
+++ b/gear/form_qc_checker/src/python/form_qc_app/main.py
@@ -112,7 +112,7 @@ def run(  # noqa: C901
         redcap_connection (Optional): REDCap project for NACC QC checks
 
     Raises:
-        GearExecutionError if any problem occurrs while validating input file
+        GearExecutionError if any problem occurs while validating input file
     """
 
     if not input_wrapper.file_input:

--- a/gear/form_qc_checker/src/python/form_qc_app/processor.py
+++ b/gear/form_qc_checker/src/python/form_qc_app/processor.py
@@ -84,7 +84,7 @@ class FileProcessor(ABC):
             bool: True if the file passed validation
 
         Raises:
-            GearExecutionError: if errors occured while processing the input file
+            GearExecutionError: if errors occurred while processing the input file
         """
 
 
@@ -105,7 +105,7 @@ class JSONFileProcessor(FileProcessor):
             FailedStatus: Literal['NONE', 'SAME', 'DIFFERENT']
 
         Raises:
-            GearExecutionError: If error occured while checking for previous visits
+            GearExecutionError: If error occurred while checking for previous visits
         """
         try:
             failed_visit = self.__subject.get_last_failed_visit(self._module)
@@ -250,7 +250,7 @@ class JSONFileProcessor(FileProcessor):
             bool: True if the record passed validation
 
         Raises:
-            GearExecutionError: if errors occured while processing the input record
+            GearExecutionError: if errors occurred while processing the input record
         """
 
         valid = False
@@ -268,7 +268,7 @@ class JSONFileProcessor(FileProcessor):
                     file_id=self.__file_id,
                     visitdate=self.__input_record[self.__date_field])
                 self.__subject.set_last_failed_visit(self._module, visit_info)
-            # reset failed visit metadta in Flyhweel
+            # reset failed visit metadata in Flywheel
             elif failed_visit == 'SAME':
                 self.__subject.reset_last_failed_visit(self._module)
 

--- a/gear/form_qc_checker/src/python/form_qc_app/processor.py
+++ b/gear/form_qc_checker/src/python/form_qc_app/processor.py
@@ -6,9 +6,8 @@ from abc import ABC, abstractmethod
 from json.decoder import JSONDecodeError
 from typing import Any, Dict, Literal, Mapping, Optional
 
-from flywheel import Project
+from flywheel_adaptor.flywheel_proxy import ProjectAdaptor
 from flywheel_adaptor.subject_adaptor import (
-    SubjectAdaptor,
     SubjectError,
     VisitInfo,
 )
@@ -19,9 +18,11 @@ from outputs.errors import (
     ListErrorWriter,
     empty_field_error,
     empty_file_error,
+    get_error_log_name,
     malformed_file_error,
     previous_visit_failed_error,
     system_error,
+    update_error_log_and_qc_metadata,
 )
 
 from form_qc_app.definitions import DefinitionsLoader
@@ -36,20 +37,28 @@ class FileProcessor(ABC):
     """Abstract class for processing the input file and running data quality
     checks."""
 
-    def __init__(self, *, pk_field: str, module: str,
-                 error_writer: ListErrorWriter) -> None:
+    def __init__(self, *, pk_field: str, module: str, date_field: str,
+                 project: ProjectAdaptor, error_writer: ListErrorWriter,
+                 gear_name: str) -> None:
         self._pk_field = pk_field
         self._module = module
+        self._date_field = date_field
+        self._project = project
         self._error_writer = error_writer
+        self._gear_name = gear_name
+        self._error_log_template = {
+            "ptid": FieldNames.PTID,
+            "visitdate": self._date_field
+        }
 
     @abstractmethod
-    def validate_input(self, *, input_wrapper: InputFileWrapper,
-                       project: Optional[Project]) -> Optional[Dict[str, Any]]:
+    def validate_input(
+            self, *,
+            input_wrapper: InputFileWrapper) -> Optional[Dict[str, Any]]:
         """Validates the input file before proceeding with data quality checks.
 
         Args:
             input_wrapper: Wrapper object for gear input file
-            project: Flywheel project container
 
         Returns:
             Dict[str, Any]: None if required info missing, else input record as dict
@@ -81,22 +90,51 @@ class FileProcessor(ABC):
             validator: Helper class for validating a input record
 
         Returns:
-            bool: True if the file passed validation
+           bool: True if input passed validation
 
         Raises:
             GearExecutionError: if errors occurred while processing the input file
         """
+
+    def update_visit_error_log(self, *, input_record: Dict[str, Any],
+                               qc_passed: bool) -> bool:
+        """Update error log file for the visit and store error metadata in
+        file.info.qc.
+
+        Args:
+            input_record: input visit record
+            qc_passed (bool): whether the visit passed QC checks
+
+        Returns:
+            bool: True if error log updated successfully, else False
+        """
+        error_log_name = get_error_log_name(
+            module=self._module,
+            input_data=input_record,
+            naming_template=self._error_log_template)
+        if not error_log_name:
+            return False
+
+        return update_error_log_and_qc_metadata(
+            error_log_name=error_log_name,
+            destination_prj=self._project,
+            gear_name=self._gear_name,
+            state='PASS' if qc_passed else 'FAIL',
+            errors=self._error_writer.errors())
 
 
 class JSONFileProcessor(FileProcessor):
     """Class for processing JSON input file."""
 
     def __init__(self, *, pk_field: str, module: str, date_field: str,
-                 error_writer: ListErrorWriter) -> None:
-        self.__date_field = date_field
+                 project: ProjectAdaptor, error_writer: ListErrorWriter,
+                 gear_name: str) -> None:
         super().__init__(pk_field=pk_field,
                          module=module,
-                         error_writer=error_writer)
+                         date_field=date_field,
+                         project=project,
+                         error_writer=error_writer,
+                         gear_name=gear_name)
 
     def __has_failed_visits(self) -> FailedStatus:
         """Check whether the participant has any failed previous visits.
@@ -112,7 +150,7 @@ class JSONFileProcessor(FileProcessor):
         except SubjectError as error:
             raise GearExecutionError(error) from error
 
-        visitdate = self.__input_record[self.__date_field]
+        visitdate = self.__input_record[self._date_field]
 
         if failed_visit:
             same_file = (failed_visit.file_id and failed_visit.file_id
@@ -145,15 +183,15 @@ class JSONFileProcessor(FileProcessor):
 
         return 'NONE'
 
-    def validate_input(self, *, input_wrapper: InputFileWrapper,
-                       project: Optional[Project]) -> Optional[Dict[str, Any]]:
+    def validate_input(
+            self, *,
+            input_wrapper: InputFileWrapper) -> Optional[Dict[str, Any]]:
         """Validates a JSON input file for a participant visit. Check whether
         all required fields are present in the input data. Check whether
         primary key matches with the Flywheel subject label in the project.
 
         Args:
             input_wrapper: Wrapper object for gear input file
-            project: Flywheel project container
 
         Returns:
             Dict[str, Any]: None if required info missing, else input record as dict
@@ -174,20 +212,19 @@ class JSONFileProcessor(FileProcessor):
             self._error_writer.write(empty_field_error(self._pk_field))
             return None
 
-        if not input_data.get(self.__date_field):
-            self._error_writer.write(empty_field_error(self.__date_field))
+        if not input_data.get(self._date_field):
+            self._error_writer.write(empty_field_error(self._date_field))
             return None
 
         if not input_data.get(FieldNames.FORMVER):
             self._error_writer.write(empty_field_error(FieldNames.FORMVER))
             return None
 
-        assert project, "Project required"
         subject_lbl = input_data[self._pk_field]
-        subject = project.subjects.find_first(f'label={subject_lbl}')
+        subject = self._project.find_subject(subject_lbl)
         if not subject:
             message = ('Failed to retrieve subject '
-                       f'{subject_lbl} in project {project.label}')
+                       f'{subject_lbl} in project {self._project.label}')
             log.error(message)
             self._error_writer.write(
                 system_error(message, JSONLocation(key_path=self._pk_field)))
@@ -196,7 +233,7 @@ class JSONFileProcessor(FileProcessor):
         self.__input_record = input_data
         self.__file_id = input_wrapper.file_id
         self.__filename = input_wrapper.filename
-        self.__subject = SubjectAdaptor(subject)
+        self.__subject = subject
 
         return self.__input_record
 
@@ -247,13 +284,15 @@ class JSONFileProcessor(FileProcessor):
             validator: Helper class for validating the input record
 
         Returns:
-            bool: True if the record passed validation
+            bool: True if input passed validation
 
         Raises:
             GearExecutionError: if errors occurred while processing the input record
         """
 
         valid = False
+
+        visitdate = self.__input_record[self._date_field]
 
         # check whether there are any pending visits for this participant/module
         failed_visit = self.__has_failed_visits()
@@ -263,13 +302,17 @@ class JSONFileProcessor(FileProcessor):
         if failed_visit in ['NONE', 'SAME']:
             valid = validator.process_data_record(record=self.__input_record)
             if not valid:
-                visit_info = VisitInfo(
-                    filename=self.__filename,
-                    file_id=self.__file_id,
-                    visitdate=self.__input_record[self.__date_field])
+                visit_info = VisitInfo(filename=self.__filename,
+                                       file_id=self.__file_id,
+                                       visitdate=visitdate)
                 self.__subject.set_last_failed_visit(self._module, visit_info)
             # reset failed visit metadata in Flywheel
             elif failed_visit == 'SAME':
                 self.__subject.reset_last_failed_visit(self._module)
+
+        if not self.update_visit_error_log(input_record=self.__input_record,
+                                           qc_passed=valid):
+            raise GearExecutionError('Failed to update visit error log for '
+                                     f'{self.__subject.label}/{visitdate}')
 
         return valid

--- a/gear/form_qc_checker/src/python/form_qc_app/processor.py
+++ b/gear/form_qc_checker/src/python/form_qc_app/processor.py
@@ -96,15 +96,18 @@ class FileProcessor(ABC):
             GearExecutionError: if errors occurred while processing the input file
         """
 
-    def update_visit_error_log(self, *, input_record: Dict[str, Any],
-                               qc_passed: bool, reset_metadata: bool = False) -> bool:
+    def update_visit_error_log(self,
+                               *,
+                               input_record: Dict[str, Any],
+                               qc_passed: bool,
+                               reset_metadata: bool = False) -> bool:
         """Update error log file for the visit and store error metadata in
         file.info.qc.
 
         Args:
             input_record: input visit record
             qc_passed: whether the visit passed QC checks
-            reset_metadata: reset metadata from previous runs, set to True for first gear
+            reset_metadata: reset metadata from previous runs, set True for first gear
 
         Returns:
             bool: True if error log updated successfully, else False

--- a/gear/form_qc_checker/src/python/form_qc_app/processor.py
+++ b/gear/form_qc_checker/src/python/form_qc_app/processor.py
@@ -97,13 +97,14 @@ class FileProcessor(ABC):
         """
 
     def update_visit_error_log(self, *, input_record: Dict[str, Any],
-                               qc_passed: bool) -> bool:
+                               qc_passed: bool, reset_metadata: bool = False) -> bool:
         """Update error log file for the visit and store error metadata in
         file.info.qc.
 
         Args:
             input_record: input visit record
-            qc_passed (bool): whether the visit passed QC checks
+            qc_passed: whether the visit passed QC checks
+            reset_metadata: reset metadata from previous runs, set to True for first gear
 
         Returns:
             bool: True if error log updated successfully, else False
@@ -120,7 +121,8 @@ class FileProcessor(ABC):
             destination_prj=self._project,
             gear_name=self._gear_name,
             state='PASS' if qc_passed else 'FAIL',
-            errors=self._error_writer.errors())
+            errors=self._error_writer.errors(),
+            reset_metadata=reset_metadata)
 
 
 class JSONFileProcessor(FileProcessor):

--- a/gear/form_qc_checker/src/python/form_qc_app/processor.py
+++ b/gear/form_qc_checker/src/python/form_qc_app/processor.py
@@ -312,7 +312,7 @@ class JSONFileProcessor(FileProcessor):
 
         if not self.update_visit_error_log(input_record=self.__input_record,
                                            qc_passed=valid):
-            raise GearExecutionError('Failed to update visit error log for '
-                                     f'{self.__subject.label}/{visitdate}')
+            raise GearExecutionError('Failed to update error log for visit '
+                                     f'{self.__subject.label}, {visitdate}')
 
         return valid

--- a/gear/form_qc_coordinator/src/docker/BUILD
+++ b/gear/form_qc_coordinator/src/docker/BUILD
@@ -7,4 +7,4 @@ docker_image(
         ":manifest",
         "gear/form_qc_coordinator/src/python/form_qc_coordinator_app:bin"
     ],
-    image_tags=["0.0.7", "latest"])
+    image_tags=["0.0.8", "latest"])

--- a/gear/form_qc_coordinator/src/docker/BUILD
+++ b/gear/form_qc_coordinator/src/docker/BUILD
@@ -7,4 +7,4 @@ docker_image(
         ":manifest",
         "gear/form_qc_coordinator/src/python/form_qc_coordinator_app:bin"
     ],
-    image_tags=["0.0.8", "latest"])
+    image_tags=["0.1.0", "latest"])

--- a/gear/form_qc_coordinator/src/docker/BUILD
+++ b/gear/form_qc_coordinator/src/docker/BUILD
@@ -7,4 +7,4 @@ docker_image(
         ":manifest",
         "gear/form_qc_coordinator/src/python/form_qc_coordinator_app:bin"
     ],
-    image_tags=["0.0.4", "latest"])
+    image_tags=["0.0.7", "latest"])

--- a/gear/form_qc_coordinator/src/docker/manifest.json
+++ b/gear/form_qc_coordinator/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "form-qc-coordinator",
     "label": "Form QC Coordinator",
     "description": "A gear to coordinate data quality checks for a given participant",
-    "version": "0.0.8",
+    "version": "0.1.0",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/form-qc-coordinator:0.0.8"
+            "image": "naccdata/form-qc-coordinator:0.1.0"
         },
         "flywheel": {
             "suite": "Utility",

--- a/gear/form_qc_coordinator/src/docker/manifest.json
+++ b/gear/form_qc_coordinator/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "form-qc-coordinator",
     "label": "Form QC Coordinator",
     "description": "A gear to coordinate data quality checks for a given participant",
-    "version": "0.0.7",
+    "version": "0.0.8",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/form-qc-coordinator:0.0.7"
+            "image": "naccdata/form-qc-coordinator:0.0.8"
         },
         "flywheel": {
             "suite": "Utility",

--- a/gear/form_qc_coordinator/src/docker/manifest.json
+++ b/gear/form_qc_coordinator/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "form-qc-coordinator",
     "label": "Form QC Coordinator",
     "description": "A gear to coordinate data quality checks for a given participant",
-    "version": "0.0.4",
+    "version": "0.0.7",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/form-qc-coordinator:0.0.4"
+            "image": "naccdata/form-qc-coordinator:0.0.7"
         },
         "flywheel": {
             "suite": "Utility",

--- a/gear/form_qc_coordinator/src/python/form_qc_coordinator_app/coordinator.py
+++ b/gear/form_qc_coordinator/src/python/form_qc_coordinator_app/coordinator.py
@@ -1,4 +1,4 @@
-"""QC checks cordination module."""
+"""QC checks coordination module."""
 
 import logging
 import time
@@ -32,10 +32,10 @@ class QCGearConfigs(BaseModel):
     rules_s3_bucket: str
     qc_checks_db_path: str
     primary_key: str
+    admin_group: str
     strict_mode: Optional[bool] = True
-    legacy_project_label: Optional[str]
-    date_field: Optional[str]
-    tag: Optional[str]
+    legacy_project_label: Optional[str] = None
+    date_field: Optional[str] = None
 
 
 class QCGearInfo(BaseModel):
@@ -46,7 +46,7 @@ class QCGearInfo(BaseModel):
 
 
 class QCCoordinator():
-    """This class cordinates the data quality checks for a given participant.
+    """This class coordinates the data quality checks for a given participant.
 
     - For each module visits are evaluated in the order of visit date.
     - If visit N for module M has not passed error checks any of the
@@ -57,7 +57,7 @@ class QCCoordinator():
     def __init__(self, *, subject: SubjectAdaptor, module: str,
                  proxy: FlywheelProxy,
                  gear_context: GearToolkitContext) -> None:
-        """Initialize the QC Cordinator.
+        """Initialize the QC Coordinator.
 
         Args:
             subject: Flywheel subject to run the QC checks
@@ -187,7 +187,7 @@ class QCCoordinator():
     def run_error_checks(self, *, gear_name: str, gear_configs: QCGearConfigs,
                          visits: List[Dict[str, str]], date_col: str) -> None:
         """Sequentially trigger the QC checks gear on the provided visits. If a
-        visit failed QC validation or error occured while running the QC gear,
+        visit failed QC validation or error occurred while running the QC gear,
         none of the subsequent visits will be evaluated.
 
         Args:
@@ -197,7 +197,7 @@ class QCCoordinator():
             date_col: name of the visit date field to sort the visits
 
         Raises:
-            GearExecutionError if errors occurr while triggering the QC gear
+            GearExecutionError if errors occur while triggering the QC gear
         """
 
         try:

--- a/gear/form_qc_coordinator/src/python/form_qc_coordinator_app/coordinator.py
+++ b/gear/form_qc_coordinator/src/python/form_qc_coordinator_app/coordinator.py
@@ -8,16 +8,19 @@ from typing import Dict, List, Optional
 from flywheel import FileEntry
 from flywheel.models.job import Job
 from flywheel.rest import ApiException
-from flywheel_adaptor.flywheel_proxy import FlywheelProxy
+from flywheel_adaptor.flywheel_proxy import FlywheelProxy, ProjectAdaptor
 from flywheel_adaptor.subject_adaptor import SubjectAdaptor, VisitInfo
 from flywheel_gear_toolkit import GearToolkitContext
 from flywheel_gear_toolkit.utils.metadata import Metadata, create_qc_result_dict
 from gear_execution.gear_execution import GearExecutionError
+from keys.keys import FieldNames
 from outputs.errors import (
     FileError,
     ListErrorWriter,
+    get_error_log_name,
     previous_visit_failed_error,
     system_error,
+    update_error_log_and_qc_metadata,
 )
 from pydantic import BaseModel, ConfigDict
 
@@ -65,10 +68,10 @@ class QCCoordinator():
             proxy: Flywheel proxy object
             gear_context: Flywheel gear context
         """
-        self._subject = subject
-        self._module = module
-        self._proxy = proxy
-        self._metadata = Metadata(context=gear_context)
+        self.__subject = subject
+        self.__module = module
+        self.__proxy = proxy
+        self.__metadata = Metadata(context=gear_context)
 
     def poll_job_status(self, job: Job) -> str:
         """Check for the completion status of a gear job.
@@ -102,7 +105,7 @@ class QCCoordinator():
             bool: True if job successfully complete, else False
         """
 
-        job = self._proxy.get_job_by_id(job_id)
+        job = self.__proxy.get_job_by_id(job_id)
         if not job:
             log.error('Cannot find a job with ID %s', job_id)
             return False
@@ -111,7 +114,7 @@ class QCCoordinator():
         max_retries = 3  # maximum number of retries in Flywheel
         retries = 1
         while status == 'retried' and retries <= max_retries:
-            new_job = self._proxy.find_job(f'previous_job_id="{job_id}"')
+            new_job = self.__proxy.find_job(f'previous_job_id="{job_id}"')
             if not new_job:
                 log.error('Cannot find a retried job with previous_job_id=%s',
                           job_id)
@@ -140,35 +143,56 @@ class QCCoordinator():
         qc_info = visit_file.info.get('qc', {})
         gear_info = qc_info.get(gear_name, {})
         validation = gear_info.get('validation', {})
-        if 'state' not in validation or validation['state'] != 'PASS':
-            return False
+        return not ('state' not in validation or validation['state'] != 'PASS')
 
-        return True
-
-    def update_qc_error_metadata(self, visit_file: FileEntry,
-                                 error: FileError):
-        """Add error metadata to the visits file qc info section
+    def __update_qc_error_metadata(self, *, visit_file: FileEntry,
+                                   error: FileError, ptid: str,
+                                   visitdate: str):
+        """Add error metadata to the visits file qc info section.
+        Also, updates the visit error log and add qc info metadata
         Note: This method modifies metadata in a file which is not tracked as gear input
 
         Args:
             visit_file: FileEntry object for the visits file
             error: FileError object with failure info
+            ptid: PTID
+            visitdate: visit date
         """
 
         error_writer = ListErrorWriter(
             container_id=visit_file.id,
-            fw_path=self._proxy.get_lookup_path(visit_file))
+            fw_path=self.__proxy.get_lookup_path(visit_file))
         error_writer.write(error)
 
         qc_result = create_qc_result_dict(name='validation',
                                           state='FAIL',
                                           data=error_writer.errors())
+
         # add qc-coordinator gear info to visit file metadata
-        updated_qc_info = self._metadata.add_gear_info('qc', visit_file,
-                                                       **qc_result)
-        self._metadata.update_file_metadata(visit_file,
-                                            container_type='acquisition',
-                                            info=updated_qc_info)
+        updated_qc_info = self.__metadata.add_gear_info(
+            'qc', visit_file, **qc_result)
+        self.__metadata.update_file_metadata(visit_file,
+                                             container_type='acquisition',
+                                             info=updated_qc_info)
+
+        error_log_name = get_error_log_name(module=self.__module,
+                                            input_data={
+                                                'ptid': ptid,
+                                                'visitdate': visitdate
+                                            })
+
+        project = self.__proxy.get_project_by_id(
+            self.__subject.parents.project)  # type: ignore
+
+        if not error_log_name or not project or not update_error_log_and_qc_metadata(
+                error_log_name=error_log_name,
+                destination_prj=ProjectAdaptor(project=project,
+                                               proxy=self.__proxy),
+                gear_name=self.__metadata.name,  # type: ignore
+                state='FAIL',
+                errors=error_writer.errors()):
+            raise GearExecutionError(
+                f'Failed to update error log for visit {ptid}, {visitdate}')
 
     def update_last_failed_visit(self, file_id: str, filename: str,
                                  visitdate: str):
@@ -182,7 +206,7 @@ class QCCoordinator():
         visit_info = VisitInfo(file_id=file_id,
                                filename=filename,
                                visitdate=visitdate)
-        self._subject.set_last_failed_visit(self._module, visit_info)
+        self.__subject.set_last_failed_visit(self.__module, visit_info)
 
     def run_error_checks(self, *, gear_name: str, gear_configs: QCGearConfigs,
                          visits: List[Dict[str, str]], date_col: str) -> None:
@@ -201,12 +225,13 @@ class QCCoordinator():
         """
 
         try:
-            gear = self._proxy.lookup_gear(gear_name)
+            gear = self.__proxy.lookup_gear(gear_name)
         except ApiException as error:
             raise GearExecutionError(error) from error
 
         configs = gear_configs.model_dump()
 
+        ptid_key = f'file.info.forms.json.{FieldNames.PTID}'
         date_col_key = f'file.info.forms.json.{date_col}'
 
         # sort the visits in the ascending order of visit date
@@ -220,10 +245,11 @@ class QCCoordinator():
             file_id = visit['file.file_id']
             acq_id = visit['file.parents.acquisition']
             visitdate = visit[date_col_key]
+            ptid = visit[ptid_key]
 
             try:
-                visit_file = self._proxy.get_file(file_id)
-                destination = self._proxy.get_acquisition(acq_id)
+                visit_file = self.__proxy.get_file(file_id)
+                destination = self.__proxy.get_acquisition(acq_id)
             except ApiException as error:
                 raise GearExecutionError(
                     f'Failed to retrieve {filename} - {error}') from error
@@ -246,7 +272,10 @@ class QCCoordinator():
                 error_obj = system_error(
                     f'Errors occurred while running gear {gear_name} on this file'
                 )
-                self.update_qc_error_metadata(visit_file, error_obj)
+                self.__update_qc_error_metadata(visit_file=visit_file,
+                                                error=error_obj,
+                                                ptid=ptid,
+                                                visitdate=visitdate)
                 failed_visit = visit_file.name
                 break
 
@@ -267,8 +296,10 @@ class QCCoordinator():
             while len(visits_queue) > 0:
                 visit = visits_queue.popleft()
                 file_id = visit['file.file_id']
+                visitdate = visit[date_col_key]
+                ptid = visit[ptid_key]
                 try:
-                    visit_file = self._proxy.get_file(file_id)
+                    visit_file = self.__proxy.get_file(file_id)
                 except ApiException as error:
                     log.warning('Failed to retrieve file %s - %s',
                                 visit['file.name'], error)
@@ -276,4 +307,7 @@ class QCCoordinator():
                                 visit['file.name'])
                     continue
                 error_obj = previous_visit_failed_error(failed_visit)
-                self.update_qc_error_metadata(visit_file, error_obj)
+                self.__update_qc_error_metadata(visit_file=visit_file,
+                                                error=error_obj,
+                                                ptid=ptid,
+                                                visitdate=visitdate)

--- a/gear/form_qc_coordinator/src/python/form_qc_coordinator_app/main.py
+++ b/gear/form_qc_coordinator/src/python/form_qc_coordinator_app/main.py
@@ -14,6 +14,7 @@ from gear_execution.gear_execution import (
     GearExecutionError,
     InputFileWrapper,
 )
+from keys.keys import FieldNames
 
 from form_qc_coordinator_app.coordinator import QCCoordinator, QCGearInfo
 
@@ -42,10 +43,10 @@ def get_matching_visits(
         module: str,
         date_col: str,
         cutoff_date: Optional[str] = None) -> Optional[List[Dict[str, str]]]:
-    """Get the list of visits for the specified partipant for the specified
+    """Get the list of visits for the specified participant for the specified
     module.
 
-    Note: This method assumes visit date in file metadata is notmalized to
+    Note: This method assumes visit date in file metadata is normalized to
     YYYY-MM-DD format at a previous stage of the submission pipeline.
 
     Args:
@@ -62,20 +63,21 @@ def get_matching_visits(
 
     title = f'{module} visits for participant {subject}'
 
+    ptid_key = f'file.info.forms.json.{FieldNames.PTID}'
     date_col_key = f'file.info.forms.json.{date_col}'
     columns = [
-        date_col_key, 'file.name', 'file.file_id', 'file.parents.acquisition',
-        'file.info.forms.json.visitnum'
+        ptid_key, date_col_key, 'file.name', 'file.file_id',
+        'file.parents.acquisition', 'file.info.forms.json.visitnum'
     ]
     filters = f'acquisition.label={module}'
 
     if cutoff_date:
         filters += f',{date_col_key}>={cutoff_date}'
 
-    return proxy.get_matching_aquisition_files_info(container_id=container_id,
-                                                    dv_title=title,
-                                                    columns=columns,
-                                                    filters=filters)
+    return proxy.get_matching_acquisition_files_info(container_id=container_id,
+                                                     dv_title=title,
+                                                     columns=columns,
+                                                     filters=filters)
 
 
 def run(*,
@@ -100,7 +102,7 @@ def run(*,
         check_all: re-evaluate all visits for the participant/module
 
     Raises:
-        GearExecutionError if any problem occurrs during the QC process
+        GearExecutionError if any problem occurs during the QC process
     """
 
     if check_all:

--- a/gear/form_transformer/src/docker/BUILD
+++ b/gear/form_transformer/src/docker/BUILD
@@ -6,4 +6,4 @@ docker_image(name="form-transformer",
                  ":manifest",
                  "gear/form_transformer/src/python/form_csv_app:bin"
              ],
-             image_tags=["1.0.3", "latest"])
+             image_tags=["1.0.5", "latest"])

--- a/gear/form_transformer/src/docker/BUILD
+++ b/gear/form_transformer/src/docker/BUILD
@@ -6,4 +6,4 @@ docker_image(name="form-transformer",
                  ":manifest",
                  "gear/form_transformer/src/python/form_csv_app:bin"
              ],
-             image_tags=["1.0.2", "latest"])
+             image_tags=["1.0.3", "latest"])

--- a/gear/form_transformer/src/docker/manifest.json
+++ b/gear/form_transformer/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "form-transformer",
     "label": "Form CSV to JSON Transformer",
     "description": "Form specific transformation from CSV to JSON",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/form-transformer:1.0.2"
+            "image": "naccdata/form-transformer:1.0.3"
         },
         "flywheel": {
             "suite": "Curation",

--- a/gear/form_transformer/src/docker/manifest.json
+++ b/gear/form_transformer/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "form-transformer",
     "label": "Form CSV to JSON Transformer",
     "description": "Form specific transformation from CSV to JSON",
-    "version": "1.0.3",
+    "version": "1.0.5",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/form-transformer:1.0.3"
+            "image": "naccdata/form-transformer:1.0.5"
         },
         "flywheel": {
             "suite": "Curation",

--- a/gear/form_transformer/src/python/form_csv_app/main.py
+++ b/gear/form_transformer/src/python/form_csv_app/main.py
@@ -200,7 +200,7 @@ class CSVTransformVisitor(CSVVisitor):
             qc_passed: whether the visit passed QC checks
 
         Returns:
-            bool: True if error log updated successfully, else False
+            str (optional): error log name if update successful, else None
         """
 
         if not self.__project or not self.module:

--- a/gear/form_transformer/src/python/form_csv_app/main.py
+++ b/gear/form_transformer/src/python/form_csv_app/main.py
@@ -81,12 +81,15 @@ class CSVTransformVisitor(CSVVisitor):
         """
 
         found_all = True
+        empty_fields = set()
         for field in self.__req_fields:
             if field not in row or not row[field]:
+                empty_fields.add(field)
                 found_all = False
-                self.__error_writer.write(empty_field_error(field, line_num))
 
         if not found_all:
+            self.__error_writer.write(
+                empty_field_error(empty_fields, line_num))
             return False
 
         # If module expected set module

--- a/gear/form_transformer/src/python/form_csv_app/main.py
+++ b/gear/form_transformer/src/python/form_csv_app/main.py
@@ -9,10 +9,13 @@ from gear_execution.gear_execution import GearExecutionError
 from inputs.csv_reader import CSVVisitor, read_csv
 from keys.keys import FieldNames
 from outputs.errors import (
-    ErrorWriter,
+    ListErrorWriter,
     empty_field_error,
+    get_error_log_name,
     missing_field_error,
+    system_error,
     unexpected_value_error,
+    update_error_log_and_qc_metadata,
 )
 from transform.transformer import BaseRecordTransformer, TransformerFactory
 from uploads.uploader import FormJSONUploader
@@ -23,17 +26,30 @@ log = logging.getLogger(__name__)
 class CSVTransformVisitor(CSVVisitor):
     """Class to transform a participant visit CSV record."""
 
-    def __init__(self, *, req_fields: List[str],
-                 transformed_records: DefaultDict[str, List[Dict[str, Any]]],
-                 error_writer: ErrorWriter,
-                 transformer_factory: TransformerFactory) -> None:
+    def __init__(self,
+                 *,
+                 req_fields: List[str],
+                 transformed_records: DefaultDict[str, Dict[str, Dict[str,
+                                                                      Any]]],
+                 error_writer: ListErrorWriter,
+                 transformer_factory: TransformerFactory,
+                 gear_name: str,
+                 project: Optional[ProjectAdaptor] = None) -> None:
         self.__req_fields = req_fields
         self.__transformed = transformed_records
         self.__error_writer = error_writer
         self.__transformer_factory = transformer_factory
         self.__has_module_field = False
+        self.__gear_name = gear_name
+        self.__project = project
         self.__module: Optional[str] = None
         self.__transformer: Optional[BaseRecordTransformer] = None
+        # TODO - change to get from template
+        self.__date_field = FieldNames.DATE_COLUMN
+        self.__error_log_template = {
+            "ptid": FieldNames.PTID,
+            "visitdate": self.__date_field
+        }
 
     def has_module(self) -> bool:
         """Indicates whether a module field was detected in the file header.
@@ -80,6 +96,8 @@ class CSVTransformVisitor(CSVVisitor):
           True if the row was processed without error, False otherwise
         """
 
+        self.__error_writer.clear()
+
         found_all = True
         empty_fields = set()
         for field in self.__req_fields:
@@ -88,8 +106,9 @@ class CSVTransformVisitor(CSVVisitor):
                 found_all = False
 
         if not found_all:
-            self.__error_writer.write(
-                empty_field_error(empty_fields, line_num))
+            self.__error_writer.write(empty_field_error(
+                empty_fields, line_num))
+            self.__update_visit_error_log(input_record=row, qc_passed=False)
             return False
 
         # If module expected set module
@@ -97,6 +116,8 @@ class CSVTransformVisitor(CSVVisitor):
             self.__set_module(row)
             # All records in the CSV file must belongs to the same module.
             if not self.__check_module(row=row, line_num=line_num):
+                self.__update_visit_error_log(input_record=row,
+                                              qc_passed=False)
                 return False
 
         # Set transformer for the module
@@ -106,10 +127,16 @@ class CSVTransformVisitor(CSVVisitor):
 
         transformed_row = self.__transformer.transform(row, line_num)
         if not transformed_row:
+            self.__update_visit_error_log(input_record=row, qc_passed=False)
+            return False
+
+        error_log_name = self.__update_visit_error_log(input_record=row,
+                                                       qc_passed=True)
+        if not error_log_name:
             return False
 
         subject_lbl = transformed_row[FieldNames.NACCID]
-        self.__transformed[subject_lbl].append(transformed_row)
+        self.__transformed[subject_lbl][error_log_name] = transformed_row
 
         return True
 
@@ -160,7 +187,45 @@ class CSVTransformVisitor(CSVVisitor):
                 value=row_module,  # type: ignore
                 expected=self.__module,  # type: ignore
                 line=line_num))
+
         return False
+
+    def __update_visit_error_log(self, *, input_record: Dict[str, Any],
+                                 qc_passed: bool) -> Optional[str]:
+        """Update error log file for the visit and store error metadata in
+        file.info.qc.
+
+        Args:
+            input_record: input visit record
+            qc_passed: whether the visit passed QC checks
+
+        Returns:
+            bool: True if error log updated successfully, else False
+        """
+
+        if not self.__project or not self.module:
+            log.warning(
+                'Parent project or module not specified to upload visit error log'
+            )
+            return None
+
+        error_log_name = get_error_log_name(
+            module=self.module,
+            input_data=input_record,
+            naming_template=self.__error_log_template)
+
+        if not error_log_name or not update_error_log_and_qc_metadata(
+                error_log_name=error_log_name,
+                destination_prj=self.__project,
+                gear_name=self.__gear_name,
+                state='PASS' if qc_passed else 'FAIL',
+                errors=self.__error_writer.errors()):
+            raise GearExecutionError(
+                'Failed to update error log for visit '
+                f'{input_record[FieldNames.PTID]}, {input_record[self.__date_field]}'
+            )
+
+        return error_log_name
 
 
 def notify_upload_errors():
@@ -169,16 +234,17 @@ def notify_upload_errors():
 
 
 def run(*, input_file: TextIO, destination: ProjectAdaptor,
-        transformer_factory: TransformerFactory,
-        error_writer: ErrorWriter) -> bool:
+        transformer_factory: TransformerFactory, error_writer: ListErrorWriter,
+        gear_name: str) -> bool:
     """Reads records from the input file and transforms each into a JSON file.
-    Uploads the JSON file to the respective aquisition in Flywheel.
+    Uploads the JSON file to the respective acquisition in Flywheel.
 
     Args:
         input_file: the input file
         destination: Flyhweel project container
         transformer_factory: the factory for column transformers
         error_writer: the writer for error output
+        gear_name: gear name
 
     Returns:
         bool: True if transformation/upload successful
@@ -190,15 +256,19 @@ def run(*, input_file: TextIO, destination: ProjectAdaptor,
         FieldNames.DATE_COLUMN, FieldNames.FORMVER
     ]
 
-    transformed_records: DefaultDict[str, List[Dict[str,
-                                                    Any]]] = defaultdict(list)
+    transformed_records: DefaultDict[str, Dict[str,
+                                               Dict[str,
+                                                    Any]]] = defaultdict(dict)
     visitor = CSVTransformVisitor(req_fields=req_fields_list,
                                   transformed_records=transformed_records,
                                   error_writer=error_writer,
-                                  transformer_factory=transformer_factory)
+                                  transformer_factory=transformer_factory,
+                                  gear_name=gear_name,
+                                  project=destination)
     result = read_csv(input_file=input_file,
                       error_writer=error_writer,
-                      visitor=visitor)
+                      visitor=visitor,
+                      clear_errors=True)
 
     if not len(transformed_records) > 0:
         return result
@@ -211,6 +281,8 @@ def run(*, input_file: TextIO, destination: ProjectAdaptor,
                                 module=visitor.module)  # type: ignore
     upload_status = uploader.upload(transformed_records)
     if not upload_status:
+        error_writer.write(
+            system_error('Error(s) occurred while uploading visit files'))
         notify_upload_errors()
 
     return result and upload_status

--- a/gear/form_transformer/src/python/form_csv_app/run.py
+++ b/gear/form_transformer/src/python/form_csv_app/run.py
@@ -85,6 +85,8 @@ class FormCSVtoJSONTransformer(GearExecutionEnvironment):
             raise GearExecutionError(
                 f'Failed to find the project with ID {file.parents.project}')
 
+        gear_name = context.manifest.get('name', 'form-transformer')
+
         with open(self.__file_input.filepath, mode='r',
                   encoding='utf-8') as csv_file:
             error_writer = ListErrorWriter(container_id=file_id,
@@ -94,7 +96,8 @@ class FormCSVtoJSONTransformer(GearExecutionEnvironment):
                                                      proxy=proxy),
                           transformer_factory=self.__build_transformer(
                               self.__transform_input),
-                          error_writer=error_writer)
+                          error_writer=error_writer,
+                          gear_name=gear_name)
 
             context.metadata.add_qc_result(self.__file_input.file_input,
                                            name='validation',
@@ -102,8 +105,7 @@ class FormCSVtoJSONTransformer(GearExecutionEnvironment):
                                            data=error_writer.errors())
 
             context.metadata.add_file_tags(self.__file_input.file_input,
-                                           tags=context.manifest.get(
-                                               'name', 'form-transformer'))
+                                           tags=gear_name)
 
     def __build_transformer(
             self, transformer_input: Optional[InputFileWrapper]

--- a/gear/identifier_lookup/src/docker/BUILD
+++ b/gear/identifier_lookup/src/docker/BUILD
@@ -6,5 +6,5 @@ docker_image(
     dependencies=[
         ":manifest", "gear/identifier_lookup/src/python/identifier_app:bin"
     ],
-    image_tags=["0.0.7", "latest"],
+    image_tags=["0.0.8", "latest"],
 )

--- a/gear/identifier_lookup/src/docker/BUILD
+++ b/gear/identifier_lookup/src/docker/BUILD
@@ -6,5 +6,5 @@ docker_image(
     dependencies=[
         ":manifest", "gear/identifier_lookup/src/python/identifier_app:bin"
     ],
-    image_tags=["0.0.5", "latest"],
+    image_tags=["0.0.7", "latest"],
 )

--- a/gear/identifier_lookup/src/docker/BUILD
+++ b/gear/identifier_lookup/src/docker/BUILD
@@ -6,5 +6,5 @@ docker_image(
     dependencies=[
         ":manifest", "gear/identifier_lookup/src/python/identifier_app:bin"
     ],
-    image_tags=["0.0.8", "latest"],
+    image_tags=["0.1.0", "latest"],
 )

--- a/gear/identifier_lookup/src/docker/manifest.json
+++ b/gear/identifier_lookup/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "identifier-lookup",
     "label": "NACC ID Lookup",
     "description": "Gear to check for NACC ID for incoming data",
-    "version": "0.0.7",
+    "version": "0.0.8",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/identifier-lookup:0.0.7"
+            "image": "naccdata/identifier-lookup:0.0.8"
         },
         "flywheel": {
             "suite": "NACC Data Gears",

--- a/gear/identifier_lookup/src/docker/manifest.json
+++ b/gear/identifier_lookup/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "identifier-lookup",
     "label": "NACC ID Lookup",
     "description": "Gear to check for NACC ID for incoming data",
-    "version": "0.0.8",
+    "version": "0.1.0",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/identifier-lookup:0.0.8"
+            "image": "naccdata/identifier-lookup:0.1.0"
         },
         "flywheel": {
             "suite": "NACC Data Gears",

--- a/gear/identifier_lookup/src/docker/manifest.json
+++ b/gear/identifier_lookup/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "identifier-lookup",
     "label": "NACC ID Lookup",
     "description": "Gear to check for NACC ID for incoming data",
-    "version": "0.0.5",
+    "version": "0.0.7",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/identifier-lookup:0.0.5"
+            "image": "naccdata/identifier-lookup:0.0.7"
         },
         "flywheel": {
             "suite": "NACC Data Gears",
@@ -56,6 +56,11 @@
             "description": "The instance specific AWS parameter gearbot path prefix",
             "type": "string",
             "default": "/prod/flywheel/gearbot"
+        },
+        "date_field": {
+            "description": "Variable name of the visit date field for the module",
+            "type": "string",
+            "default": "visitdate"
         }
     },
     "command": "/bin/run"

--- a/gear/identifier_lookup/src/python/identifier_app/main.py
+++ b/gear/identifier_lookup/src/python/identifier_app/main.py
@@ -35,7 +35,6 @@ class IdentifierVisitor(CSVVisitor):
             module_name: the module name for the form
             error_writer: the error output writer
         """
-        self.__adcid = adcid
         self.__identifiers = identifiers
         self.__output_file = output_file
         self.__error_writer = error_writer

--- a/gear/identifier_lookup/src/python/identifier_app/main.py
+++ b/gear/identifier_lookup/src/python/identifier_app/main.py
@@ -164,14 +164,14 @@ class IdentifierVisitor(CSVVisitor):
             naming_template=self.__error_log_template)
 
         # This is first gear in pipeline validating individual rows
-        # therefore, clear metadata from previous runs `copy_metadata=False`
+        # therefore, clear metadata from previous runs `reset_metadata=True`
         if not error_log_name or not update_error_log_and_qc_metadata(
                 error_log_name=error_log_name,
                 destination_prj=self.__project,
                 gear_name=self.__gear_name,
                 state='PASS' if qc_passed else 'FAIL',
                 errors=self.__error_writer.errors(),
-                copy_metadata=False):
+                reset_metadata=True):
             raise GearExecutionError(
                 'Failed to update error log for visit '
                 f'{input_record[FieldNames.PTID]}, {input_record[self.__date_field]}'

--- a/gear/identifier_lookup/src/python/identifier_app/run.py
+++ b/gear/identifier_lookup/src/python/identifier_app/run.py
@@ -5,6 +5,8 @@ import os
 from pathlib import Path
 from typing import Dict, Optional
 
+from flywheel.rest import ApiException
+from flywheel_adaptor.flywheel_proxy import ProjectAdaptor
 from flywheel_gear_toolkit import GearToolkitContext
 from gear_execution.gear_execution import (
     ClientWrapper,
@@ -24,6 +26,7 @@ from identifiers.identifiers_repository import (
 )
 from identifiers.model import IdentifierObject
 from inputs.parameter_store import ParameterStore
+from keys.keys import FieldNames
 from lambdas.lambda_function import LambdaClient, create_lambda_client
 from outputs.errors import ListErrorWriter
 
@@ -32,8 +35,9 @@ from identifier_app.main import run
 log = logging.getLogger(__name__)
 
 
-def get_identifiers(identifiers_repo: IdentifierRepository,
-                    adcid: int) -> Dict[str, IdentifierObject]:
+def get_identifiers(
+    identifiers_repo: IdentifierRepository, adcid: int
+) -> Dict[str, IdentifierObject]:
     """Gets all of the Identifier objects from the identifier database using
     the RDSParameters.
 
@@ -48,9 +52,7 @@ def get_identifiers(identifiers_repo: IdentifierRepository,
     if center_identifiers:
         # pylint: disable=(not-an-iterable)
         identifiers = {
-            identifier.ptid: identifier
-            for identifier in center_identifiers
-        }
+            identifier.ptid: identifier for identifier in center_identifiers}
 
     return identifiers
 
@@ -58,9 +60,13 @@ def get_identifiers(identifiers_repo: IdentifierRepository,
 class IdentifierLookupVisitor(GearExecutionEnvironment):
     """The gear execution visitor for the identifier lookup app."""
 
-    def __init__(self, client: ClientWrapper, admin_id: str,
-                 file_input: InputFileWrapper,
-                 identifiers_mode: IdentifiersMode):
+    def __init__(
+        self,
+        client: ClientWrapper,
+        admin_id: str,
+        file_input: InputFileWrapper,
+        identifiers_mode: IdentifiersMode,
+    ):
         super().__init__(client=client)
         self.__admin_id = admin_id
         self.__file_input = file_input
@@ -68,9 +74,8 @@ class IdentifierLookupVisitor(GearExecutionEnvironment):
 
     @classmethod
     def create(
-        cls, context: GearToolkitContext,
-        parameter_store: Optional[ParameterStore]
-    ) -> 'IdentifierLookupVisitor':
+        cls, context: GearToolkitContext, parameter_store: Optional[ParameterStore]
+    ) -> "IdentifierLookupVisitor":
         """Creates an identifier lookup execution visitor.
 
         Args:
@@ -81,19 +86,21 @@ class IdentifierLookupVisitor(GearExecutionEnvironment):
         """
         assert parameter_store, "Parameter store expected"
 
-        client = GearBotClient.create(context=context,
-                                      parameter_store=parameter_store)
-        file_input = InputFileWrapper.create(input_name='input_file',
-                                             context=context)
+        client = GearBotClient.create(
+            context=context, parameter_store=parameter_store)
+        file_input = InputFileWrapper.create(
+            input_name="input_file", context=context)
         assert file_input, "create raises exception if missing expected input"
 
         admin_id = context.config.get("admin_group", "nacc")
         mode = context.config.get("database_mode", "prod")
 
-        return IdentifierLookupVisitor(client=client,
-                                       admin_id=admin_id,
-                                       file_input=file_input,
-                                       identifiers_mode=mode)
+        return IdentifierLookupVisitor(
+            client=client,
+            admin_id=admin_id,
+            file_input=file_input,
+            identifiers_mode=mode,
+        )
 
     def run(self, context: GearToolkitContext):
         """Runs the identifier lookup app.
@@ -102,56 +109,86 @@ class IdentifierLookupVisitor(GearExecutionEnvironment):
             context: the gear execution context
         """
 
-        assert context, 'Gear context required'
+        assert context, "Gear context required"
 
         file_id = self.__file_input.file_id
         admin_group = self.admin_group(admin_id=self.__admin_id)
         adcid = admin_group.get_adcid(self.proxy.get_file_group(file_id))
         if adcid is None:
-            raise GearExecutionError('Unable to determine center ID for file')
+            raise GearExecutionError("Unable to determine center ID for file")
+
+        try:
+            file = self.proxy.get_file(file_id)
+        except ApiException as error:
+            raise GearExecutionError(
+                f"Failed to find the input file: {error}"
+            ) from error
+
+        project = self.proxy.get_project_by_id(file.parents.project)
+        if not project:
+            raise GearExecutionError(
+                f"Failed to find the project with ID {file.parents.project}"
+            )
 
         try:
             identifiers = get_identifiers(
                 identifiers_repo=IdentifiersLambdaRepository(
                     client=LambdaClient(client=create_lambda_client()),
-                    mode=self.__identifiers_mode),
-                adcid=adcid)
+                    mode=self.__identifiers_mode,
+                ),
+                adcid=adcid,
+            )
         except IdentifierRepositoryError as error:
             raise GearExecutionError(error) from error
 
         if not identifiers:
-            raise GearExecutionError('Unable to load center participant IDs')
+            raise GearExecutionError("Unable to load center participant IDs")
 
         module_name = self.__file_input.get_module_name_from_file_suffix()
         if not module_name:
             raise GearExecutionError(
-                'Expect module suffix to input file name: '
-                f'{self.__file_input.filename}')
+                "Expect module suffix to input file name: "
+                f"{self.__file_input.filename}"
+            )
+
+        date_field = (context.config.get(
+            "date_field", FieldNames.DATE_COLUMN)).lower()
+
+        gear_name = context.manifest.get("name", "identifier-lookup")
 
         (basename, extension) = os.path.splitext(self.__file_input.filename)
         filename = f"{basename}-identifier{extension}"
         input_path = Path(self.__file_input.filepath)
-        with (open(input_path, mode='r', encoding='utf-8') as csv_file,
-              context.open_output(filename, mode='w', encoding='utf-8') as
-              out_file):
-            error_writer = ListErrorWriter(container_id=file_id,
-                                           fw_path=self.proxy.get_lookup_path(
-                                               self.proxy.get_file(file_id)))
-            success = run(input_file=csv_file,
-                          identifiers=identifiers,
-                          module_name=module_name,
-                          adcid=adcid,
-                          output_file=out_file,
-                          error_writer=error_writer)
+        with (
+            open(input_path, mode="r", encoding="utf-8") as csv_file,
+            context.open_output(filename, mode="w", encoding="utf-8") as out_file,
+        ):
+            error_writer = ListErrorWriter(
+                container_id=file_id,
+                fw_path=self.proxy.get_lookup_path(
+                    self.proxy.get_file(file_id)),
+            )
+            success = run(
+                input_file=csv_file,
+                identifiers=identifiers,
+                module_name=module_name,
+                adcid=adcid,
+                output_file=out_file,
+                error_writer=error_writer,
+                date_field=date_field,
+                project=ProjectAdaptor(project=project, proxy=self.proxy),
+                gear_name=gear_name,
+            )
 
-            context.metadata.add_qc_result(self.__file_input.file_input,
-                                           name="validation",
-                                           state="PASS" if success else "FAIL",
-                                           data=error_writer.errors())
+            context.metadata.add_qc_result(
+                self.__file_input.file_input,
+                name="validation",
+                state="PASS" if success else "FAIL",
+                data=error_writer.errors(),
+            )
 
-            context.metadata.add_file_tags(self.__file_input.file_input,
-                                           tags=context.manifest.get(
-                                               'name', 'identifier-lookup'))
+            context.metadata.add_file_tags(
+                self.__file_input.file_input, tags=gear_name)
 
 
 def main():
@@ -163,8 +200,7 @@ def main():
     Writes errors to a CSV file compatible with Flywheel error UI.
     """
 
-    GearEngine.create_with_parameter_store().run(
-        gear_type=IdentifierLookupVisitor)
+    GearEngine.create_with_parameter_store().run(gear_type=IdentifierLookupVisitor)
 
 
 if __name__ == "__main__":

--- a/gear/identifier_lookup/src/python/identifier_app/run.py
+++ b/gear/identifier_lookup/src/python/identifier_app/run.py
@@ -1,6 +1,6 @@
 """Entrypoint script for the identifier lookup app."""
 
-import logging
+import logging  # noqa: I001
 import os
 from pathlib import Path
 from typing import Dict, Optional
@@ -16,6 +16,7 @@ from gear_execution.gear_execution import (
     GearExecutionError,
     InputFileWrapper,
 )
+from identifier_app.main import run
 from identifiers.identifiers_lambda_repository import (
     IdentifiersLambdaRepository,
     IdentifiersMode,
@@ -29,8 +30,6 @@ from inputs.parameter_store import ParameterStore
 from keys.keys import FieldNames
 from lambdas.lambda_function import LambdaClient, create_lambda_client
 from outputs.errors import ListErrorWriter
-
-from identifier_app.main import run
 
 log = logging.getLogger(__name__)
 

--- a/gear/identifier_lookup/src/python/identifier_app/run.py
+++ b/gear/identifier_lookup/src/python/identifier_app/run.py
@@ -1,6 +1,6 @@
 """Entrypoint script for the identifier lookup app."""
 
-import logging  # noqa: I001
+import logging
 import os
 from pathlib import Path
 from typing import Dict, Optional

--- a/gear/identifier_lookup/src/python/identifier_app/run.py
+++ b/gear/identifier_lookup/src/python/identifier_app/run.py
@@ -14,7 +14,6 @@ from gear_execution.gear_execution import (
     GearExecutionError,
     InputFileWrapper,
 )
-from identifier_app.main import run
 from identifiers.identifiers_lambda_repository import (
     IdentifiersLambdaRepository,
     IdentifiersMode,
@@ -27,6 +26,8 @@ from identifiers.model import IdentifierObject
 from inputs.parameter_store import ParameterStore
 from lambdas.lambda_function import LambdaClient, create_lambda_client
 from outputs.errors import ListErrorWriter
+
+from identifier_app.main import run
 
 log = logging.getLogger(__name__)
 

--- a/gear/identifier_lookup/src/python/identifier_app/run.py
+++ b/gear/identifier_lookup/src/python/identifier_app/run.py
@@ -35,9 +35,8 @@ from identifier_app.main import run
 log = logging.getLogger(__name__)
 
 
-def get_identifiers(
-    identifiers_repo: IdentifierRepository, adcid: int
-) -> Dict[str, IdentifierObject]:
+def get_identifiers(identifiers_repo: IdentifierRepository,
+                    adcid: int) -> Dict[str, IdentifierObject]:
     """Gets all of the Identifier objects from the identifier database using
     the RDSParameters.
 
@@ -52,7 +51,9 @@ def get_identifiers(
     if center_identifiers:
         # pylint: disable=(not-an-iterable)
         identifiers = {
-            identifier.ptid: identifier for identifier in center_identifiers}
+            identifier.ptid: identifier
+            for identifier in center_identifiers
+        }
 
     return identifiers
 
@@ -74,7 +75,8 @@ class IdentifierLookupVisitor(GearExecutionEnvironment):
 
     @classmethod
     def create(
-        cls, context: GearToolkitContext, parameter_store: Optional[ParameterStore]
+        cls, context: GearToolkitContext,
+        parameter_store: Optional[ParameterStore]
     ) -> "IdentifierLookupVisitor":
         """Creates an identifier lookup execution visitor.
 
@@ -86,10 +88,10 @@ class IdentifierLookupVisitor(GearExecutionEnvironment):
         """
         assert parameter_store, "Parameter store expected"
 
-        client = GearBotClient.create(
-            context=context, parameter_store=parameter_store)
-        file_input = InputFileWrapper.create(
-            input_name="input_file", context=context)
+        client = GearBotClient.create(context=context,
+                                      parameter_store=parameter_store)
+        file_input = InputFileWrapper.create(input_name="input_file",
+                                             context=context)
         assert file_input, "create raises exception if missing expected input"
 
         admin_id = context.config.get("admin_group", "nacc")
@@ -121,14 +123,12 @@ class IdentifierLookupVisitor(GearExecutionEnvironment):
             file = self.proxy.get_file(file_id)
         except ApiException as error:
             raise GearExecutionError(
-                f"Failed to find the input file: {error}"
-            ) from error
+                f"Failed to find the input file: {error}") from error
 
         project = self.proxy.get_project_by_id(file.parents.project)
         if not project:
             raise GearExecutionError(
-                f"Failed to find the project with ID {file.parents.project}"
-            )
+                f"Failed to find the project with ID {file.parents.project}")
 
         try:
             identifiers = get_identifiers(
@@ -148,11 +148,10 @@ class IdentifierLookupVisitor(GearExecutionEnvironment):
         if not module_name:
             raise GearExecutionError(
                 "Expect module suffix to input file name: "
-                f"{self.__file_input.filename}"
-            )
+                f"{self.__file_input.filename}")
 
-        date_field = (context.config.get(
-            "date_field", FieldNames.DATE_COLUMN)).lower()
+        date_field = (context.config.get("date_field",
+                                         FieldNames.DATE_COLUMN)).lower()
 
         gear_name = context.manifest.get("name", "identifier-lookup")
 
@@ -160,8 +159,9 @@ class IdentifierLookupVisitor(GearExecutionEnvironment):
         filename = f"{basename}-identifier{extension}"
         input_path = Path(self.__file_input.filepath)
         with (
-            open(input_path, mode="r", encoding="utf-8") as csv_file,
-            context.open_output(filename, mode="w", encoding="utf-8") as out_file,
+                open(input_path, mode="r", encoding="utf-8") as csv_file,
+                context.open_output(filename, mode="w", encoding="utf-8") as
+                out_file,
         ):
             error_writer = ListErrorWriter(
                 container_id=file_id,
@@ -187,8 +187,8 @@ class IdentifierLookupVisitor(GearExecutionEnvironment):
                 data=error_writer.errors(),
             )
 
-            context.metadata.add_file_tags(
-                self.__file_input.file_input, tags=gear_name)
+            context.metadata.add_file_tags(self.__file_input.file_input,
+                                           tags=gear_name)
 
 
 def main():
@@ -200,7 +200,8 @@ def main():
     Writes errors to a CSV file compatible with Flywheel error UI.
     """
 
-    GearEngine.create_with_parameter_store().run(gear_type=IdentifierLookupVisitor)
+    GearEngine.create_with_parameter_store().run(
+        gear_type=IdentifierLookupVisitor)
 
 
 if __name__ == "__main__":

--- a/gear/identifier_lookup/test/python/test_identifier_app.py
+++ b/gear/identifier_lookup/test/python/test_identifier_app.py
@@ -115,8 +115,8 @@ class TestIdentifierLookup:
                                 identifiers_map: dict[Any, Any]):
         """Test empty input stream."""
         out_stream = StringIO()
-        error_writer = ListErrorWriter(
-            container_id='dummy', fw_path='dummy-path')
+        error_writer = ListErrorWriter(container_id='dummy',
+                                       fw_path='dummy-path')
         success = run(input_file=empty_data_stream,
                       adcid=1,
                       identifiers=identifiers_map,
@@ -133,8 +133,8 @@ class TestIdentifierLookup:
                        identifiers_map: dict[Any, Any]):
         """Test case with no header."""
         out_stream = StringIO()
-        error_writer = ListErrorWriter(
-            container_id='dummy', fw_path='dummy-path')
+        error_writer = ListErrorWriter(container_id='dummy',
+                                       fw_path='dummy-path')
         success = run(input_file=no_header_stream,
                       adcid=1,
                       identifiers=identifiers_map,
@@ -142,8 +142,7 @@ class TestIdentifierLookup:
                       module_name='dummy-module',
                       error_writer=error_writer,
                       date_field='visitdate',
-                      gear_name='identifier-lookup'
-                      )
+                      gear_name='identifier-lookup')
         assert not success
         assert empty(out_stream)
         assert error_writer.errors()
@@ -152,8 +151,8 @@ class TestIdentifierLookup:
                                   identifiers_map: dict[Any, Any]):
         """Test case where header doesn't have ID columns."""
         out_stream = StringIO()
-        error_writer = ListErrorWriter(
-            container_id='dummy', fw_path='dummy-path')
+        error_writer = ListErrorWriter(container_id='dummy',
+                                       fw_path='dummy-path')
         success = run(input_file=no_ids_stream,
                       adcid=1,
                       identifiers=identifiers_map,
@@ -170,8 +169,8 @@ class TestIdentifierLookup:
                                     identifiers_map: dict[Any, Any]):
         """Test case where everything should match."""
         out_stream = StringIO()
-        error_writer = ListErrorWriter(
-            container_id='dummy', fw_path='dummy-path')
+        error_writer = ListErrorWriter(container_id='dummy',
+                                       fw_path='dummy-path')
         success = run(input_file=data_stream,
                       adcid=1,
                       identifiers=identifiers_map,
@@ -197,8 +196,8 @@ class TestIdentifierLookup:
                                                                        Any]):
         """Test case where there is no matching identifier."""
         out_stream = StringIO()
-        error_writer = ListErrorWriter(
-            container_id='dummy', fw_path='dummy-path')
+        error_writer = ListErrorWriter(container_id='dummy',
+                                       fw_path='dummy-path')
         success = run(input_file=data_stream,
                       identifiers=mismatched_identifiers_map,
                       adcid=1,

--- a/gear/identifier_provisioning/src/docker/BUILD
+++ b/gear/identifier_provisioning/src/docker/BUILD
@@ -7,5 +7,5 @@ docker_image(
         ":manifest",
         "gear/identifier_provisioning/src/python/identifier_provisioning_app:bin",
     ],
-    image_tags=["1.0.0", "latest"],
+    image_tags=["1.0.1", "latest"],
 )

--- a/gear/identifier_provisioning/src/docker/manifest.json
+++ b/gear/identifier_provisioning/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "identifier-provisioning",
     "label": "Identifier Provisioning",
     "description": "Gear for provisioning NACCIDs from Enrollment forms",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/identifier-provisioning:1.0.0"
+            "image": "naccdata/identifier-provisioning:1.0.1"
         },
         "flywheel": {
             "suite": "NACC Admin Gears",

--- a/gear/identifier_provisioning/src/python/identifier_provisioning_app/run.py
+++ b/gear/identifier_provisioning/src/python/identifier_provisioning_app/run.py
@@ -107,6 +107,7 @@ class IdentifierProvisioningVisitor(GearExecutionEnvironment):
                                      f'{file.parents.project}')
 
         input_path = Path(self.__file_input.filepath)
+        gear_name = context.manifest.get('name', 'identifier-provisioning')
         with open(input_path, mode='r', encoding='utf-8') as csv_file:
             error_writer = ListErrorWriter(
                 container_id=file_id, fw_path=self.proxy.get_lookup_path(file))
@@ -115,6 +116,7 @@ class IdentifierProvisioningVisitor(GearExecutionEnvironment):
                 center_id=adcid,
                 error_writer=error_writer,
                 enrollment_project=enrollment_project,
+                gear_name=gear_name,
                 repo=IdentifiersLambdaRepository(
                     client=LambdaClient(client=create_lambda_client()),
                     mode=self.__identifiers_mode))
@@ -125,9 +127,7 @@ class IdentifierProvisioningVisitor(GearExecutionEnvironment):
                                            data=error_writer.errors())
 
             context.metadata.add_file_tags(self.__file_input.file_input,
-                                           tags=context.manifest.get(
-                                               'name',
-                                               'identifier-provisioning'))
+                                           tags=gear_name)
 
 
 def main():

--- a/gear/redcap_error_checks_import/test/python/test_visitor.py
+++ b/gear/redcap_error_checks_import/test/python/test_visitor.py
@@ -97,7 +97,8 @@ class TestErrorCheckCSVVisitor:
 
         assert len(errors) == len(visitor.REQUIRED_HEADERS)
         for error in errors:
-            assert error['message'].startswith("Missing required field")
+            assert error['message'].startswith(
+                "Missing one or more required field(s)")
             assert error['message'].endswith("in the header")
 
     def test_visit_row(self, visitor, data):
@@ -129,7 +130,7 @@ class TestErrorCheckCSVVisitor:
         errors = list_handler.get_logs()
         assert len(errors) == 14
         for error in errors:
-            assert error['message'].endswith("is required") or \
+            assert error['message'].endswith("cannot be blank") or \
                 error['message'].startswith('Expected')
 
             for field in visitor.ALLOWED_EMPTY_FIELDS:


### PR DESCRIPTION
Move error metadata to visit error log files stored at project level. 
Error logs are named as <ptid>_<visit date>_<module>_qc-status.log
All the gears store metadata in the visit error logs for centralized error reporting
Visit log file content will have the cumulated history of qc status over the time for a particular visit. However, the log file metadata will only be for the latest submission of that visit.

This turned out to be a bigger PR than I expected. It would be easy check gear by gear and in the order of execution in the pipeline.

For form submissions
identifier-lookup -> form-transformer -> form-qc-coordinator -> form-qc-checker

For enrollment submissions
form-qc-checker -> identifier-provisioning