### PR TITLE
Identifier Lookup: Fix case bug

### DIFF
--- a/docs/identifier_lookup/CHANGELOG.md
+++ b/docs/identifier_lookup/CHANGELOG.md
@@ -2,15 +2,9 @@
 
 All notable changes to this gear are documented in this file.
 
-<<<<<<< HEAD
 ## 1.0.9
-* Fixes bug where `CenterLookupVisitor.visit_row` was setting the keys to lowercase, causing `writer.write()` to fail with case-sensitive headers
 * Adds `preserve_case` configuration value (default `false`) to allow preserving case of header keys in output file
-=======
-## 1.0.9 (Unreleased)
-
 * Refactors to use `InputFileWrapper.get_parent_project`
->>>>>>> main
 
 ## 1.0.8
 * Fixes CSV line number in error reports (exclude header row)

--- a/docs/identifier_lookup/CHANGELOG.md
+++ b/docs/identifier_lookup/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this gear are documented in this file.
 
+## 1.0.9
+* Fixes bug where `CenterLookupVisitor.visit_row` was setting the keys to lowercase, causing `writer.write()` to fail with case-sensitive headers
+
 ## 1.0.8
 * Fixes CSV line number in error reports (exclude header row)
 * Updates pre-processing error codes

--- a/docs/identifier_lookup/CHANGELOG.md
+++ b/docs/identifier_lookup/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this gear are documented in this file.
 
 ## 1.0.9
 * Fixes bug where `CenterLookupVisitor.visit_row` was setting the keys to lowercase, causing `writer.write()` to fail with case-sensitive headers
+* Adds `preserve_case` configuration value (default `false`) to allow preserving case of header keys in output file
 
 ## 1.0.8
 * Fixes CSV line number in error reports (exclude header row)

--- a/docs/identifier_lookup/index.md
+++ b/docs/identifier_lookup/index.md
@@ -1,7 +1,10 @@
 # Identifier Lookup
 
-The identifier-lookup gear reads participant IDs from a tabular (CSV) input file and checks whether each ID corresponds to a NACCID (the NACC-assigned participant ID).
-The input file is assumed to have one participant per row with columns `adcid` (NACC-assigned center ID), and `ptid` (center-assigned participant ID).
+The identifier-lookup gear reads participant IDs from a tabular (CSV) input file and checks whether each ID corresponds to a NACCID (the NACC-assigned participant ID). This gear supports two directions: `nacc` and `center`.
+
+If the direction is `nacc`, the input file is assumed to have one participant per row with columns `adcid` (NACC-assigned center ID), and `ptid` (center-assigned participant ID), and will append `naccid` to the output.
+
+If the direction is `center`, the input file is assumed to have one participant per row with a `naccid` column, and will append `adcid` and `ptid` to the output.
 
 The gear outputs a copy of the CSV file consisting of the rows for participants that have NACCIDs, with an added `naccid` column for the NACCID.
 
@@ -26,7 +29,8 @@ The input is a single CSV file, which must have columns `adcid` and `ptid`.
 
 The gear has two output files.
 
-- A CSV file consisting of the rows of the input file for which a NACCID was found, with an additional `naccid` column.
+- A CSV file consisting of the rows of the input file for which a NACCID was found, with an additional `naccid` column if the direction is `nacc` or additional `adcid` and `ptid` columns if the direction is `center`
+  - Unless the configuration value `preserve_case` is set to `True`, all header keys will also be forced to lower case and spaces replaced with `_`
 - A CSV file indicating errors, and specifically information about rows for which a NACCID was not found.
   The format of this file is determined by the FW interface for displaying errors.
 

--- a/gear/identifier_lookup/src/docker/BUILD
+++ b/gear/identifier_lookup/src/docker/BUILD
@@ -6,5 +6,5 @@ docker_image(
     dependencies=[
         ":manifest", "gear/identifier_lookup/src/python/identifier_app:bin"
     ],
-    image_tags=["1.0.8", "latest"],
+    image_tags=["1.0.9", "latest"],
 )

--- a/gear/identifier_lookup/src/docker/BUILD
+++ b/gear/identifier_lookup/src/docker/BUILD
@@ -6,5 +6,5 @@ docker_image(
     dependencies=[
         ":manifest", "gear/identifier_lookup/src/python/identifier_app:bin"
     ],
-    image_tags=["1.0.9", "latest"],
+    image_tags=["1.0.9a", "latest"],
 )

