### PR TITLE
Add centerid lookup

### DIFF
--- a/docs/identifier_lookup/CHANGELOG.md
+++ b/docs/identifier_lookup/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this gear are documented in this file.
 
+## 1.0.0
+
+* Adds ability to do a reverse lookup on NACCID to find the center IDs.
+  Allows injecting the ADCID needed to split a CSV for distribution across centers.
+
 ## 0.1.0
 * Update error reporting - move error metadata to visit error log files stored at project level.
   

--- a/gear/identifier_lookup/src/docker/BUILD
+++ b/gear/identifier_lookup/src/docker/BUILD
@@ -6,5 +6,5 @@ docker_image(
     dependencies=[
         ":manifest", "gear/identifier_lookup/src/python/identifier_app:bin"
     ],
-    image_tags=["1.0.0", "latest"],
+    image_tags=["1.0.3", "latest"],
 )

--- a/gear/identifier_lookup/src/docker/BUILD
+++ b/gear/identifier_lookup/src/docker/BUILD
@@ -6,5 +6,5 @@ docker_image(
     dependencies=[
         ":manifest", "gear/identifier_lookup/src/python/identifier_app:bin"
     ],
-    image_tags=["0.1.0", "latest"],
+    image_tags=["1.0.0", "latest"],
 )

--- a/gear/identifier_lookup/src/docker/manifest.json
+++ b/gear/identifier_lookup/src/docker/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "identifier-lookup",
-    "label": "NACC ID Lookup",
-    "description": "Gear to check for NACC ID for incoming data",
+    "label": "Identifier Lookup",
+    "description": "Gear to look up participant identifiers for incoming data",
     "version": "1.0.0",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",

--- a/gear/identifier_lookup/src/docker/manifest.json
+++ b/gear/identifier_lookup/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "identifier-lookup",
     "label": "NACC ID Lookup",
     "description": "Gear to check for NACC ID for incoming data",
-    "version": "0.1.0",
+    "version": "1.0.0",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/identifier-lookup:0.1.0"
+            "image": "naccdata/identifier-lookup:1.0.0"
         },
         "flywheel": {
             "suite": "NACC Data Gears",

--- a/gear/identifier_lookup/src/docker/manifest.json
+++ b/gear/identifier_lookup/src/docker/manifest.json
@@ -27,7 +27,7 @@
             "base": "api-key"
         },
         "input_file": {
-            "description": "The CSV input file. Each row must have ADCID and PTID",
+            "description": "The CSV input file. Requires participant ID that matches mapping direction.",
             "base": "file",
             "type": {
                 "enum": [
@@ -58,7 +58,7 @@
             "default": "/prod/flywheel/gearbot"
         },
         "direction": {
-            "description": "Direction of identifier mapping: to nacc, or to center",
+            "description": "Direction of identifier mapping; 'nacc' to naccid, or 'center' to center",
             "type": "string",
             "default": "nacc"
         }

--- a/gear/identifier_lookup/src/docker/manifest.json
+++ b/gear/identifier_lookup/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "identifier-lookup",
     "label": "Identifier Lookup",
     "description": "Gear to look up participant identifiers for incoming data",
-    "version": "1.0.0",
+    "version": "1.0.3",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/identifier-lookup:1.0.0"
+            "image": "naccdata/identifier-lookup:1.0.3"
         },
         "flywheel": {
             "suite": "NACC Data Gears",

--- a/gear/identifier_lookup/src/docker/manifest.json
+++ b/gear/identifier_lookup/src/docker/manifest.json
@@ -56,6 +56,11 @@
             "description": "The instance specific AWS parameter gearbot path prefix",
             "type": "string",
             "default": "/prod/flywheel/gearbot"
+        },
+        "direction": {
+            "description": "Direction of identifier mapping: to nacc, or to center",
+            "type": "string",
+            "default": "nacc"
         }
     },
     "command": "/bin/run"

--- a/gear/identifier_lookup/src/python/identifier_app/main.py
+++ b/gear/identifier_lookup/src/python/identifier_app/main.py
@@ -4,6 +4,11 @@ import logging
 from typing import Any, Dict, List, Optional, TextIO
 
 from enrollment.enrollment_transfer import CenterValidator
+from gear_execution.gear_execution import GearExecutionError
+from identifiers.identifiers_repository import (
+    IdentifierRepository,
+    IdentifierRepositoryError,
+)
 from identifiers.model import IdentifierObject
 from inputs.csv_reader import CSVVisitor, read_csv
 from keys.keys import FieldNames
@@ -17,7 +22,7 @@ from outputs.outputs import CSVWriter
 log = logging.getLogger(__name__)
 
 
