### PR TITLE
Attribute Curator: Add curated tag

### DIFF
--- a/common/src/python/curator/form_curator.py
+++ b/common/src/python/curator/form_curator.py
@@ -6,6 +6,7 @@ from flywheel import Client
 from flywheel.models.file_entry import FileEntry
 from flywheel.models.subject import Subject
 from flywheel.rest import ApiException
+from keys.keys import GearTags
 from nacc_attribute_deriver.attribute_deriver import AttributeDeriver, ScopeLiterals
 from nacc_attribute_deriver.symbol_table import SymbolTable
 
@@ -15,9 +16,13 @@ log = logging.getLogger(__name__)
 class FormCurator:
     """Curator that uses NACC Attribute Deriver."""
 
-    def __init__(self, sdk_client: Client, deriver: AttributeDeriver) -> None:
+    def __init__(self,
+                 sdk_client: Client,
+                 deriver: AttributeDeriver,
+                 force_curate: bool = False) -> None:
         self.__sdk_client = sdk_client
         self.__deriver = deriver
+        self.__force_curate = force_curate
 
     @property
     def client(self):
@@ -68,6 +73,8 @@ class FormCurator:
         if subject_info:
             subject.update_info(subject_info)
 
+        file_entry.add_tag(GearTags.CURATION_TAG)
+
     def curate_file(self,
                     subject: Subject,
                     file_id: str,
@@ -75,6 +82,7 @@ class FormCurator:
         """Curate the given file.
 
         Args:
+            subject: Subject the file is being curated under
             file_id: File ID curate
             retries: Max number of times to retry before giving up
         """
@@ -83,6 +91,10 @@ class FormCurator:
             try:
                 log.info('looking up file %s', file_id)
                 file_entry = self.__sdk_client.get_file(file_id)
+
+                if GearTags.CURATION_TAG in file_entry.tags and not self.__force_curate:
+                    log.info(f"{file_entry.name} already curated, skipping")
+
                 table = self.get_table(subject, file_entry)
 
                 scope = determine_scope(file_entry.name)

--- a/common/src/python/keys/keys.py
+++ b/common/src/python/keys/keys.py
@@ -106,3 +106,7 @@ class SysErrorCodes:
     DUPLICATE_VISIT = 'preprocess-022'
     LOWER_VISITNUM = 'preprocess-023'
     MISSING_SUBMISSION_STATUS = 'preprocess-024'
+
+
+class GearTags:
+    CURATION_TAG = 'curated'

--- a/docs/attribute-curator/CHANGELOG.md
+++ b/docs/attribute-curator/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this gear are documented in this file.
 
+## 0.2.7 (unreleased)
+
+* Adds a `curated` tag to each curated file, and will skip curation on subsequent passes if the file has this tag
+
 ## 0.2.6
 
 * Moves the `get_subject` call to beginning of loop to avoid calling it for every file in the same subject-specific heap

--- a/gear/attribute_curator/src/docker/BUILD
+++ b/gear/attribute_curator/src/docker/BUILD
@@ -6,4 +6,4 @@ docker_image(name="attribute-curator",
                  ":manifest",
                  "gear/attribute_curator/src/python/attribute_curator_app:bin"
              ],
-             image_tags=["0.2.6", "latest"])
+             image_tags=["0.2.7", "latest"])

--- a/gear/attribute_curator/src/docker/manifest.json
+++ b/gear/attribute_curator/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "attribute-curator",
     "label": "Attribute Curator",
     "description": "Curation of derived data for MQT project",
-    "version": "0.2.6",
+    "version": "0.2.7",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "analysis",
-            "image": "naccdata/attribute-curator:0.2.6"
+            "image": "naccdata/attribute-curator:0.2.7"
         },
         "flywheel": {
             "suite": "Curation",
@@ -38,6 +38,11 @@
             "description": "Filename pattern to match on",
             "type": "string",
             "default": "*.json"
+        },
+        "force_curate": {
+            "description": "Curate file even if it's already been curated",
+            "type": "boolean",
+            "default": false
         }
     },
     "command": "/bin/run"