--- a/gear/identifier_lookup/src/docker/manifest.json
+++ b/gear/identifier_lookup/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "identifier-lookup",
     "label": "Identifier Lookup",
     "description": "Gear to look up participant identifiers for incoming data",
-    "version": "1.0.9",
+    "version": "1.0.9a",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/identifier-lookup:1.0.9"
+            "image": "naccdata/identifier-lookup:1.0.9a"
         },
         "flywheel": {
             "suite": "NACC Data Gears",
@@ -66,6 +66,11 @@
             "description": "Direction of identifier mapping; 'nacc' to naccid, or 'center' to center",
             "type": "string",
             "default": "nacc"
+        },
+        "preserve_case": {
+            "description": "Whether or not to preserve the case of the header keys in the input file",
+            "type": "boolean",
+            "default": false
         }
     },
     "command": "/bin/run"

--- a/gear/identifier_lookup/src/docker/manifest.json
+++ b/gear/identifier_lookup/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "identifier-lookup",
     "label": "Identifier Lookup",
     "description": "Gear to look up participant identifiers for incoming data",
-    "version": "1.0.8",
+    "version": "1.0.9",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/identifier-lookup:1.0.8"
+            "image": "naccdata/identifier-lookup:1.0.9"
         },
         "flywheel": {
             "suite": "NACC Data Gears",

--- a/gear/identifier_lookup/src/python/identifier_app/main.py
+++ b/gear/identifier_lookup/src/python/identifier_app/main.py
@@ -41,7 +41,8 @@ class NACCIDLookupVisitor(CSVVisitor):
                  error_writer: ListErrorWriter,
                  date_field: str,
                  gear_name: str,
-                 project: Optional[ProjectAdaptor] = None) -> None:
+                 project: Optional[ProjectAdaptor] = None,
+                 preserve_case: bool = False) -> None:
         """
         Args:
             adcid: ADCID for the center
@@ -52,6 +53,8 @@ class NACCIDLookupVisitor(CSVVisitor):
             date_field: visit date field for the module
             gear_name: gear name
             project: Flywheel project adaptor
+            preserve_case: whether or not to preserve the case of the
+                header keys
         """
         self.__identifiers = identifiers
         self.__output_file = output_file
@@ -60,6 +63,7 @@ class NACCIDLookupVisitor(CSVVisitor):
         self.__date_field = date_field
         self.__project = project
         self.__gear_name = gear_name
