### PR TITLE
Fix curation timeouts

### DIFF
--- a/common/src/python/curator/curator.py
+++ b/common/src/python/curator/curator.py
@@ -8,6 +8,7 @@ from flywheel import Client
 from flywheel.models.file_entry import FileEntry
 from flywheel.models.subject import Subject
 from flywheel_gear_toolkit import GearToolkitContext
+from gear_execution.gear_execution import GearExecutionError
 from nacc_attribute_deriver.symbol_table import SymbolTable
 from nacc_attribute_deriver.utils.scope import ScopeLiterals
 from utils.decorators import api_retry
@@ -59,7 +60,11 @@ class Curator(ABC):
         Returns:
           the corresponding Subject
         """
-        return self.sdk_client.get_subject(subject_id)
+        subject = self.sdk_client.get_subject(subject_id)
+        if not subject:
+            raise GearExecutionError(f"Unable to get subject: {subject_id}")
+
+        return subject
 
     @api_retry
     def get_table(self, subject: Subject,

--- a/common/src/python/curator/curator.py
+++ b/common/src/python/curator/curator.py
@@ -8,7 +8,6 @@ from flywheel import Client
 from flywheel.models.file_entry import FileEntry
 from flywheel.models.subject import Subject
 from flywheel_gear_toolkit import GearToolkitContext
-from gear_execution.gear_execution import GearExecutionError
 from nacc_attribute_deriver.symbol_table import SymbolTable
 from nacc_attribute_deriver.utils.scope import ScopeLiterals
 from utils.decorators import api_retry

--- a/common/src/python/curator/curator.py
+++ b/common/src/python/curator/curator.py
@@ -60,11 +60,7 @@ class Curator(ABC):
         Returns:
           the corresponding Subject
         """
