### PR TITLE
Fixes DictProxy error and reduces overhead of reloading subject.info

### DIFF
--- a/common/src/python/curator/form_curator.py
+++ b/common/src/python/curator/form_curator.py
@@ -1,6 +1,7 @@
 import logging
 from multiprocessing import Manager
-from typing import List, MutableMapping
+from multiprocessing.managers import DictProxy
+from typing import List
 
 from flywheel.models.file_entry import FileEntry
 from flywheel.models.subject import Subject
@@ -26,7 +27,7 @@ class FormCurator(Curator):
         self.__failed_files = Manager().dict()
 
     @property
-    def failed_files(self) -> MutableMapping:
+    def failed_files(self) -> DictProxy:
         return self.__failed_files
 
     def get_table(self, subject: Subject,

--- a/common/src/python/curator/form_curator.py
+++ b/common/src/python/curator/form_curator.py
@@ -5,6 +5,7 @@ from typing import List
 
 from flywheel.models.file_entry import FileEntry
 from flywheel.models.subject import Subject
+from flywheel.rest import ApiException
 from nacc_attribute_deriver.attribute_deriver import AttributeDeriver
 from nacc_attribute_deriver.symbol_table import SymbolTable
 from nacc_attribute_deriver.utils.scope import ScopeLiterals
@@ -95,22 +96,26 @@ class FormCurator(Curator):
         # only keep while MQT is being aggressively iterated on
         if self.force_curate:
 
-            # TODO: need to reload due to an issue with upsert-hierarchy
-            # not creating the info object correctly, so calling delete_info
-            # on a subject without info raises an exception.
-            # sent support ticket to FW to see if this is something they
-            # can resolve on their end
-            subject = subject.reload()
-            if subject.info:
-                log.info(
-                    f"Force curation set to True, cleaning up {subject.label} metadata"
-                )
-                for field in [
-                        'cognitive.uds', 'demographics.uds', 'derived',
-                        'genetics', 'longitudinal-data.uds', 'neuropathology',
-                        'study-parameters.uds'
-                ]:
+            # TODO: there is an issue with upsert-hierarchy not creating the
+            # info object correctly, so calling delete_info on a subject without
+            # info raises an exception. FW is aware of issue but may not be fixed
+            # for a while. however calling subject.reload() for everything introduces
+            # significant overhead, so instead just catch when it fails (which will be
+            # much rarer)
+            log.info(
+                f"Force curation set to True, cleaning up {subject.label} metadata"
+            )
+            for field in [
+                    'cognitive.uds', 'demographics.uds', 'derived', 'genetics',
+                    'longitudinal-data.uds', 'neuropathology',
+                    'study-parameters.uds'
+            ]:
+                try:
                     subject.delete_info(field)
+                except ApiException as e:  # check if it failed due to info object
+                    if str(e) == "(500) Reason: 'info'":
+                        break
+                    raise e
 
     @api_retry
     def post_process(self, subject: Subject,

--- a/docs/attribute_curator/CHANGELOG.md
+++ b/docs/attribute_curator/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this gear are documented in this file.
 
+## 0.3.2
+
+* Fixes DictProxy error on reporting failed files
+
 ## 0.3.1
 
 * Updates how the SDK client is set for multiprocessing - gives each worker its own instance

--- a/docs/attribute_curator/CHANGELOG.md
+++ b/docs/attribute_curator/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this gear are documented in this file.
 
 ## 0.3.2
 
+* Updates how metadata deletions are handled to reduce overhead
 * Fixes DictProxy error on reporting failed files
 
 ## 0.3.1

--- a/gear/attribute_curator/src/docker/BUILD
+++ b/gear/attribute_curator/src/docker/BUILD
@@ -6,4 +6,4 @@ docker_image(name="attribute-curator",
                  ":manifest",
                  "gear/attribute_curator/src/python/attribute_curator_app:bin"
              ],
-             image_tags=["0.3.1", "latest"])
+             image_tags=["0.3.2", "latest"])

--- a/gear/attribute_curator/src/docker/manifest.json
+++ b/gear/attribute_curator/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "attribute-curator",
     "label": "Attribute Curator",
     "description": "Curation of derived data for MQT project",
-    "version": "0.3.1",
+    "version": "0.3.2",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "analysis",
-            "image": "naccdata/attribute-curator:0.3.1"
+            "image": "naccdata/attribute-curator:0.3.2"
         },
         "flywheel": {
             "suite": "Curation",

--- a/gear/attribute_curator/src/python/attribute_curator_app/main.py
+++ b/gear/attribute_curator/src/python/attribute_curator_app/main.py
@@ -33,7 +33,8 @@ def run(context: GearToolkitContext,
     scheduler.apply(curator=curator, context=context)
 
     if curator.failed_files:
-        log.error(json.dumps(curator.failed_files, indent=4))
+        failed_files = curator.failed_files.copy()
+        log.error(json.dumps(failed_files, indent=4))
         raise GearExecutionError(
-            f"Failed to curate {len(curator.failed_files)} files, see above error logs"
+            f"Failed to curate {len(failed_files)} files, see above error logs"
         )


### PR DESCRIPTION
Fixes error with DictProxy when reporting failed files ([see this FW log for an example](https://flywheel.naccdata.org/#/jobs/6844ab5933e172c278e28c27?sort=created:desc&state=failed&gear=attribute-curator)). Also reduces overhead of deleting subject.info by catching the issue of no info property in a try/catch instead of reloading every single subject 