### PR TITLE
Refactor/identifier fields

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,6 +24,7 @@
         "apoe",
         "devcontainer",
         "NACC",
+        "naccadc",
         "naccid",
         "ptid"
     ]

--- a/common/src/python/enrollment/enrollment_subject.py
+++ b/common/src/python/enrollment/enrollment_subject.py
@@ -4,9 +4,9 @@ from datetime import datetime
 from typing import Optional
 
 from flywheel_adaptor.subject_adaptor import SubjectAdaptor
-from identifiers.model import GUID_PATTERN, NACCID_PATTERN
+from identifiers.model import CenterFields, GUIDField, NACCIDField
 from keys.keys import DefaultValues
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import BaseModel, ValidationError
 
 from enrollment.enrollment_transfer import (
     Demographics,
@@ -15,12 +15,8 @@ from enrollment.enrollment_transfer import (
 )
 
 
-class IdentifierInfoRecord(BaseModel):
+class IdentifierInfoRecord(CenterFields, GUIDField, NACCIDField):
     """Info object for enrollment identifiers object."""
-    adcid: int = Field(ge=0)
-    ptid: str = Field(max_length=10)
-    naccid: str = Field(max_length=10, pattern=NACCID_PATTERN)
-    guid: Optional[str] = Field(max_length=13, pattern=GUID_PATTERN)
     update_date: datetime
 
 

--- a/common/src/python/enrollment/enrollment_transfer.py
+++ b/common/src/python/enrollment/enrollment_transfer.py
@@ -11,10 +11,11 @@ from identifiers.identifiers_repository import (
     IdentifierRepository,
 )
 from identifiers.model import (
-    GUID_PATTERN,
     NACCID_PATTERN,
     PTID_PATTERN,
     CenterIdentifiers,
+    GUIDField,
+    OptionalNACCIDField,
 )
 from inputs.csv_reader import RowValidator
 from keys.keys import FieldNames, SysErrorCodes
@@ -90,11 +91,9 @@ class TransferRecord(BaseModel):
     naccid: Optional[str] = Field(None, max_length=10, pattern=NACCID_PATTERN)
 
 
-class EnrollmentRecord(BaseModel):
+class EnrollmentRecord(GUIDField, OptionalNACCIDField):
     """Model representing enrollment of participant."""
     center_identifier: CenterIdentifiers
-    naccid: Optional[str] = Field(None, max_length=10, pattern=NACCID_PATTERN)
-    guid: Optional[str] = Field(None, max_length=20, pattern=GUID_PATTERN)
     start_date: datetime
     end_date: Optional[datetime] = None
     transfer_from: Optional[TransferRecord] = None

--- a/common/src/python/identifiers/identifiers_lambda_repository.py
+++ b/common/src/python/identifiers/identifiers_lambda_repository.py
@@ -11,11 +11,12 @@ from identifiers.identifiers_repository import (
     IdentifierRepositoryError,
 )
 from identifiers.model import (
-    GUID_PATTERN,
-    NACCID_PATTERN,
+    ADCIDField,
     CenterIdentifiers,
+    GUIDField,
     IdentifierList,
     IdentifierObject,
+    NACCIDField,
 )
 
 
@@ -25,9 +26,8 @@ class ListRequest(BaseRequest):
     limit: int = Field(le=100)
 
 
-class IdentifierRequest(BaseRequest, CenterIdentifiers):
+class IdentifierRequest(BaseRequest, CenterIdentifiers, GUIDField):
     """Request model for creating Identifier."""
-    guid: Optional[str] = Field(None, max_length=13, pattern=GUID_PATTERN)
 
 
 class IdentifierListRequest(BaseRequest):
@@ -35,19 +35,16 @@ class IdentifierListRequest(BaseRequest):
     identifiers: List[IdentifierQueryObject]
 
 
-class ADCIDRequest(ListRequest):
+class ADCIDRequest(ListRequest, ADCIDField):
     """Model for request object with ADCID, and offset and limit."""
-    adcid: int = Field(ge=0)
 
 
-class GUIDRequest(BaseRequest):
+class GUIDRequest(BaseRequest, GUIDField):
     """Request model for search by GUID."""
-    guid: str = Field(max_length=13, pattern=GUID_PATTERN)
 
 
-class NACCIDRequest(BaseRequest):
+class NACCIDRequest(BaseRequest, NACCIDField):
     """Request model for search by NACCID."""
-    naccid: str = Field(max_length=10, pattern=NACCID_PATTERN)
 
 
 class ListResponseObject(BaseModel):

--- a/common/src/python/identifiers/identifiers_repository.py
+++ b/common/src/python/identifiers/identifiers_repository.py
@@ -9,11 +9,9 @@ import logging
 from abc import abstractmethod
 from typing import List, Optional, overload
 
-from pydantic import Field
-
 from identifiers.model import (
-    GUID_PATTERN,
     CenterIdentifiers,
+    GUIDField,
     IdentifierList,
     IdentifierObject,
 )
@@ -21,9 +19,8 @@ from identifiers.model import (
 log = logging.getLogger(__name__)
 
 
-class IdentifierQueryObject(CenterIdentifiers):
+class IdentifierQueryObject(CenterIdentifiers, GUIDField):
     """Query model creating objects."""
-    guid: Optional[str] = Field(None, max_length=13, pattern=GUID_PATTERN)
 
 
 class IdentifierRepository(abc.ABC):

--- a/common/src/python/identifiers/model.py
+++ b/common/src/python/identifiers/model.py
@@ -8,16 +8,41 @@ NACCID_PATTERN = r"^NACC\d{6}$"
 PTID_PATTERN = r"^[a-zA-Z0-9-]{1,10}$"
 
 
-class IdentifierObject(BaseModel):
+class GUIDField(BaseModel):
+    """Base model for models with guid."""
+    guid: Optional[str] = Field(None, max_length=20, pattern=GUID_PATTERN)
+
+
+class ADCIDField(BaseModel):
+    """Base model for models with adcid."""
+    adcid: int = Field(ge=0)
+
+
+class CenterFields(ADCIDField):
+    """Base model for models with center ids."""
+    ptid: str = Field(max_length=10)
+
+
+class NACCADCField(BaseModel):
+    """Base model for models with naccadc."""
+    naccadc: int = Field(ge=0)
+
+
+class NACCIDField(BaseModel):
+    """Base model for models with naccid."""
+    naccid: str = Field(max_length=10, pattern=NACCID_PATTERN)
+
+
+class OptionalNACCIDField(BaseModel):
+    """Base model for models with optional naccid."""
+    naccid: Optional[str] = Field(max_length=10, pattern=NACCID_PATTERN)
+
+
+class IdentifierObject(CenterFields, GUIDField, NACCADCField, NACCIDField):
     """Response model for identifiers.
 
     Hides unconventional naming of fields and has NACCID as string.
     """
-    adcid: int = Field(ge=0)
-    naccadc: int
-    ptid: str = Field(max_length=10)
-    naccid: str = Field(max_length=10, pattern=NACCID_PATTERN)
-    guid: Optional[str] = Field(None, max_length=13, pattern=GUID_PATTERN)
 
 
 class IdentifierList(RootModel):
@@ -44,15 +69,11 @@ class IdentifierList(RootModel):
         self.root.append(identifier)
 
 
-class CenterIdentifiers(BaseModel):
+class CenterIdentifiers(CenterFields):
     """Model for ADCID, PTID pair."""
-    adcid: int = Field(ge=0)
-    ptid: str = Field(max_length=10)
 
 
-class ParticipantIdentifiers(BaseModel):
+class ParticipantIdentifiers(NACCIDField, GUIDField):
     """Model for participant identifiers."""
     center_identifiers: CenterIdentifiers
-    naccid: str = Field(max_length=10, pattern=NACCID_PATTERN)
     aliases: Optional[List[str]]
-    guid: Optional[str]


### PR DESCRIPTION
Factors duplicated fields out of pydantic data models to avoid having multiple definitions of fields.

Also, fixes a bug where the GUID field was defined as length 20 in one place but 13 in all the others.

Note: `EnrollmentRecord` did define naccid as optional, so ended up with a base model where it is optional and one where it is not. Not sure if there is a different way to do this, but at least the two definitions are adjacent in the file.