+        self.__preserve_case: bool = preserve_case
         self.__header: Optional[List[str]] = None
         self.__writer: Optional[CSVWriter] = None
         self.__validator = CenterValidator(center_id=adcid,
@@ -101,6 +105,10 @@ class NACCIDLookupVisitor(CSVVisitor):
             self.__error_writer.write(missing_field_error(self.__req_fields))
             return False
 
+        if not self.__preserve_case:
+            for i, field in enumerate(header):
+                header[i] = field.strip().lower().replace(' ', '_')
+
         self.__header = header
         self.__header.append(FieldNames.NACCID)
         self.__header.append(FieldNames.MODULE)
@@ -121,6 +129,9 @@ class NACCIDLookupVisitor(CSVVisitor):
         Returns:
           True if there is a NACCID for the PTID, False otherwise
         """
+        if not self.__preserve_case:
+            row = {key.strip().lower().replace(' ', '_'): value
+                   for key, value in row.items()}
 
         self.__error_writer.clear()
 
@@ -193,11 +204,15 @@ class CenterLookupVisitor(CSVVisitor):
     Requires the input CSV has a NACCID column
     """
 
-    def __init__(self, *, identifiers_repo: IdentifierRepository,
-                 output_file: TextIO, error_writer: ListErrorWriter) -> None:
+    def __init__(self, *,
+                 identifiers_repo: IdentifierRepository,
+                 output_file: TextIO,
+                 error_writer: ListErrorWriter,
+                 preserve_case: bool = False) -> None:
         self.__identifiers_repo = identifiers_repo
         self.__output_file = output_file
         self.__error_writer = error_writer
+        self.__preserve_case: bool = preserve_case
         self.__writer: Optional[CSVWriter] = None
         self.__header: Optional[List[str]] = None
 
@@ -229,6 +244,12 @@ class CenterLookupVisitor(CSVVisitor):
             self.__error_writer.write(missing_field_error(FieldNames.NACCID))
             return False
 
+        # if not preserving, convert headers to lowercase and replace any
+        # spaces with an underscsore
+        if not self.__preserve_case:
+            for i, field in enumerate(header):
+                header[i] = field.strip().lower().replace(' ', '_')
+
         self.__header = header
         self.__header.append(FieldNames.ADCID)
         self.__header.append(FieldNames.PTID)
@@ -250,7 +271,10 @@ class CenterLookupVisitor(CSVVisitor):
         Raises:
           GearExecutionError if the identifiers repository raises an error
         """
-        row = {key.strip(): value for key, value in row.items()}
+        if not self.__preserve_case:
+            row = {key.strip().lower().replace(' ', '_'): value
+                   for key, value in row.items()}
+
         naccid = row.get(FieldNames.NACCID,
                          row.get(FieldNames.NACCID.upper(), None))
 

--- a/gear/identifier_lookup/src/python/identifier_app/main.py
+++ b/gear/identifier_lookup/src/python/identifier_app/main.py
@@ -251,15 +251,17 @@ class CenterLookupVisitor(CSVVisitor):
           GearExecutionError if the identifiers repository raises an error
         """
         row = {key.strip(): value for key, value in row.items()}
-        naccid = row.get(FieldNames.NACCID, row[FieldNames.NACCID.upper()])
+        naccid = row.get(FieldNames.NACCID,
+                         row.get(FieldNames.NACCID.upper(), None))
+
+        if naccid is None:
+            raise GearExecutionError(f"NACCID not found in row {line_num}")
 
         try:
-            identifier = self.__identifiers_repo.get(
-                naccid=naccid)
+            identifier = self.__identifiers_repo.get(naccid=naccid)
         except IdentifierRepositoryError as error:
             raise GearExecutionError(
-                f"Lookup of {naccid} failed: {error}"
-            ) from error
+                f"Lookup of {naccid} failed: {error}") from error
 
         if not identifier:
             self.__error_writer.write(

--- a/gear/identifier_lookup/src/python/identifier_app/main.py
+++ b/gear/identifier_lookup/src/python/identifier_app/main.py
@@ -251,18 +251,19 @@ class CenterLookupVisitor(CSVVisitor):
           GearExecutionError if the identifiers repository raises an error
         """
         row = {key.strip(): value for key, value in row.items()}
+        naccid = row.get(FieldNames.NACCID, row[FieldNames.NACCID.upper()])
 
         try:
             identifier = self.__identifiers_repo.get(
-                naccid=row[FieldNames.NACCID])
+                naccid=naccid)
         except IdentifierRepositoryError as error:
             raise GearExecutionError(
-                f"Lookup of {row[FieldNames.NACCID]} failed: {error}"
+                f"Lookup of {naccid} failed: {error}"
             ) from error
 
         if not identifier:
             self.__error_writer.write(
-                identifier_error(line=line_num, value=row[FieldNames.NACCID]))
+                identifier_error(line=line_num, value=naccid))
             return False
 
         row[FieldNames.ADCID] = identifier.adcid

--- a/gear/identifier_lookup/src/python/identifier_app/main.py
+++ b/gear/identifier_lookup/src/python/identifier_app/main.py
@@ -250,7 +250,7 @@ class CenterLookupVisitor(CSVVisitor):
         Raises:
           GearExecutionError if the identifiers repository raises an error
         """
-        row = {key.strip().lower(): value for key, value in row.items()}
+        row = {key.strip(): value for key, value in row.items()}
 
         try:
             identifier = self.__identifiers_repo.get(

--- a/gear/identifier_lookup/src/python/identifier_app/run.py
+++ b/gear/identifier_lookup/src/python/identifier_app/run.py
@@ -64,7 +64,7 @@ class IdentifierLookupVisitor(GearExecutionEnvironment):
                  file_input: InputFileWrapper,
                  identifiers_mode: IdentifiersMode, date_field: str,
                  direction: Literal['nacc', 'center'], gear_name: str,
-                 preserve_case: str):
+                 preserve_case: bool):
         super().__init__(client=client)
         self.__admin_id = admin_id
         self.__file_input = file_input