-class IdentifierVisitor(CSVVisitor):
+class NACCIDLookupVisitor(CSVVisitor):
     """A CSV Visitor class for adding a NACCID to the rows of a CSV input.
 
     Requires the input CSV has a PTID column, and all rows represent
@@ -35,7 +40,6 @@ class IdentifierVisitor(CSVVisitor):
             module_name: the module name for the form
             error_writer: the error output writer
         """
-        self.__adcid = adcid
         self.__identifiers = identifiers
         self.__output_file = output_file
         self.__error_writer = error_writer
@@ -111,8 +115,91 @@ class IdentifierVisitor(CSVVisitor):
         return True
 
 
-def run(*, input_file: TextIO, identifiers: Dict[str, IdentifierObject],
-        module_name: str, adcid: int, output_file: TextIO,
+class CenterLookupVisitor(CSVVisitor):
+    """Defines a CSV visitor class for adding ADCID, PTID to the rows of CSV
+    input.
+
+    Requires the input CSV has a NACCID column
+    """
+
+    def __init__(self, *, identifiers_repo: IdentifierRepository,
+                 output_file: TextIO, error_writer: ErrorWriter) -> None:
+        self.__identifiers_repo = identifiers_repo
+        self.__output_file = output_file
+        self.__error_writer = error_writer
+        self.__writer: Optional[CSVWriter] = None
+        self.__header: Optional[List[str]] = None
+
+    def __get_writer(self):
+        """Returns the writer for the CSV output.
+
+        Manages whether writer has been initialized. Requires that
+        header has been set.
+        """
+        if not self.__writer:
+            assert self.__header, "Header must be set before visiting any rows"
+            self.__writer = CSVWriter(stream=self.__output_file,
+                                      fieldnames=self.__header)
+
+        return self.__writer
+
+    def visit_header(self, header: List[str]) -> bool:
+        """Prepares the visitor to write a CSV file with the given header.
+
+        If the header doesn't have `naccid`, returns an error.
+
+        Args:
+          header: the list of header names
+        Returns:
+          True if `naccid` occurs in the header, False otherwise
+        """
+        expected_columns = {FieldNames.NACCID}
+        if not set(expected_columns).issubset(set(header)):
+            self.__error_writer.write(missing_field_error(expected_columns))
+            return False
+
+        self.__header = header
+        self.__header.append(FieldNames.ADCID)
+
+        return True
+
+    def visit_row(self, row: Dict[str, Any], line_num: int) -> bool:
+        """Finds the ADCID, PTID for the row from the NACCID, and outputs a row
+        to a CSV file with the ADCID and PTID inserted.
+
+        If the ADCID, PTID are not found for a row, an error is written to the
+        error file.
+
+        Args:
+          row: the dictionary from the CSV row (DictReader)
+          line_num: the line number of the row
+        Returns
+          True if there is a ADCID, PTID for the NACCID. False otherwise.
+        Raises:
+          GearExecutionError if the identifiers repository raises an error
+        """
+
+        try:
+            identifier = self.__identifiers_repo.get(
+                naccid=row[FieldNames.NACCID])
+        except IdentifierRepositoryError as error:
+            raise GearExecutionError(error) from error
+
+        if not identifier:
+            self.__error_writer.write(
+                identifier_error(line=line_num, value=row[FieldNames.NACCID]))
+            return False
+
+        row[FieldNames.ADCID] = identifier.adcid
+        row[FieldNames.PTID] = identifier.ptid
+
+        writer = self.__get_writer()
+        writer.write(row)
+
+        return True
+
+
+def run(*, input_file: TextIO, lookup_visitor: CSVVisitor,
         error_writer: ErrorWriter) -> bool:
     """Reads participant records from the input CSV file, finds the NACCID for
     each row from the ADCID and PTID, and outputs a CSV file with the NACCID
@@ -128,10 +215,7 @@ def run(*, input_file: TextIO, identifiers: Dict[str, IdentifierObject],
 
     Args:
       input_file: the data input stream
-      identifiers: the map from PTID to Identifier object
-      module_name: the module name for the form
-      adcid: ADCID for the center
-      output_file: the data output stream
+      lookup_visitor: the CSVVisitor for identifier lookup
       error_writer: the error output writer
     Returns:
       True if there were IDs with no corresponding NACCID
@@ -139,8 +223,4 @@ def run(*, input_file: TextIO, identifiers: Dict[str, IdentifierObject],
 
     return read_csv(input_file=input_file,
                     error_writer=error_writer,
-                    visitor=IdentifierVisitor(adcid=adcid,
-                                              identifiers=identifiers,
-                                              output_file=output_file,
-                                              module_name=module_name,
-                                              error_writer=error_writer))
+                    visitor=lookup_visitor)

--- a/gear/identifier_lookup/src/python/identifier_app/main.py
+++ b/gear/identifier_lookup/src/python/identifier_app/main.py
@@ -221,7 +221,7 @@ class CenterLookupVisitor(CSVVisitor):
           True if `naccid` occurs in the header, False otherwise
         """
         if (FieldNames.NACCID not in header
-                or FieldNames.NACCID.upper() not in header):
+                and FieldNames.NACCID.upper() not in header):
             self.__error_writer.write(missing_field_error(FieldNames.NACCID))
             return False
 
