### PR TITLE
Fix/change fw client put payload

### DIFF
--- a/common/src/python/flywheel_adaptor/flywheel_proxy.py
+++ b/common/src/python/flywheel_adaptor/flywheel_proxy.py
@@ -471,7 +471,7 @@ class FlywheelProxy:
         """
         assert self.__fw_client, "Requires FWClient to be instantiated"
         self.__fw_client.put(url=f"/api/projects/{project.id}/settings",
-                             data=settings)
+                             json=settings)
 
     def get_project_apps(self, project: flywheel.Project) -> List[AttrDict]:
         """Returns the viewer apps for the project.

--- a/docs/push_template/CHANGELOG.md
+++ b/docs/push_template/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this gear are documented in this file.
 
 ## Unreleased
 
+## 1.0.5
+
+* Changes call to FWClient.put for project app management to use parameter `json` instead of `data` for the payload.
+  
 ## 1.0.4
 
 * Updates template pattern regex to `^((\w+(?:-[\w]+)*)-)?(\w+)-template$` (previously `^((\w+)-)?(\w+)-template$`) which allows matches on data types with dashes in them

--- a/gear/push_template/src/docker/BUILD
+++ b/gear/push_template/src/docker/BUILD
@@ -5,4 +5,4 @@ docker_image(name="push-template",
              dependencies=[
                  ":manifest", "gear/push_template/src/python/template_app:bin"
              ],
-             image_tags=["1.0.4", "latest"])
+             image_tags=["1.0.5", "latest"])

--- a/gear/push_template/src/docker/manifest.json
+++ b/gear/push_template/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "push-template",
     "label": "Push Project Template",
     "description": "Pushes template projects to center projects",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/push-template:1.0.4"
+            "image": "naccdata/push-template:1.0.5"
         },
         "flywheel": {
             "suite": "NACC Admin Gears",


### PR DESCRIPTION
Changes the usage of FWClient.put to pass payload object using the `json` parameter rather than `data`.
Fixes a failure that seems to be due to change in FWClient.