-        subject = self.sdk_client.get_subject(subject_id)
-        if not subject:
-            raise GearExecutionError(f"Unable to get subject: {subject_id}")
-
-        return subject
+        return self.sdk_client.get_subject(subject_id)
 
     @api_retry
     def get_table(self, subject: Subject,

--- a/common/src/python/curator/form_curator.py
+++ b/common/src/python/curator/form_curator.py
@@ -1,7 +1,6 @@
 import logging
 from typing import List
 
-from flywheel import Client
 from flywheel.models.file_entry import FileEntry
 from flywheel.models.subject import Subject
 from nacc_attribute_deriver.attribute_deriver import AttributeDeriver
@@ -18,13 +17,10 @@ class FormCurator(Curator):
     """Curator that uses NACC Attribute Deriver."""
 
     def __init__(self,
-                 sdk_client: Client,
                  deriver: AttributeDeriver,
                  curation_tag: str,
                  force_curate: bool = False) -> None:
-        super().__init__(sdk_client=sdk_client,
-                         curation_tag=curation_tag,
-                         force_curate=force_curate)
+        super().__init__(curation_tag=curation_tag, force_curate=force_curate)
         self.__deriver = deriver
 
     def get_table(self, subject: Subject,

--- a/common/src/python/curator/form_curator.py
+++ b/common/src/python/curator/form_curator.py
@@ -1,9 +1,9 @@
 import logging
+from multiprocessing import Manager
 from typing import List, MutableMapping
 
 from flywheel.models.file_entry import FileEntry
 from flywheel.models.subject import Subject
-from multiprocessing import Manager
 from nacc_attribute_deriver.attribute_deriver import AttributeDeriver
 from nacc_attribute_deriver.symbol_table import SymbolTable
 from nacc_attribute_deriver.utils.scope import ScopeLiterals
@@ -61,8 +61,8 @@ class FormCurator(Curator):
 
     def execute(self, subject: Subject, file_entry: FileEntry,
                 table: SymbolTable, scope: ScopeLiterals) -> None:
-        """Perform contents of curation. Keeps track of files that
-        failed to be curated.
+        """Perform contents of curation. Keeps track of files that failed to be
+        curated.
 
         Args:
             subject: Subject the file belongs to

--- a/common/src/python/curator/form_curator.py
+++ b/common/src/python/curator/form_curator.py
@@ -34,6 +34,7 @@ class FormCurator(Curator):
 
         return super().get_table(subject, file_entry)
 
+    @api_retry
     def apply_curation(self, subject: Subject, file_entry: FileEntry,
                        table: SymbolTable) -> None:
         """Applies the curated information back to FW.
@@ -80,7 +81,7 @@ class FormCurator(Curator):
         # only keep while MQT is being aggressively iterated on
         if self.force_curate:
 
-            # TODO: this needs to be done due to an issue with upsert-hierarchy
+            # TODO: need to reload due to an issue with upsert-hierarchy
             # not creating the info object correctly, so calling delete_info
             # on a subject without info raises an exception.
             # sent support ticket to FW to see if this is something they

--- a/common/src/python/curator/regression_curator.py
+++ b/common/src/python/curator/regression_curator.py
@@ -25,12 +25,7 @@ class RegressionCurator(Curator):
 
     def __init__(self, baseline: MutableMapping,
                  error_writer: ListErrorWriter) -> None:
-        """Initializer.
-
-        Sets force_curate to true since in this case we are always
-        regression testing.
-        """
-        super().__init__(force_curate=True)
+        super().__init__()
         self.__baseline = SymbolTable(baseline)
         self.__error_writer = error_writer
 

--- a/common/src/python/curator/regression_curator.py
+++ b/common/src/python/curator/regression_curator.py
@@ -9,7 +9,6 @@ with NACC or key values such as as visit date.)
 import logging
 from typing import Any, Dict, MutableMapping
 
-from flywheel import Client
 from flywheel.models.file_entry import FileEntry
 from flywheel.models.subject import Subject
 from nacc_attribute_deriver.symbol_table import SymbolTable
@@ -24,9 +23,14 @@ log = logging.getLogger(__name__)
 class RegressionCurator(Curator):
     """Runs regression testing against curation."""
 
-    def __init__(self, sdk_client: Client, baseline: MutableMapping,
+    def __init__(self, baseline: MutableMapping,
                  error_writer: ListErrorWriter) -> None:
-        super().__init__(sdk_client)
+        """Initializer.
+
+        Sets force_curate to true since in this case we are always
+        regression testing.
+        """
+        super().__init__(force_curate=True)
         self.__baseline = SymbolTable(baseline)
         self.__error_writer = error_writer
 

--- a/common/src/python/curator/scheduling.py
+++ b/common/src/python/curator/scheduling.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, List, Literal, Optional
 from curator.curator import Curator
 from dataview.dataview import ColumnModel, make_builder
 from flywheel_adaptor.flywheel_proxy import ProjectAdaptor
+from flywheel_gear_toolkit import GearToolkitContext
 from pydantic import BaseModel, ValidationError, field_validator
 from scheduling.min_heap import MinHeap
 
@@ -169,16 +170,18 @@ class ViewResponseModel(BaseModel):
 curator = None  # global curator object
 
 
-def initialize_worker(in_curator: Curator):
+def initialize_worker(in_curator: Curator, context: GearToolkitContext):
     """Initialize worker context, this function is executed once in each worker
     process upon its creation.
 
     Args:
         in_curator: Curator to use for curation
+        context: context to set SDK client from
     """
     # Make the curator global for spawned process
     global curator
     curator = in_curator
+    curator.set_client(context)
 
 
 def curate_subject(subject_id: str, heap: MinHeap[FileModel]) -> None:
@@ -305,11 +308,12 @@ class ProjectCurationScheduler:
         os_cpu_cores: int = os_cpu_count if os_cpu_count else 1
         return max(1, max(os_cpu_cores - 1, multiprocessing.cpu_count() - 1))
 
-    def apply(self, curator: Curator) -> None:
+    def apply(self, curator: Curator, context: GearToolkitContext) -> None:
         """Applies a Curator to the form files in this curator.
 
         Args:
-          curator: a Curator subclass
+          curator: an instantiated curator class
+          context: context to set SDK client from
         """
         log.info("Start curator for %s subjects", len(self.__heap_map))
 
@@ -318,7 +322,10 @@ class ProjectCurationScheduler:
 
         with Pool(processes=process_count,
                   initializer=initialize_worker,
-                  initargs=(curator, )) as pool:
+                  initargs=(
+                      curator,
+                      context,
+                  )) as pool:
             for subject_id, heap in self.__heap_map.items():
                 log.info("Curating files for subject %s", subject_id)
                 results.append(

--- a/common/src/python/utils/decorators.py
+++ b/common/src/python/utils/decorators.py
@@ -13,7 +13,7 @@ def api_retry(func, max_retries: int = 3):
         retries = 0
         while retries <= max_retries:
             try:
-                func(*args, **kwargs)
+                return func(*args, **kwargs)
                 break
             except ApiException as e:
                 retries += 1

--- a/docs/attribute_curator/CHANGELOG.md
+++ b/docs/attribute_curator/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this gear are documented in this file.
 ## 0.3.1
 
 * Updates how the SDK client is set for multiprocessing - gives each worker its own instance
+* Fixes bug with decorator `api_retry` not returning the returned function value
 
 ## 0.3.0
 

--- a/docs/attribute_curator/CHANGELOG.md
+++ b/docs/attribute_curator/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this gear are documented in this file.
 
+## 0.3.1
+
+* Updates how the SDK client is set for multiprocessing - gives each worker its own instance
+
 ## 0.3.0
 
 * Adds the `historic_apoe` namespace, which requires a 3rd pass category

--- a/docs/attribute_curator/CHANGELOG.md
+++ b/docs/attribute_curator/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this gear are documented in this file.
 ## 0.3.1
 
 * Updates how the SDK client is set for multiprocessing - gives each worker its own instance
+* Updates to keep track of files that failed to be curated instead of just immediately dying, and report at end
 * Fixes bug with decorator `api_retry` not returning the returned function value
 
 ## 0.3.0

--- a/gear/attribute_curator/src/docker/BUILD
+++ b/gear/attribute_curator/src/docker/BUILD
@@ -6,4 +6,4 @@ docker_image(name="attribute-curator",
                  ":manifest",
                  "gear/attribute_curator/src/python/attribute_curator_app:bin"
              ],
-             image_tags=["0.3.1a", "latest"])
+             image_tags=["0.3.1", "latest"])

--- a/gear/attribute_curator/src/docker/BUILD
+++ b/gear/attribute_curator/src/docker/BUILD
@@ -6,4 +6,4 @@ docker_image(name="attribute-curator",
                  ":manifest",
                  "gear/attribute_curator/src/python/attribute_curator_app:bin"
              ],
-             image_tags=["0.3.0", "latest"])
+             image_tags=["0.3.1a", "latest"])

--- a/gear/attribute_curator/src/docker/manifest.json
+++ b/gear/attribute_curator/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "attribute-curator",
     "label": "Attribute Curator",
     "description": "Curation of derived data for MQT project",
-    "version": "0.3.1a",
+    "version": "0.3.1",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "analysis",
-            "image": "naccdata/attribute-curator:0.3.1a"
+            "image": "naccdata/attribute-curator:0.3.1"
         },
         "flywheel": {
             "suite": "Curation",

--- a/gear/attribute_curator/src/docker/manifest.json
+++ b/gear/attribute_curator/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "attribute-curator",
     "label": "Attribute Curator",
     "description": "Curation of derived data for MQT project",
-    "version": "0.3.0",
+    "version": "0.3.1a",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "analysis",
-            "image": "naccdata/attribute-curator:0.3.0"
+            "image": "naccdata/attribute-curator:0.3.1a"
         },
         "flywheel": {
             "suite": "Curation",

--- a/gear/attribute_curator/src/python/attribute_curator_app/main.py
+++ b/gear/attribute_curator/src/python/attribute_curator_app/main.py
@@ -24,9 +24,8 @@ def run(context: GearToolkitContext,
         curation_tag: Tag to apply to curated files
         force_curate: Curate file even if it's already been curated
     """
-    curator = FormCurator(sdk_client=context.get_client(),
-                          deriver=deriver,
+    curator = FormCurator(deriver=deriver,
                           curation_tag=curation_tag,
                           force_curate=force_curate)
 
-    scheduler.apply(curator=curator)
+    scheduler.apply(curator=curator, context=context)

--- a/gear/attribute_curator/src/python/attribute_curator_app/main.py
+++ b/gear/attribute_curator/src/python/attribute_curator_app/main.py
@@ -35,4 +35,5 @@ def run(context: GearToolkitContext,
     if curator.failed_files:
         log.error(json.dumps(curator.failed_files, indent=4))
         raise GearExecutionError(
-            f"Failed to curate {len(curation.failed_files)} files, see above error logs")
+            f"Failed to curate {len(curator.failed_files)} files, see above error logs"
+        )

--- a/gear/attribute_curator/src/python/attribute_curator_app/main.py
+++ b/gear/attribute_curator/src/python/attribute_curator_app/main.py
@@ -1,9 +1,11 @@
 """Defines Attribute Curator."""
+import json
 import logging
 
 from curator.form_curator import FormCurator
 from curator.scheduling import ProjectCurationScheduler
 from flywheel_gear_toolkit import GearToolkitContext
+from gear_execution.gear_execution import GearExecutionError
 from nacc_attribute_deriver.attribute_deriver import AttributeDeriver
 
 log = logging.getLogger(__name__)
@@ -29,3 +31,8 @@ def run(context: GearToolkitContext,
                           force_curate=force_curate)
 
     scheduler.apply(curator=curator, context=context)
+
+    if curator.failed_files:
+        log.error(json.dumps(curator.failed_files, indent=4))
+        raise GearExecutionError(
+            f"Failed to curate {len(curation.failed_files)} files, see above error logs")

--- a/gear/regression_curator/src/python/regression_curator_app/main.py
+++ b/gear/regression_curator/src/python/regression_curator_app/main.py
@@ -124,8 +124,6 @@ def run(context: GearToolkitContext, s3_qaf_file: str, keep_fields: List[str],
     """
     baseline = localize_qaf(s3_qaf_file, keep_fields, error_writer)
 
-    curator = RegressionCurator(sdk_client=context.get_client(),
-                                baseline=baseline,
-                                error_writer=error_writer)
+    curator = RegressionCurator(baseline=baseline, error_writer=error_writer)
 
-    scheduler.apply(curator=curator)
+    scheduler.apply(curator=curator, context=context)


### PR DESCRIPTION
* Updates how the SDK client is set for multiprocessing - gives each worker its own instance
* Updates to keep track of files that failed to be curated instead of just immediately dying, and report at end
* Fixes bug with decorator `api_retry` not returning the returned function value

Turns out the API does in fact return a lot of connection errors when a single SDK client is used across all workers (likely race condition, interestingly does not happen when gear is run locally), so resolve by creating a new SDK client for each worker.