@@ -246,6 +246,7 @@ class CenterLookupVisitor(CSVVisitor):
         Raises:
           GearExecutionError if the identifiers repository raises an error
         """
+        row = { key.strip().lower(): value for key, value in row.items() }
 
         try:
             identifier = self.__identifiers_repo.get(

--- a/gear/identifier_lookup/src/python/identifier_app/main.py
+++ b/gear/identifier_lookup/src/python/identifier_app/main.py
@@ -270,8 +270,11 @@ class CenterLookupVisitor(CSVVisitor):
         return True
 
 
-def run(*, input_file: TextIO, error_writer: ListErrorWriter,
-        lookup_visitor: CSVVisitor) -> bool:
+def run(*,
+        input_file: TextIO,
+        error_writer: ListErrorWriter,
+        lookup_visitor: CSVVisitor,
+        clear_errors: bool = False) -> bool:
     """Reads participant records from the input CSV file and applies the ID
     lookup visitor to insert corresponding IDs.
 
@@ -279,6 +282,7 @@ def run(*, input_file: TextIO, error_writer: ListErrorWriter,
       input_file: the data input stream
       lookup_visitor: the CSVVisitor for identifier lookup
       error_writer: the error output writer
+      clear_errors: clear the accumulated error metadata
 
     Returns:
       True if there were IDs with no corresponding ID by lookup visitor
@@ -286,4 +290,5 @@ def run(*, input_file: TextIO, error_writer: ListErrorWriter,
 
     return read_csv(input_file=input_file,
                     error_writer=error_writer,
-                    visitor=lookup_visitor)
+                    visitor=lookup_visitor,
+                    clear_errors=clear_errors)

--- a/gear/identifier_lookup/src/python/identifier_app/main.py
+++ b/gear/identifier_lookup/src/python/identifier_app/main.py
@@ -153,13 +153,13 @@ class CenterLookupVisitor(CSVVisitor):
         Returns:
           True if `naccid` occurs in the header, False otherwise
         """
-        expected_columns = {FieldNames.NACCID}
-        if not set(expected_columns).issubset(set(header)):
-            self.__error_writer.write(missing_field_error(expected_columns))
+        if FieldNames.NACCID not in header or FieldNames.NACCID.upper() not in header:
+            self.__error_writer.write(missing_field_error(FieldNames.NACCID))
             return False
 
         self.__header = header
         self.__header.append(FieldNames.ADCID)
+        self.__header.append(FieldNames.PTID)
 
         return True
 

--- a/gear/identifier_lookup/src/python/identifier_app/main.py
+++ b/gear/identifier_lookup/src/python/identifier_app/main.py
@@ -246,13 +246,15 @@ class CenterLookupVisitor(CSVVisitor):
         Raises:
           GearExecutionError if the identifiers repository raises an error
         """
-        row = { key.strip().lower(): value for key, value in row.items() }
+        row = {key.strip().lower(): value for key, value in row.items()}
 
         try:
             identifier = self.__identifiers_repo.get(
                 naccid=row[FieldNames.NACCID])
         except IdentifierRepositoryError as error:
-            raise GearExecutionError(error) from error
+            raise GearExecutionError(
+                f"Lookup of {row[FieldNames.NACCID]} failed: {error}"
+            ) from error
 
         if not identifier:
             self.__error_writer.write(

--- a/gear/identifier_lookup/src/python/identifier_app/main.py
+++ b/gear/identifier_lookup/src/python/identifier_app/main.py
@@ -220,8 +220,8 @@ class CenterLookupVisitor(CSVVisitor):
         Returns:
           True if `naccid` occurs in the header, False otherwise
         """
-        if FieldNames.NACCID not in header or FieldNames.NACCID.upper(
-        ) not in header:
+        if (FieldNames.NACCID not in header
+                or FieldNames.NACCID.upper() not in header):
             self.__error_writer.write(missing_field_error(FieldNames.NACCID))
             return False
 

--- a/gear/identifier_lookup/src/python/identifier_app/run.py
+++ b/gear/identifier_lookup/src/python/identifier_app/run.py
@@ -162,7 +162,6 @@ class IdentifierLookupVisitor(GearExecutionEnvironment):
                                    output_file=output_file,
                                    error_writer=error_writer)
 
-
     def run(self, context: GearToolkitContext):
         """Runs the identifier lookup app.
 

--- a/gear/identifier_lookup/src/python/identifier_app/run.py
+++ b/gear/identifier_lookup/src/python/identifier_app/run.py
@@ -186,12 +186,14 @@ class IdentifierLookupVisitor(GearExecutionEnvironment):
                                            fw_path=self.proxy.get_lookup_path(
                                                self.proxy.get_file(file_id)))
 
+            clear_errors = False
             if self.__direction == 'nacc':
                 lookup_visitor = self.__build_naccid_lookup(
                     file_id=file_id,
                     identifiers_repo=identifiers_repo,
                     output_file=out_file,
                     error_writer=error_writer)
+                clear_errors = True
             elif self.__direction == 'center':
                 lookup_visitor = self.__build_center_lookup(
                     identifiers_repo=identifiers_repo,
@@ -200,7 +202,8 @@ class IdentifierLookupVisitor(GearExecutionEnvironment):
 
             success = run(input_file=csv_file,
                           lookup_visitor=lookup_visitor,
-                          error_writer=error_writer)
+                          error_writer=error_writer,
+                          clear_errors=clear_errors)
 
             context.metadata.add_qc_result(
                 self.__file_input.file_input,

--- a/gear/identifier_lookup/test/python/test_identifier_app.py
+++ b/gear/identifier_lookup/test/python/test_identifier_app.py
@@ -123,7 +123,9 @@ class TestIdentifierLookup:
                           identifiers=identifiers_map,
                           output_file=out_stream,
                           module_name='dummy-module',
-                          error_writer=error_writer),
+                          error_writer=error_writer,
+                          date_field='visitdate',
+                          gear_name='dummy'),
                       error_writer=error_writer)
         assert not success
         assert empty(out_stream)
