### PR TITLE
Remove visit number order checks

### DIFF
--- a/common/src/python/test_mocks/mock_forms_store.py
+++ b/common/src/python/test_mocks/mock_forms_store.py
@@ -43,7 +43,7 @@ class MockFormsStore(FormsStore):
         self.__subjects[subject_lbl][module][file_name] = form_data
 
     def is_new_subject(self, subject_lbl: str) -> bool:
-        return subject_lbl in self.__subjects
+        return subject_lbl not in self.__subjects
 
     def query_form_data(self, subject_lbl: str, module: str,
                         **kwargs) -> Optional[List[Dict[str, str]]]:

--- a/common/src/python/utils/utils.py
+++ b/common/src/python/utils/utils.py
@@ -1,6 +1,6 @@
 """Utility functions."""
 import logging
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from configs.ingest_configs import FormProjectConfigs
 from flywheel.models.file_entry import FileEntry
@@ -37,7 +37,7 @@ def update_file_info_metadata(file: FileEntry,
     return True
 
 
-def parse_string_to_list(input_str: str,
+def parse_string_to_list(input_str: Optional[str],
                          to_lower: bool = True,
                          delimiter: str = ',') -> List[str]:
     """Parses a comma delimited string to a list.

--- a/docs/form_transformer/CHANGELOG.md
+++ b/docs/form_transformer/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this gear are documented in this file.
 
+## 1.3.3
+* Removes pre-processing checks on visit number ordering
+
 ## 1.3.2
 * Fixes a bug in visitnum comparison in pre-processing checks
 * Upgrades to dependencies

--- a/gear/form_transformer/src/docker/BUILD
+++ b/gear/form_transformer/src/docker/BUILD
@@ -6,4 +6,4 @@ docker_image(name="form-transformer",
                  ":manifest",
                  "gear/form_transformer/src/python/form_csv_app:bin"
              ],
-             image_tags=["1.3.2", "latest"])
+             image_tags=["1.3.3", "latest"])

--- a/gear/form_transformer/src/docker/manifest.json
+++ b/gear/form_transformer/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "form-transformer",
     "label": "Form CSV to JSON Transformer",
     "description": "Form specific transformation from CSV to JSON",
-    "version": "1.3.2",
+    "version": "1.3.3",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/form-transformer:1.3.2"
+            "image": "naccdata/form-transformer:1.3.3"
         },
         "flywheel": {
             "suite": "Curation",


### PR DESCRIPTION
Removes pre-processing checks on visit number ordering to support centers that doesn't follow natural order of visit numbers