--- a/gear/attribute_curator/src/python/attribute_curator_app/main.py
+++ b/gear/attribute_curator/src/python/attribute_curator_app/main.py
@@ -9,8 +9,10 @@ from nacc_attribute_deriver.attribute_deriver import AttributeDeriver
 log = logging.getLogger(__name__)
 
 
-def run(context: GearToolkitContext, deriver: AttributeDeriver,
-        scheduler: ProjectCurationScheduler) -> None:
+def run(context: GearToolkitContext,
+        deriver: AttributeDeriver,
+        scheduler: ProjectCurationScheduler,
+        force_curate: bool = False) -> None:
     """Runs the Attribute Curator process.
 
     Args:
@@ -18,6 +20,10 @@ def run(context: GearToolkitContext, deriver: AttributeDeriver,
         deriver: attribute deriver
         curation_type: which type of file and derive rules to curate with
         scheduler: Schedules the files to be curated
+        force_curate: Curate file even if it's already been curated
     """
 
-    scheduler.apply(context=context, curator_type=FormCurator, deriver=deriver)
+    scheduler.apply(context=context,
+                    curator_type=FormCurator,
+                    deriver=deriver,
+                    force_curate=force_curate)

--- a/gear/attribute_curator/src/python/attribute_curator_app/run.py
+++ b/gear/attribute_curator/src/python/attribute_curator_app/run.py
@@ -25,11 +25,15 @@ log = logging.getLogger(__name__)
 class AttributeCuratorVisitor(GearExecutionEnvironment):
     """Visitor for the UDS Curator gear."""
 
-    def __init__(self, client: ClientWrapper, project: ProjectAdaptor,
-                 filename_pattern: str):
+    def __init__(self,
+                 client: ClientWrapper,
+                 project: ProjectAdaptor,
+                 filename_pattern: str,
+                 force_curate: bool = False):
         super().__init__(client=client)
         self.__project = project
         self.__filename_pattern = filename_pattern
+        self.__force_curate = force_curate
 
     @classmethod
     def create(
@@ -52,6 +56,7 @@ class AttributeCuratorVisitor(GearExecutionEnvironment):
         proxy = client.get_proxy()
 
         filename_pattern = context.config.get('filename_pattern', "*.json")
+        force_curate = context.config.get('force_curate', False)
 
         try:
             destination = context.get_destination_container()
@@ -75,7 +80,8 @@ class AttributeCuratorVisitor(GearExecutionEnvironment):
 
         return AttributeCuratorVisitor(client=client,
                                        project=project,
-                                       filename_pattern=filename_pattern)
+                                       filename_pattern=filename_pattern,
+                                       force_curate=force_curate)
 
     def run(self, context: GearToolkitContext) -> None:
         log.info("Curating project: %s/%s", self.__project.group,
@@ -90,7 +96,10 @@ class AttributeCuratorVisitor(GearExecutionEnvironment):
         except ProjectCurationError as error:
             raise GearExecutionError(error) from error
 
-        run(context=context, deriver=deriver, scheduler=scheduler)
+        run(context=context,
+            deriver=deriver,
+            scheduler=scheduler,
+            force_curate=self.__force_curate)
 
 
 def main():


### PR DESCRIPTION
Adds a "curated" tag to curated files, and skips the file on subsequent curations if it has the tag. Should help significantly cut down runtime and API calls on subsequent runs (assuming derive rules don't change, if they do then we need to re-curate).

Wondering if tag can be queried at the dataview level instead? 

I _think_ this is okay for most scenarios but I'm not sure if there's a case where we'd want to re-curate previous files and can't rely on subject metadata, likely would be needed by something in UDS or similar where there can be multiple forms. 