@@ -141,7 +143,9 @@ class TestIdentifierLookup:
                           identifiers=identifiers_map,
                           output_file=out_stream,
                           module_name='dummy-module',
-                          error_writer=error_writer),
+                          error_writer=error_writer,
+                          date_field='visitdate',
+                          gear_name='dummy'),
                       error_writer=error_writer)
         assert not success
         assert empty(out_stream)
@@ -159,7 +163,9 @@ class TestIdentifierLookup:
                           identifiers=identifiers_map,
                           output_file=out_stream,
                           module_name='dummy-module',
-                          error_writer=error_writer),
+                          error_writer=error_writer,
+                          date_field='visitdate',
+                          gear_name='dummy'),
                       error_writer=error_writer)
         assert not success
         assert empty(out_stream)
@@ -177,7 +183,9 @@ class TestIdentifierLookup:
                           identifiers=identifiers_map,
                           output_file=out_stream,
                           module_name='dummy-module',
-                          error_writer=error_writer),
+                          error_writer=error_writer,
+                          date_field='visitdate',
+                          gear_name='dummy'),
                       error_writer=error_writer)
         assert success
         assert not error_writer.errors()
@@ -204,7 +212,9 @@ class TestIdentifierLookup:
                           adcid=1,
                           output_file=out_stream,
                           module_name='dummy-module',
-                          error_writer=error_writer),
+                          error_writer=error_writer,
+                          date_field='visitdate',
+                          gear_name='dummy'),
                       error_writer=error_writer)
         assert not success
         assert empty(out_stream)

--- a/gear/identifier_lookup/test/python/test_identifier_app.py
+++ b/gear/identifier_lookup/test/python/test_identifier_app.py
@@ -4,7 +4,7 @@ from io import StringIO
 from typing import Any, List
 
 import pytest
-from identifier_app.main import run
+from identifier_app.main import NACCIDLookupVisitor, run
 from identifiers.model import IdentifierObject
 from outputs.errors import StreamErrorWriter
 
@@ -115,14 +115,17 @@ class TestIdentifierLookup:
         """Test empty input stream."""
         out_stream = StringIO()
         err_stream = StringIO()
