### PR TITLE
CenterManagement: Refactor tags

### DIFF
--- a/common/src/python/centers/center_group.py
+++ b/common/src/python/centers/center_group.py
@@ -93,13 +93,17 @@ class CenterGroup(CenterAdaptor):
                                              group=adaptor.group)
 
     @classmethod
-    def create_from_center(cls, *, proxy: FlywheelProxy,
-                           center: CenterInfo) -> 'CenterGroup':
+    def create_from_center(cls,
+                           *,
+                           proxy: FlywheelProxy,
+                           center: CenterInfo,
+                           tags: Optional[List[str]] = None) -> 'CenterGroup':
         """Creates a CenterGroup from a center object.
 
         Args:
           center: CenterInfo object, the study center
           proxy: The flywheel proxy object
+          tags: Tags to add, if specified
         Returns:
           the CenterGroup for the center
         """
@@ -112,7 +116,10 @@ class CenterGroup(CenterAdaptor):
             group=group,
             proxy=proxy)
 
-        tags = list(center.tags)  # type: ignore
+        # handle tags
+        if tags is None:
+            tags = []
+
         adcid_tag = f"adcid-{center.adcid}"
         if adcid_tag not in tags:
             tags.append(adcid_tag)

--- a/common/src/python/centers/center_info.py
+++ b/common/src/python/centers/center_info.py
@@ -1,8 +1,8 @@
 """Models representing center information and center mappings."""
-from typing import Dict, List, Optional, Set, Tuple
+from typing import Dict, List, Optional, Set
 
 from projects.study import StudyVisitor
-from pydantic import AliasChoices, BaseModel, Field, field_validator
+from pydantic import AliasChoices, BaseModel, Field
 
 
 class CenterInfo(BaseModel):
@@ -14,7 +14,6 @@ class CenterInfo(BaseModel):
         group (str): The symbolic ID for the center
 
         active (bool): Optional, active or inactive status. Defaults to True.
