### PR TITLE
Fix/csv splitter inferred type

### DIFF
--- a/common/src/python/tabular_data/site_table.py
+++ b/common/src/python/tabular_data/site_table.py
@@ -34,7 +34,7 @@ class SiteTable:
         Returns:
           a wrapper object for the data frame or None if no center id column
         """
-        table_data = pd.read_csv(object_data)
+        table_data = pd.read_csv(object_data, dtype=object)
 
         if 'ADCID' in table_data.columns:
             site_id_name = 'ADCID'

--- a/common/test/python/tabular_data/test_site_table.py
+++ b/common/test/python/tabular_data/test_site_table.py
@@ -37,6 +37,21 @@ def adcid_data_stream():
     yield stream
 
 
+@pytest.fixture(scope='function')
+def type_data_stream():
+    """Create data frame for table column with expected int values."""
+    data = [['ADCID', 'expected_int'], ['4', 1], ['4', 2], ['4', None]]
+    stream = StringIO()
+    writer = csv.writer(stream,
+                        delimiter=',',
+                        quotechar='\"',
+                        quoting=csv.QUOTE_NONNUMERIC,
+                        lineterminator='\n')
+    writer.writerows(data)
+    stream.seek(0)
+    yield stream
+
+
 # pylint: disable=no-self-use,redefined-outer-name
 class TestSiteTable:
     """Tests for SiteTable."""
@@ -56,3 +71,9 @@ class TestSiteTable:
         assert table.get_adcids() == {'1', '2'}
         assert table.select_site('1') == 'ADCID,BLAH\n1,blah1\n'
         assert table.select_site('2') == 'ADCID,BLAH\n2,blah2\n'
+
+    def test_create_from_column_type(self, type_data_stream):
+        """Test create_from with df that has int and not float in column."""
+        table = SiteTable.create_from(type_data_stream)
+        assert table
+        assert table.select_site('4') == 'ADCID,expected_int\n4,1\n4,2\n4,\n'

--- a/common/test/python/tabular_data/test_site_table.py
+++ b/common/test/python/tabular_data/test_site_table.py
@@ -1,6 +1,7 @@
 """Tests for tabular_data.site_table.SiteTable."""
 import csv
 from io import StringIO
+from typing import Any, List
 
 import pytest
 from tabular_data.site_table import SiteTable
@@ -40,7 +41,8 @@ def adcid_data_stream():
 @pytest.fixture(scope='function')
 def type_data_stream():
     """Create data frame for table column with expected int values."""
-    data = [['ADCID', 'expected_int'], ['4', 1], ['4', 2], ['4', None]]
+    data: List[List[Any]] = [['ADCID', 'expected_int'], ['4', 1], ['4', 2],
+                             ['4', None]]
     stream = StringIO()
     writer = csv.writer(stream,
                         delimiter=',',


### PR DESCRIPTION
Added dtype parameter to stop pandas from inferring types; added test