### PR TITLE
Attribute Curator: Fix silent failures

### DIFF
--- a/common/src/python/curator/form_curator.py
+++ b/common/src/python/curator/form_curator.py
@@ -75,7 +75,7 @@ class FormCurator:
             file_id: File ID curate
         """
 
-        log.info('curating file %s', file_id)
+        log.info('looking up file %s', file_id)
         file_entry = self.__sdk_client.get_file(file_id)
 
         subject = self.get_subject(file_entry)
@@ -86,6 +86,7 @@ class FormCurator:
             log.warning("ignoring unexpected file %s", file_entry.name)
             return
 
+        log.info("curating file %s", file_entry.name)
         self.__deriver.curate(table, scope)
         self.apply_curation(subject, file_entry, table)
 

--- a/common/src/python/curator/scheduling.py
+++ b/common/src/python/curator/scheduling.py
@@ -5,7 +5,7 @@ import multiprocessing
 from multiprocessing.pool import Pool
 import os
 import re
-from typing import Dict, List, Literal, Optional, Type, TypeVar
+from typing import Any, Dict, List, Literal, Optional, Type, TypeVar
 
 from curator.form_curator import FormCurator
 from dataview.dataview import ColumnModel, make_builder
@@ -150,6 +150,11 @@ class ViewResponseModel(BaseModel):
     """Defines the data model for a dataview response."""
     data: List[FileModel]
 
+    @field_validator("data", mode='before')
+    def trim_data(cls, data: List[Dict[str, Any]]) -> List[FileModel]:
+        """Remove any rows that are completely empty."""
+        return [row for row in data if any(x is not None for x in row.values())]
+
 
 curator = None  # global curator object
 
@@ -290,6 +295,8 @@ class ProjectCurationScheduler:
         log.info("Start curator for %s subjects", len(self.__heap_map))
 
         process_count = max(4, self.__compute_cores())
+        results = []
+
         with Pool(processes=process_count,
                   initializer=initialize_worker,
                   initargs=(
@@ -299,8 +306,12 @@ class ProjectCurationScheduler:
                   )) as pool:
             for subject_id, heap in self.__heap_map.items():
                 log.info("Curating files for subject %s", subject_id)
-                pool.apply_async(curate_subject, (heap, ))
+                results.append(pool.apply_async(curate_subject, (heap, )))
+
             pool.close()
+            for r in results:  # checks for exceptions
+                r.get()
+
             pool.join()
 
 

--- a/common/src/python/curator/scheduling.py
+++ b/common/src/python/curator/scheduling.py
@@ -156,7 +156,7 @@ class ViewResponseModel(BaseModel):
         filename pattern does not match.
 
         Args:
-            data: List of retreived rows from the builder
+            data: List of retrieved rows from the builder
         Returns:
             Trimmed data
         """

--- a/common/src/python/curator/scheduling.py
+++ b/common/src/python/curator/scheduling.py
@@ -151,9 +151,18 @@ class ViewResponseModel(BaseModel):
     data: List[FileModel]
 
     @field_validator("data", mode='before')