-        tags (Tuple[str]): Optional, list of tags for the center
     """
     adcid: int
     name: str
@@ -23,27 +22,19 @@ class CenterInfo(BaseModel):
     active: Optional[bool] = Field(validation_alias=AliasChoices(
         'active', 'is-active', 'is_active'),
                                    default=True)
-    tags: Optional[Tuple[str, ...]] = ()
 
     def __repr__(self) -> str:
         return (f"Center(group={self.group}, "
                 f"name={self.name}, "
                 f"adcid={self.adcid}, "
-                f"active={self.active}, "
-                f"tags={self.tags}")
+                f"active={self.active}")
 
     def __eq__(self, __o: object) -> bool:
         if not isinstance(__o, CenterInfo):
             return False
-        # compare everything except tags
+        # compare everything
         return (self.adcid == __o.adcid and self.group == __o.group
                 and self.name == __o.name and self.active == __o.active)
-
-    @field_validator("tags")
-    def set_tags(cls, tags: Tuple[Tuple[str], List[str]]) -> Tuple[str]:
-        if not tags:
-            return ()
-        return tuple(tags)  # type: ignore
 
     def apply(self, visitor: StudyVisitor):
         """Applies visitor to this Center."""

--- a/common/src/python/centers/nacc_group.py
+++ b/common/src/python/centers/nacc_group.py
@@ -91,7 +91,6 @@ class NACCGroup(CenterAdaptor):
                        name=group_label,
                        group=group_id,
                        active=active))
-        exclude = {'centers': {'__all__': {'tags'}}}
         metadata.update_info(center_map.model_dump(exclude=exclude))
 
     def get_center_map(self,

--- a/common/src/python/centers/nacc_group.py
+++ b/common/src/python/centers/nacc_group.py
@@ -91,7 +91,7 @@ class NACCGroup(CenterAdaptor):
                        name=group_label,
                        group=group_id,
                        active=active))
-        metadata.update_info(center_map.model_dump(exclude=exclude))
+        metadata.update_info(center_map.model_dump())
 
     def get_center_map(self,
                        center_filter: Optional[List[str]] = None

--- a/common/src/python/projects/project_mapper.py
+++ b/common/src/python/projects/project_mapper.py
@@ -21,7 +21,6 @@ def build_project_map(
     Args:
       proxy: the flywheel instance proxy
       destination_label: the project of center to map to
-      center_tag_pattern: the regex for adcid-tags
       center_filter: Optional list of ADCIDs to filter on for a mapping subset
     Returns:
       dictionary mapping from adcid to group

--- a/common/test/python/centers/test_center_info.py
+++ b/common/test/python/centers/test_center_info.py
@@ -29,10 +29,7 @@ class DummyVisitor(StudyVisitor):
 @pytest.fixture(scope='module')
 def dummy_center():
     """Generate dummy CenterInfo for general testing."""
-    return CenterInfo(adcid=7,
-                      name="Alpha ADRC",
-                      group='alpha-adrc',
-                      tags=('adcid-7', ))
+    return CenterInfo(adcid=7, name="Alpha ADRC", group='alpha-adrc')
 
 
 @pytest.fixture(scope='function')
@@ -47,7 +44,6 @@ class TestCenterInfo:
 
     def test_object(self, dummy_center):
         """Sanity check on object creation and properties."""
-        assert 'adcid-7' in dummy_center.tags
         assert dummy_center.name == "Alpha ADRC"
         assert dummy_center.active
         assert dummy_center.group == 'alpha-adrc'
@@ -57,7 +53,6 @@ class TestCenterInfo:
         matches."""
         center = CenterInfo(
             **{  # type: ignore
-                'tags': ('adcid-7', ),
                 'name': 'Alpha ADRC',
                 'center-id': 'alpha-adrc',
                 'adcid': 7,
@@ -71,8 +66,7 @@ class TestCenterInfo:
             CenterInfo()  # type: ignore
 
         with pytest.raises(ValidationError):
-            CenterInfo(tags=('adcid-7', ), name="Alpha ADRC",
-                       adcid=7)  # type: ignore
+            CenterInfo(name="Alpha ADRC", adcid=7)  # type: ignore
 
     def test_apply(self, dummy_center):
         """Test that visitor applied."""
@@ -95,8 +89,7 @@ class TestCenterInfo:
         assert repr(dummy_center) == ("Center(group=alpha-adrc, "
                                       "name=Alpha ADRC, "
                                       "adcid=7, "
-                                      "active=True, "
-                                      "tags=('adcid-7',)")
+                                      "active=True")
 
 
 # pylint: disable=(no-self-use)

--- a/docs/center_management/CHANGELOG.md
+++ b/docs/center_management/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this gear are documented in this file.
 
+## Unreleased
+
+* Updates how tags are handled by the CenterInfo model
+
 ## 1.0.6
 * Fix center map index type
   

--- a/gear/center_management/src/python/center_app/main.py
+++ b/gear/center_management/src/python/center_app/main.py
@@ -1,7 +1,7 @@
 """Defines center management computation."""
 
 import logging
-from typing import List
+from typing import Dict, List
 
 from centers.center_group import CenterGroup
 from centers.center_info import CenterInfo
@@ -37,7 +37,7 @@ def get_project_roles(flywheel_proxy,
 def run(*,
         proxy: FlywheelProxy,
         admin_group: NACCGroup,
-        center_list: List[CenterInfo],
+        center_map: Dict[CenterInfo, List[str]],
         role_names: List[str],
         new_only: bool = False):
     """Runs center creation/management.
@@ -45,20 +45,21 @@ def run(*,
     Args:
       proxy: the proxy for the Flywheel instance
       admin_group: the administrative group
-      center_list: the list of center objects
+      center_map: map of CenterInfo objects to optional list of tags
       role_names: list of project role names
       new_only: whether to only create centers with new tag
     """
     center_roles = get_project_roles(proxy, role_names)
 
-    for center in center_list:
-        if new_only and 'new-center' not in center.tags:  # type: ignore
+    for center, tags in center_map.items():
+        if new_only and 'new-center' not in tags:
             log.info(f"new_only set to True and {center.name} does not " +
                      "have `new-center` tag, skipping")
             continue
 
         try:
             center_group = CenterGroup.create_from_center(center=center,
+                                                          tags=tags,
                                                           proxy=proxy)
         except FlywheelError as error:
             log.warning("Unable to create center: %s", str(error))


### PR DESCRIPTION
Remove tags from CenterInfo and refactor how tags are managed by center_management gear. I don't think tags are being used in this context anywhere else. 

From this old conversation here: https://github.com/naccdata/flywheel-gear-extensions/pull/128#discussion_r1878740614

Tagging as unreleased for now as it is not critical and can be bundled with the next necessary update for the Center Management gear.