### PR TITLE
CSV Subject Splitter: Query subject first

### DIFF
--- a/common/src/python/flywheel_adaptor/flywheel_proxy.py
+++ b/common/src/python/flywheel_adaptor/flywheel_proxy.py
@@ -1311,13 +1311,19 @@ class ProjectAdaptor:
         return info
 
     def add_subject(self, label: str) -> SubjectAdaptor:
-        """Adds a subject with the given label.
+        """Adds a subject with the given label. If the subject already exists,
+        returns it instead.
 
         Args:
           label: the subject label
         Returns:
           the created Subject object
         """
+        subject = self.find_subject(label)
+        if subject:
+            log.info(f"Subject {label} already exists")
+            return subject
+
         return SubjectAdaptor(self._project.add_subject(label=label))
 
     def find_subject(self, label: str) -> Optional[SubjectAdaptor]:

--- a/common/src/python/uploads/uploader.py
+++ b/common/src/python/uploads/uploader.py
@@ -13,6 +13,7 @@ from flywheel_adaptor.subject_adaptor import (
     SubjectAdaptor,
     SubjectError,
 )
+from gear_execution.gear_execution import GearExecutionError
 from keys.keys import DefaultValues, FieldNames
 from outputs.errors import (
     FileError,
@@ -110,15 +111,14 @@ class JSONUploader:
         """
         success = True
         for subject_label, record_list in records.items():
-            try:
-                subject = self.__project.add_subject(subject_label)
-            except ApiException as error:
+            subject = self.__project.find_subject(subject_label)
+            if subject:
                 if not self.__allow_updates:
-                    raise error
-                else:
-                    log.info(f"{subject_label} already exists")
-                    subject = self.__project.find_subject(
-                        subject_label)  # type: ignore
+                    raise GearExecutionError(
+                        f"Subject {subject_label} already exists and " +
+                        "allow_updates set to False")
+            else:
+                subject = self.__project.add_subject(subject_label)
 
             for record in record_list:
                 try:

--- a/common/src/python/uploads/uploader.py
+++ b/common/src/python/uploads/uploader.py
@@ -13,7 +13,6 @@ from flywheel_adaptor.subject_adaptor import (
     SubjectAdaptor,
     SubjectError,
 )
-from gear_execution.gear_execution import GearExecutionError
 from keys.keys import DefaultValues, FieldNames
 from outputs.errors import (
     FileError,
@@ -92,14 +91,12 @@ class JSONUploader:
                  *,
                  project: ProjectAdaptor,
                  environment: Optional[Dict[str, Any]] = None,
-                 template_map: UploadTemplateInfo,
-                 allow_updates: bool = False) -> None:
+                 template_map: UploadTemplateInfo) -> None:
         self.__project = project
         self.__session_template = template_map.session
         self.__acquisition_template = template_map.acquisition
         self.__filename_template = template_map.filename
         self.__environment = environment if environment else {}
-        self.__allow_updates = allow_updates
 
     def upload(self, records: Dict[str, List[Dict[str, Any]]]) -> bool:
         """Uploads the records to acquisitions under the subject.
@@ -111,14 +108,7 @@ class JSONUploader:
         """
         success = True
         for subject_label, record_list in records.items():
-            subject = self.__project.find_subject(subject_label)
-            if subject:
-                if not self.__allow_updates:
-                    raise GearExecutionError(
-                        f"Subject {subject_label} already exists and " +
-                        "allow_updates set to False")
-            else:
-                subject = self.__project.add_subject(subject_label)
+            subject = self.__project.add_subject(subject_label)
 
             for record in record_list:
                 try:

--- a/docs/csv_subject_splitter/CHANGELOG.md
+++ b/docs/csv_subject_splitter/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this gear are documented in this file.
 
+## 1.0.2
+
+* Updates `uploader.JSONUploader` to query subject first and then add if it doesn't exist, instead of the other way around, since after any initial pipeline it is more likely for the subject to exist than not
+
 ## 1.0.1
 
 * Updates `hierarchy_labels` config to be type `string` instead of type `object`

--- a/docs/csv_subject_splitter/CHANGELOG.md
+++ b/docs/csv_subject_splitter/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this gear are documented in this file.
 
 ## 1.0.2
 
-* Updates `uploader.JSONUploader` to query subject first and then add if it doesn't exist, instead of the other way around, since after any initial pipeline it is more likely for the subject to exist than not
+* Updates `ProjectAdaptor.add_subject` to return the subject if it already exists
+* Updates `uploader.JSONUploader` to remove the `allow_updates` parameter - will always update instead
 
 ## 1.0.1
 

--- a/gear/csv_subject_splitter/src/docker/BUILD
+++ b/gear/csv_subject_splitter/src/docker/BUILD
@@ -6,4 +6,4 @@ docker_image(name="csv-subject-splitter",
                  ":manifest",
                  "gear/csv_subject_splitter/src/python/csv_app:bin"
              ],
-             image_tags=["1.0.1", "latest"])
+             image_tags=["1.0.2", "latest"])

--- a/gear/csv_subject_splitter/src/docker/manifest.json
+++ b/gear/csv_subject_splitter/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "csv-subject-splitter",
     "label": "CSV Subject Splitter",
     "description": "Converts rows of CSV file to subject JSON files based on NACCID",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/csv-subject-splitter:1.0.1"
+            "image": "naccdata/csv-subject-splitter:1.0.2"
         },
         "flywheel": {
             "suite": "Curation",

--- a/gear/csv_subject_splitter/src/python/csv_app/main.py
+++ b/gear/csv_subject_splitter/src/python/csv_app/main.py
@@ -109,8 +109,7 @@ def run(*, input_file: TextIO, destination: ProjectAdaptor,
 
     uploader = JSONUploader(project=destination,
                             template_map=template_map,
-                            environment=environment,
-                            allow_updates=True)
+                            environment=environment)
     upload_status = uploader.upload(subject_record_map)
     if not upload_status:
         notify_upload_errors()


### PR DESCRIPTION
Change query subject order by first searching, then adding if it does not exist. In the long run this should result in less API calls (also kind of backwards to act on a caught exception to begin with). 