-    def trim_data(cls, data: List[Dict[str, Any]]) -> List[FileModel]:
-        """Remove any rows that are completely empty."""
-        return [row for row in data if any(x is not None for x in row.values())]
+    def trim_data(cls, data: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Remove any rows that are completely empty, which can happen if the
+        filename pattern does not match.
+
+        Args:
+            data: List of retreived rows from the builder
+        Returns:
+            Trimmed data
+        """
+        return [
+            row for row in data if any(x is not None for x in row.values())
+        ]
 
 
 curator = None  # global curator object

--- a/docs/attribute-curator/CHANGELOG.md
+++ b/docs/attribute-curator/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this gear are documented in this file.
 
 ## 0.2.4
 
+* Updates `nacc_attribute_deriver` to `1.2.2`
 * Removes rows from ViewResponseModel where all fields are null
 * Fixes issue where multiprocessing was failing silently on exception
 

--- a/docs/attribute-curator/CHANGELOG.md
+++ b/docs/attribute-curator/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this gear are documented in this file.
 
+## 0.2.4
+
+* Removes rows from ViewResponseModel where all fields are null
+* Fixes issue where multiprocessing was failing silently on exception
+
 ## 0.2.3
 
 * Ignores unexpected files instead of throwing an exception.

--- a/gear/attribute_curator/src/docker/BUILD
+++ b/gear/attribute_curator/src/docker/BUILD
@@ -6,4 +6,4 @@ docker_image(name="attribute-curator",
                  ":manifest",
                  "gear/attribute_curator/src/python/attribute_curator_app:bin"
              ],
-             image_tags=["0.2.3", "latest"])
+             image_tags=["0.2.4", "latest"])

--- a/gear/attribute_curator/src/docker/manifest.json
+++ b/gear/attribute_curator/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "attribute-curator",
     "label": "Attribute Curator",
     "description": "Curation of derived data for MQT project",
-    "version": "0.2.3",
+    "version": "0.2.4",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "analysis",
-            "image": "naccdata/attribute-curator:0.2.3"
+            "image": "naccdata/attribute-curator:0.2.4"
         },
         "flywheel": {
             "suite": "Curation",

--- a/python-default.lock
+++ b/python-default.lock
@@ -17,7 +17,7 @@
 //     "fw-client>=0.7.0",
 //     "fw-utils>=3",
 //     "moto[s3,ses,ssm]>=5.0.15",
-//     "nacc_attribute_deriver@ https://github.com/naccdata/nacc-attribute-deriver/releases/download/v1.2.1/nacc_attribute_deriver-1.2.1-py3-none-any.whl",
+//     "nacc_attribute_deriver@ https://github.com/naccdata/nacc-attribute-deriver/releases/download/v1.2.2/nacc_attribute_deriver-1.2.2-py3-none-any.whl",
 //     "nacc_form_validator@ https://github.com/naccdata/nacc-form-validator/releases/download/v0.5.1/nacc_form_validator-0.5.1-py3-none-any.whl",
 //     "natsort",
 //     "pandas-stubs>=2.0.3",
@@ -196,42 +196,42 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "869979050e2cf6f5461503e0f1c8f226e47ec02802e88a2210f085ec22485945",
-              "url": "https://files.pythonhosted.org/packages/0f/cc/a0485c8df7d148f356a5934388c887dc4e156833ab3bf8368edc8140f2e4/boto3-1.37.29-py3-none-any.whl"
+              "hash": "cf8997be0742a5cab9d33a138ef56e423a8ebd8881f6f73e95076b26656b36dc",
+              "url": "https://files.pythonhosted.org/packages/2e/6f/5eba2f027aa20c4d936d6932d268146606c41ae3c8e4ff788674710d3107/boto3-1.37.31-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5702e38356b93c56ed2a27e17f7664d791f1fe2eafd58ae6ab3853b2804cadd2",
-              "url": "https://files.pythonhosted.org/packages/91/98/040aad0ddda4f42a6f1c249bebe9b631e5d8a1425ac450dd912eacc8cf53/boto3-1.37.29.tar.gz"
+              "hash": "dfee02b2f8f632a239a2f4ba6a2d568e2edd7f7464e9afd8a487fdb3fa9a0ad3",
+              "url": "https://files.pythonhosted.org/packages/a3/3b/6b4562b00be71ec82de8f33c857501a093f99bdec439cda56622c3932eea/boto3-1.37.31.tar.gz"
             }
           ],
           "project_name": "boto3",
           "requires_dists": [
-            "botocore<1.38.0,>=1.37.29",
+            "botocore<1.38.0,>=1.37.31",
             "botocore[crt]<2.0a0,>=1.21.0; extra == \"crt\"",
             "jmespath<2.0.0,>=0.7.1",
             "s3transfer<0.12.0,>=0.11.0"
           ],
           "requires_python": ">=3.8",
-          "version": "1.37.29"
+          "version": "1.37.31"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "a3471040c098c4e82a87fafeb38deb66eb4966950a771c62eba0bf36834f69d6",
-              "url": "https://files.pythonhosted.org/packages/f1/d9/d4c683d775f49676bbd7cec88e36b656ed5769c0e445da21d5c9bb4866e5/boto3_stubs-1.37.29-py3-none-any.whl"
+              "hash": "356d5af1e3d8aba5d8068492f11426ee9f41d0a799c099ec548be13462337632",
+              "url": "https://files.pythonhosted.org/packages/99/ef/120d68cf0b3638d7573d6d5d155f060896b7ceee57200303753bd584d0f5/boto3_stubs-1.37.31-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "36444606a7c1c10c9700dde590f7afb134546065553f761f36207c1feb847e0b",
-              "url": "https://files.pythonhosted.org/packages/c5/43/9ae3539447f920176a8a7ea91cc0967c397831b175fd2bb2d42d0e64152a/boto3_stubs-1.37.29.tar.gz"
+              "hash": "ab2e8f7877fddb97f50f4712f3e6ffafa0b20fbc6a1ac7019400d3b2261936cb",
+              "url": "https://files.pythonhosted.org/packages/1b/08/d352287c6ec162605d45d3df58fe0a8be47fabdb389af49619e9f8da0bfb/boto3_stubs-1.37.31.tar.gz"
             }
           ],
           "project_name": "boto3-stubs",
           "requires_dists": [
             "boto3-stubs-full<1.38.0,>=1.37.0; extra == \"full\"",
-            "boto3==1.37.29; extra == \"boto3\"",
+            "boto3==1.37.31; extra == \"boto3\"",
             "botocore-stubs",
             "mypy-boto3-accessanalyzer<1.38.0,>=1.37.0; extra == \"accessanalyzer\"",
             "mypy-boto3-accessanalyzer<1.38.0,>=1.37.0; extra == \"all\"",
@@ -1052,19 +1052,19 @@
             "typing-extensions>=4.1.0; python_version < \"3.12\""
           ],
           "requires_python": ">=3.8",
-          "version": "1.37.29"
+          "version": "1.37.31"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "092c41e346df37a8d7cf60a799791f8225ad3a5ba7cda749047eb31d1440b9c5",
-              "url": "https://files.pythonhosted.org/packages/f9/97/e3c88d7c8063b9f53e6b17c875819efdadde0179ed70d5bfaf2cb65f3e0e/botocore-1.37.29-py3-none-any.whl"
+              "hash": "598a33a7a0e5a014bd1416c999a0b9c634fbbba3d1363e2368e6a92da4544df4",
+              "url": "https://files.pythonhosted.org/packages/b5/6b/320774d6d3c456cb49713797121b351daacdacaafa699e3ad6eba8a98555/botocore-1.37.31-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "728c1ef3b66a0f79bc08008a59f6fd6bef2a0a0195e5b3b9e9bef255df519890",
-              "url": "https://files.pythonhosted.org/packages/ad/36/9ebd515572717e8e8532ab979f1751488038c56cafdbd24b9008ca2fe8b5/botocore-1.37.29.tar.gz"
+              "hash": "eb3dfa44a87187bd82c3b493d568d8436270d4d000f237b49b669a01fcd8a21c",
+              "url": "https://files.pythonhosted.org/packages/c5/89/33afc4b679212a02e825e634a37bc48d51060811be64bb396aec06e9da52/botocore-1.37.31.tar.gz"
             }
           ],
           "project_name": "botocore",
@@ -1076,7 +1076,7 @@
             "urllib3<1.27,>=1.25.4; python_version < \"3.10\""
           ],
           "requires_python": ">=3.8",
-          "version": "1.37.29"
+          "version": "1.37.31"
         },
         {
           "artifacts": [
@@ -2009,8 +2009,8 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "78fb24deb82ddbfda3796927234c739dc8d4346ac931136782d4461936b6799b",
-              "url": "https://github.com/naccdata/nacc-attribute-deriver/releases/download/v1.2.1/nacc_attribute_deriver-1.2.1-py3-none-any.whl"
+              "hash": "f822c582920bce94746ea933b078e6d3960d0d1f4366ca2ab6a291621576ea58",
+              "url": "https://github.com/naccdata/nacc-attribute-deriver/releases/download/v1.2.2/nacc_attribute_deriver-1.2.2-py3-none-any.whl"
             }
           ],
           "project_name": "nacc-attribute-deriver",
@@ -2018,7 +2018,7 @@
             "pydantic>=2.10.6"
           ],
           "requires_python": "==3.11.*",
-          "version": "1.2.1"
+          "version": "1.2.2"
         },
         {
           "artifacts": [

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,4 +26,4 @@ urllib3 >= 2.2.1
 ratelimit>=2.2.1
 ratelimit-types>=0.0.1
 nacc_form_validator@ https://github.com/naccdata/nacc-form-validator/releases/download/v0.5.1/nacc_form_validator-0.5.1-py3-none-any.whl
-nacc_attribute_deriver@ https://github.com/naccdata/nacc-attribute-deriver/releases/download/v1.2.1/nacc_attribute_deriver-1.2.1-py3-none-any.whl
+nacc_attribute_deriver@ https://github.com/naccdata/nacc-attribute-deriver/releases/download/v1.2.2/nacc_attribute_deriver-1.2.2-py3-none-any.whl


### PR DESCRIPTION
Fixes issue where curator fails silently on pooled exceptions and updates the deriver. 

* Updates `nacc_attribute_deriver` to `1.2.2`
* Removes rows from ViewResponseModel where all fields are null
* Fixes issue where multiprocessing was failing silently on exception