### PR TITLE
APOE Transformer: Add a1/a2 encoding to output

### DIFF
--- a/docs/apoe_transformer/CHANGELOG.md
+++ b/docs/apoe_transformer/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 All notable changes to this gear are documented in this file.
 
-## 0.1.4 (Unreleased)
+## 0.1.4
 
+* Updates to add original `A1/A2` fields to output data
 * Refactors to use `InputFileWrapper.get_parent_project`
 
 ## 0.1.3

--- a/gear/apoe_transformer/test/python/test_apoe_transformer.py
+++ b/gear/apoe_transformer/test/python/test_apoe_transformer.py
@@ -134,3 +134,4 @@ class TestAPOETransformerCSVVisitor:
             assert error['message'].startswith(
                 'Required field(s)')
             assert error['message'].endswith('cannot be blank')
+        assert not visitor.transformed_data

--- a/gear/apoe_transformer/test/python/test_apoe_transformer.py
+++ b/gear/apoe_transformer/test/python/test_apoe_transformer.py
@@ -88,10 +88,9 @@ class TestAPOETransformerCSVVisitor:
             'a2': 'FF'
         }
 
-    def test_visit_row_drops_extra_fields(self, visitor, apoe_headers):
-        """Test that the visit_row method drops unexpected fields in output."""
+    def test_visit_row_extra_fields(self, visitor, apoe_headers):
+        """Test that the visit_row method keeps unexpected fields in output."""
         visitor.visit_header(apoe_headers)
-
         data = {
             'Adcid': 3,
             'Ptid': 3,
@@ -117,7 +116,6 @@ class TestAPOETransformerCSVVisitor:
     def test_encoding_missing(self, visitor, apoe_headers, list_handler):
         """Test when a1 or a2 is set to None."""
         visitor.visit_header(apoe_headers)
-
         data = {
             'Adcid': 3,
             'Ptid': 3,
@@ -131,7 +129,6 @@ class TestAPOETransformerCSVVisitor:
         errors = list_handler.get_logs()
         assert len(errors) == 2
         for error in errors:
-            assert error['message'].startswith(
-                'Required field(s)')
+            assert error['message'].startswith('Required field(s)')
             assert error['message'].endswith('cannot be blank')
         assert not visitor.transformed_data

--- a/gear/apoe_transformer/test/python/test_apoe_transformer.py
+++ b/gear/apoe_transformer/test/python/test_apoe_transformer.py
@@ -70,7 +70,9 @@ class TestAPOETransformerCSVVisitor:
                 'adcid': 0,
                 'ptid': 0,
                 'naccid': 0,
-                'apoe': value
+                'apoe': value,
+                'a1': pair[0],
+                'a2': pair[1]
             }
 
         # test the 9/unknown case
@@ -81,7 +83,9 @@ class TestAPOETransformerCSVVisitor:
             'adcid': 3,
             'ptid': 3,
             'naccid': 3,
-            'apoe': 9
+            'apoe': 9,
+            'a1': 'EE',
+            'a2': 'FF'
         }
 
     def test_visit_row_drops_extra_fields(self, visitor, apoe_headers):
@@ -105,5 +109,28 @@ class TestAPOETransformerCSVVisitor:
             'naccid': 3,
             'extra1': 'hello',
             'extra2': 'world',
-            'apoe': 9
+            'apoe': 9,
+            'a1': 'EE',
+            'a2': 'FF'
         }
+
+    def test_encoding_missing(self, visitor, apoe_headers, list_handler):
+        """Test when a1 or a2 is set to None."""
+        visitor.visit_header(apoe_headers)
+
+        data = {
+            'Adcid': 3,
+            'Ptid': 3,
+            'Naccid': 3,
+            'a1': None,
+            'A2': None,
+            'extra1': 'hello',
+            'extra2': 'world'
+        }
+        assert not visitor.visit_row(data, 1)
+        errors = list_handler.get_logs()
+        assert len(errors) == 2
+        for error in errors:
+            assert error['message'].startswith(
+                'Required field(s)')
+            assert error['message'].endswith('cannot be blank')


### PR DESCRIPTION
Adds A1/A2 encoding to output.

On that note I realized it is keeping all input headers, so if NCRAD ever gives additional extra fields those will be propagated to the output.