@@ -150,8 +150,7 @@ class IdentifierLookupVisitor(GearExecutionEnvironment):
                                    date_field=self.__date_field,
                                    gear_name=self.__gear_name,
                                    project=ProjectAdaptor(project=project,
-                                                          proxy=self.proxy),
-                                   preserve_case=self.__preserve_case)
+                                                          proxy=self.proxy))
 
     def __build_center_lookup(self, *, identifiers_repo: IdentifierRepository,
                               output_file: TextIO,
@@ -159,8 +158,7 @@ class IdentifierLookupVisitor(GearExecutionEnvironment):
 
         return CenterLookupVisitor(identifiers_repo=identifiers_repo,
                                    output_file=output_file,
-                                   error_writer=error_writer,
-                                   preserve_case=self.__preserve_case)
+                                   error_writer=error_writer)
 
     def run(self, context: GearToolkitContext):
         """Runs the identifier lookup app.
@@ -203,7 +201,8 @@ class IdentifierLookupVisitor(GearExecutionEnvironment):
             success = run(input_file=csv_file,
                           lookup_visitor=lookup_visitor,
                           error_writer=error_writer,
-                          clear_errors=clear_errors)
+                          clear_errors=clear_errors,
+                          preserve_case=self.__preserve_case)
 
             contents = out_file.getvalue()
             if len(contents) > 0:

--- a/gear/identifier_lookup/src/python/identifier_app/run.py
+++ b/gear/identifier_lookup/src/python/identifier_app/run.py
@@ -64,7 +64,8 @@ class IdentifierLookupVisitor(GearExecutionEnvironment):
     def __init__(self, *, client: ClientWrapper, admin_id: str,
                  file_input: InputFileWrapper,
                  identifiers_mode: IdentifiersMode, date_field: str,
-                 direction: Literal['nacc', 'center'], gear_name: str):
+                 direction: Literal['nacc', 'center'], gear_name: str,
+                 preserve_case: str):
         super().__init__(client=client)
         self.__admin_id = admin_id
         self.__file_input = file_input
@@ -72,6 +73,7 @@ class IdentifierLookupVisitor(GearExecutionEnvironment):
         self.__direction: Literal['nacc', 'center'] = direction
         self.__date_field = date_field
         self.__gear_name = gear_name
+        self.__preserve_case = preserve_case
 
     @classmethod
     def create(
@@ -97,6 +99,7 @@ class IdentifierLookupVisitor(GearExecutionEnvironment):
         admin_id = context.config.get("admin_group", "nacc")
         mode = context.config.get("database_mode", "prod")
         direction = context.config.get("direction", "nacc")
+        preserve_case = context.config.get("preserve_case", False)
 
         date_field = (context.config.get("date_field",
                                          FieldNames.DATE_COLUMN)).lower()
@@ -109,7 +112,8 @@ class IdentifierLookupVisitor(GearExecutionEnvironment):
                                        file_input=file_input,
                                        identifiers_mode=mode,
                                        date_field=date_field,
-                                       direction=direction)
+                                       direction=direction,
+                                       preserve_case=preserve_case)
 
     def __build_naccid_lookup(self, *, file_id: str,
                               identifiers_repo: IdentifierRepository,
@@ -155,7 +159,8 @@ class IdentifierLookupVisitor(GearExecutionEnvironment):
                                    date_field=self.__date_field,
                                    gear_name=self.__gear_name,
                                    project=ProjectAdaptor(project=project,
-                                                          proxy=self.proxy))
+                                                          proxy=self.proxy),
+                                   preserve_case=self.__preserve_case)
 
     def __build_center_lookup(self, *, identifiers_repo: IdentifierRepository,
                               output_file: TextIO,
@@ -163,7 +168,8 @@ class IdentifierLookupVisitor(GearExecutionEnvironment):
 
         return CenterLookupVisitor(identifiers_repo=identifiers_repo,
                                    output_file=output_file,
-                                   error_writer=error_writer)
+                                   error_writer=error_writer,
+                                   preserve_case=self.__preserve_case)
 
     def run(self, context: GearToolkitContext):
         """Runs the identifier lookup app.


### PR DESCRIPTION
Fixes issue where `CenterLookupVisitor.visit_row` was setting the keys to lowercase, causing `writer.write()` to fail with non-lower case headers

If we want to enforce lowercase keys, I can update this to allow for a `preserve_case` configuration value, which when set to False (the default), sets everything to lowercase. 

EDIT: Updated to pass `preserve_case` to `read_csv`, which will convert all keys to lowercase and replace spaces with underscores (and remove trailing whitespace). Default is set to `true` so backwards compatibility is conserved, and for something that changes data that should probably be an intentionally-passed parameter. 