### PR TITLE
Only do created user process immediately after user creation

### DIFF
--- a/common/src/python/users/user_processes.py
+++ b/common/src/python/users/user_processes.py
@@ -408,6 +408,8 @@ class ClaimedUserProcess(BaseUserProcess[RegisteredUserEntry]):
             if not self.__add_user(entry):
                 return
 
+            self.__created_queue.enqueue(entry)
+
             log.info('Added user %s', entry.registry_id)
 
         fw_user = self.__env.proxy.find_user(entry.registry_id)
@@ -415,9 +417,6 @@ class ClaimedUserProcess(BaseUserProcess[RegisteredUserEntry]):
             log.error('Failed to find user %s with ID %s', entry.email,
                       entry.registry_id)
             return
-
-        if not fw_user.firstlogin:
-            self.__created_queue.enqueue(entry)
 
         self.__update_queue.enqueue(entry)
 


### PR DESCRIPTION
Changes when a user entry is added to the created queue so that it is only added immediately after the user is created. It had been adding the entry if the user has not logged in, which was resulting in an email being sent every night. The downside is that people are not reminded that they haven't logged in.