+        error_writer = StreamErrorWriter(stream=err_stream,
+                                         container_id='dummy',
+                                         fw_path='dummy-path')
         success = run(input_file=empty_data_stream,
-                      adcid=1,
-                      identifiers=identifiers_map,
-                      output_file=out_stream,
-                      module_name='dummy-module',
-                      error_writer=StreamErrorWriter(stream=err_stream,
-                                                     container_id='dummy',
-                                                     fw_path='dummy-path'))
+                      lookup_visitor=NACCIDLookupVisitor(
+                          adcid=1,
+                          identifiers=identifiers_map,
+                          output_file=out_stream,
+                          module_name='dummy-module',
+                          error_writer=error_writer),
+                      error_writer=error_writer)
         assert not success
         assert empty(out_stream)
         assert not empty(err_stream)
@@ -132,14 +135,17 @@ class TestIdentifierLookup:
         """Test case with no header."""
         out_stream = StringIO()
         err_stream = StringIO()
+        error_writer = StreamErrorWriter(stream=err_stream,
+                                         container_id='dummy',
+                                         fw_path='dummy-path')
         success = run(input_file=no_header_stream,
-                      adcid=1,
-                      identifiers=identifiers_map,
-                      output_file=out_stream,
-                      module_name='dummy-module',
-                      error_writer=StreamErrorWriter(stream=err_stream,
-                                                     container_id='dummy',
-                                                     fw_path='dummy-path'))
+                      lookup_visitor=NACCIDLookupVisitor(
+                          adcid=1,
+                          identifiers=identifiers_map,
+                          output_file=out_stream,
+                          module_name='dummy-module',
+                          error_writer=error_writer),
+                      error_writer=error_writer)
         assert not success
         assert empty(out_stream)
         assert not empty(err_stream)
@@ -149,14 +155,17 @@ class TestIdentifierLookup:
         """Test case where header doesn't have ID columns."""
         out_stream = StringIO()
         err_stream = StringIO()
+        error_writer = StreamErrorWriter(stream=err_stream,
+                                         container_id='dummy',
+                                         fw_path='dummy-path')
         success = run(input_file=no_ids_stream,
-                      adcid=1,
-                      identifiers=identifiers_map,
-                      output_file=out_stream,
-                      module_name='dummy-module',
-                      error_writer=StreamErrorWriter(stream=err_stream,
-                                                     container_id='dummy',
-                                                     fw_path='dummy-path'))
+                      lookup_visitor=NACCIDLookupVisitor(
+                          adcid=1,
+                          identifiers=identifiers_map,
+                          output_file=out_stream,
+                          module_name='dummy-module',
+                          error_writer=error_writer),
+                      error_writer=error_writer)
         assert not success
         assert empty(out_stream)
         assert not empty(err_stream)
@@ -166,14 +175,17 @@ class TestIdentifierLookup:
         """Test case where everything should match."""
         out_stream = StringIO()
         err_stream = StringIO()
+        error_writer = StreamErrorWriter(stream=err_stream,
+                                         container_id='dummy',
+                                         fw_path='dummy-path')
         success = run(input_file=data_stream,
-                      adcid=1,
-                      identifiers=identifiers_map,
-                      output_file=out_stream,
-                      module_name='dummy-module',
-                      error_writer=StreamErrorWriter(stream=err_stream,
-                                                     container_id='dummy',
-                                                     fw_path='dummy-path'))
+                      lookup_visitor=NACCIDLookupVisitor(
+                          adcid=1,
+                          identifiers=identifiers_map,
+                          output_file=out_stream,
+                          module_name='dummy-module',
+                          error_writer=error_writer),
+                      error_writer=error_writer)
         assert success
         assert empty(err_stream)
         assert not empty(out_stream)
@@ -192,14 +204,17 @@ class TestIdentifierLookup:
         """Test case where there is no matching identifier."""
         out_stream = StringIO()
         err_stream = StringIO()
+        error_writer = StreamErrorWriter(stream=err_stream,
+                                         container_id='dummy',
+                                         fw_path='dummy-path')
         success = run(input_file=data_stream,
-                      identifiers=mismatched_identifiers_map,
-                      adcid=1,
-                      output_file=out_stream,
-                      module_name='dummy-module',
-                      error_writer=StreamErrorWriter(stream=err_stream,
-                                                     container_id='dummy',
-                                                     fw_path='dummy-path'))
+                      lookup_visitor=NACCIDLookupVisitor(
+                          identifiers=mismatched_identifiers_map,
+                          adcid=1,
+                          output_file=out_stream,
+                          module_name='dummy-module',
+                          error_writer=error_writer),
+                      error_writer=error_writer)
         assert not success
         assert empty(out_stream)
         assert not empty(err_stream)


### PR DESCRIPTION
Refactors and extends the identifier lookup gear to allow looking up ADCID-PTID pair from NACCID.
This enables splitting a CSV file with just NACCID across centers.