### PR TITLE
Trigger QC checks on dependent modules

### DIFF
--- a/common/src/python/configs/ingest_configs.py
+++ b/common/src/python/configs/ingest_configs.py
@@ -8,6 +8,8 @@ from gear_execution.gear_trigger import GearInfo
 from keys.keys import DefaultValues
 from pydantic import BaseModel, Field, RootModel
 
+PipelineType = Literal['submission', 'finalization']
+
 
 class LabelTemplate(BaseModel):
     """Defines a string template object for generating labels using input data
@@ -148,7 +150,7 @@ class FormProjectConfigs(BaseModel):
 
 class Pipeline(BaseModel):
     """Defines model for form scheduler pipeline."""
-    name: Literal['submission', 'finalization']
+    name: PipelineType
     modules: List[str]
     tags: List[str]
     extensions: List[str]

--- a/common/src/python/configs/ingest_configs.py
+++ b/common/src/python/configs/ingest_configs.py
@@ -124,3 +124,22 @@ class FormProjectConfigs(BaseModel):
     accepted_modules: List[str]
     legacy_project_label: Optional[str] = DefaultValues.LEGACY_PRJ_LABEL
     module_configs: Dict[str, ModuleConfigs]
+
+    def get_module_dependencies(self, module: str) -> Optional[List[str]]:
+        """Returns the list of dependent modules for a given module.
+
+        Args:
+            module: module label
+
+        Returns:
+            List[str](optional): list of dependent module labels if found
+        """
+
+        dependent_modules = []
+        for module_label, config in self.module_configs.items():
+            if (config.supplement_module
+                    and config.supplement_module.exact_match
+                    and config.supplement_module.label == module.upper()):
+                dependent_modules.append(module_label)
+
+        return dependent_modules

--- a/common/src/python/configs/ingest_configs.py
+++ b/common/src/python/configs/ingest_configs.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from string import Template
 from typing import Any, Dict, List, Literal, Optional
 
+from gear_execution.gear_trigger import GearInfo
 from keys.keys import DefaultValues
 from pydantic import BaseModel, Field, RootModel
 
@@ -143,3 +144,16 @@ class FormProjectConfigs(BaseModel):
                 dependent_modules.append(module_label)
 
         return dependent_modules
+
+
+class Pipeline(BaseModel):
+    name: str
+    modules: List[str]
+    tags: List[str]
+    extensions: List[str]
+    starting_gear: GearInfo
+
+
+class PipelineConfigs(BaseModel):
+    gears: List[str]
+    pipelines: List[Pipeline]

--- a/common/src/python/configs/ingest_configs.py
+++ b/common/src/python/configs/ingest_configs.py
@@ -147,7 +147,8 @@ class FormProjectConfigs(BaseModel):
 
 
 class Pipeline(BaseModel):
-    name: str
+    """Defines model for form scheduler pipeline."""
+    name: Literal['submission', 'finalization']
     modules: List[str]
     tags: List[str]
     extensions: List[str]

--- a/common/src/python/configs/ingest_configs.py
+++ b/common/src/python/configs/ingest_configs.py
@@ -153,6 +153,7 @@ class Pipeline(BaseModel):
     tags: List[str]
     extensions: List[str]
     starting_gear: GearInfo
+    notify_user: bool = False
 
 
 class PipelineConfigs(BaseModel):

--- a/common/src/python/dates/form_dates.py
+++ b/common/src/python/dates/form_dates.py
@@ -9,6 +9,7 @@ from dateutil import parser
 DATE_FORMATS = ['%m/%d/%Y', '%m-%d-%Y', '%Y/%m/%d', '%Y-%m-%d']
 DATE_PATTERN = r"^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$"
 DEFAULT_DATE_FORMAT = '%Y-%m-%d'
+DEFAULT_DATE_TIME_FORMAT = '%Y-%m-%d %H:%M:%S'
 
 
 def parse_date(*, date_string: str, formats: List[str]) -> datetime:

--- a/common/src/python/enrollment/enrollment_subject.py
+++ b/common/src/python/enrollment/enrollment_subject.py
@@ -3,6 +3,7 @@
 from datetime import datetime
 from typing import Optional
 
+from dates.form_dates import DEFAULT_DATE_FORMAT
 from flywheel_adaptor.subject_adaptor import SubjectAdaptor
 from identifiers.model import CenterFields, GUIDField, NACCIDField
 from keys.keys import DefaultValues
@@ -100,7 +101,7 @@ class EnrollmentSubject(SubjectAdaptor):
         Args:
           record: the enrollment record
         """
-        formdate = record.start_date.strftime("%Y-%m-%d")
+        formdate = record.start_date.strftime(DEFAULT_DATE_FORMAT)
         session_label = f'{DefaultValues.ENRL_SESSION_LBL_PRFX}{formdate}'
         self.upload_acquisition_file(
             session_label=session_label,

--- a/common/src/python/flywheel_adaptor/flywheel_proxy.py
+++ b/common/src/python/flywheel_adaptor/flywheel_proxy.py
@@ -4,7 +4,7 @@ import json
 import logging
 from codecs import StreamReader
 from json.decoder import JSONDecodeError
-from typing import Any, Dict, Iterable, List, Mapping, Optional
+from typing import Any, Dict, Iterable, List, Literal, Mapping, Optional
 
 import flywheel
 from flywheel import (
@@ -646,17 +646,17 @@ class FlywheelProxy:
             return None
 
     def get_matching_acquisition_files_info(
-            self,
-            *,
-            container_id: str,
-            dv_title: str,
-            columns: List[str],
-            filename_pattern: Optional[str] = '*.json',
-            filters: Optional[str] = None) -> Optional[List[Dict[str, str]]]:
+        self,
+        *,
+        container_id: str,
+        dv_title: str,
+        columns: List[str],
+        filename_pattern: Optional[str] = '*.json',
+        filters: Optional[str] = None,
+        missing_data_strategy: Literal['drop-row', 'none'] = 'drop-row'
+    ) -> Optional[List[Dict[str, str]]]:
         """Retrieve info on the list of files matching with the given filters
         (if any) from the specified Flywheel container.
-
-        Note: missing_data_strategy is set to 'drop-row'
 
         Args:
             container_id: Flywheel container ID
@@ -664,6 +664,7 @@ class FlywheelProxy:
             columns: list of columns to be included in dataview
             filename_pattern (optional): the filename pattern to match, default '*.json'
             filters (optional): If specified, returns visits matching with the filter
+            missing_data_strategy: missing_data_strategy, default 'drop-row'
 
         Returns:
             List[Dict]: List of visits matching with the specified filters
@@ -678,7 +679,7 @@ class FlywheelProxy:
                               filter=filters,
                               include_ids=False,
                               include_labels=False)
-        builder = builder.missing_data_strategy('drop-row')
+        builder = builder.missing_data_strategy(missing_data_strategy)
         view = builder.build()
 
         with self.read_view_data(view, container_id) as resp:

--- a/common/src/python/flywheel_adaptor/flywheel_proxy.py
+++ b/common/src/python/flywheel_adaptor/flywheel_proxy.py
@@ -17,6 +17,7 @@ from flywheel import (
 )
 from flywheel.models.access_permission import AccessPermission
 from flywheel.models.acquisition import Acquisition
+from flywheel.models.container_output import ContainerOutput
 from flywheel.models.file_entry import FileEntry
 from flywheel.models.group_role import GroupRole
 from flywheel.models.job import Job
@@ -708,6 +709,17 @@ class FlywheelProxy:
             ResolverOutput
         """
         return self.__fw.lookup(path)
+
+    def get_container_by_id(self, container_id: str) -> ContainerOutput:
+        """Find the Flywheel container for the specified ID.
+
+        Args:
+            container_id: ID to lookup the container
+
+        Returns:
+            ContainerOutput: Container object
+        """
+        return self.__fw.get(container_id)
 
 
 def get_name(container) -> str:

--- a/common/src/python/flywheel_adaptor/subject_adaptor.py
+++ b/common/src/python/flywheel_adaptor/subject_adaptor.py
@@ -33,6 +33,7 @@ class VisitInfo(BaseModel):
     file_id: Optional[str] = None  # Flywheel File ID
     visitdate: str = Field(pattern=DATE_PATTERN)
     visitnum: Optional[str] = None
+    validated_timestamp: Optional[str] = None
 
 
 class ParticipantVisits(BaseModel):

--- a/common/src/python/flywheel_adaptor/subject_adaptor.py
+++ b/common/src/python/flywheel_adaptor/subject_adaptor.py
@@ -32,6 +32,7 @@ class VisitInfo(BaseModel):
     filename: str
     file_id: Optional[str] = None  # Flywheel File ID
     visitdate: str = Field(pattern=DATE_PATTERN)
+    visitnum: Optional[str] = None
 
 
 class ParticipantVisits(BaseModel):

--- a/common/src/python/gear_execution/gear_execution.py
+++ b/common/src/python/gear_execution/gear_execution.py
@@ -172,6 +172,9 @@ class InputFileWrapper:
             if mimetype.find(extension.lower()) != -1:
                 return extension.lower()
 
+            if self.filename.lower().endswith(f".{extension.lower()}"):
+                return extension.lower()
+
         return None
 
     @property

--- a/common/src/python/gear_execution/gear_execution.py
+++ b/common/src/python/gear_execution/gear_execution.py
@@ -154,6 +154,26 @@ class InputFileWrapper:
         container = container.reload()
         return container.get_file(self.filename)
 
+    def validate_file_extension(
+            self, accepted_extensions: List[str]) -> Optional[str]:
+        """Check whether the input file type is accepted.
+
+        Args:
+            accepted_extensions: list of accepted file extensions
+
+        Returns:
+            Optional[str]: If accepted file type, return the file extension, else None
+        """
+        if not self.file_type:
+            return None
+
+        mimetype = self.file_type.lower()
+        for extension in accepted_extensions:
+            if mimetype.find(extension.lower()) != -1:
+                return extension.lower()
+
+        return None
+
     @property
     def file_id(self) -> str:
         """Returns the file ID."""

--- a/common/src/python/gear_execution/gear_trigger.py
+++ b/common/src/python/gear_execution/gear_trigger.py
@@ -25,7 +25,7 @@ LocatorType = Literal['matched', 'module', 'fixed']
 class GearInput(BaseModel):
     label: str
     file_locator: LocatorType
-    file_name: Optional[str]
+    file_name: Optional[str] = None
 
     @model_validator(mode='after')
     def validate_iteration_mode(self) -> 'GearInput':

--- a/common/src/python/gear_execution/gear_trigger.py
+++ b/common/src/python/gear_execution/gear_trigger.py
@@ -233,12 +233,16 @@ class BatchRunInfo(BaseModel):
         return configs
 
 
-def trigger_gear(proxy: FlywheelProxy, gear_name: str, **kwargs) -> str:
+def trigger_gear(proxy: FlywheelProxy,
+                 gear_name: str,
+                 log_args: bool = True,
+                 **kwargs) -> str:
     """Trigger the gear.
 
     Args:
         proxy: the proxy for the Flywheel instance
         gear_name: the name of the gear to trigger
+        log_args: whether to log argument details (default True)
         kwargs: keyword arguments to pass to gear.run, which include:
             config: the configs to pass to the gear
             inputs: The inputs to pass to the gear
@@ -261,11 +265,12 @@ def trigger_gear(proxy: FlywheelProxy, gear_name: str, **kwargs) -> str:
     if destination:
         destination = destination.label
 
-    log.info(f"Triggering {gear_name} with the following args:")
-    log.info(f"config: {kwargs.get('config')}")
-    log.info(f"inputs: {kwargs.get('inputs')}")
-    log.info(f"destination: {destination}")
-    log.info(f"analysis_label: {kwargs.get('analysis_label')}")
-    log.info(f"tags: {kwargs.get('tags')}")
+    if log_args:
+        log.info(f"Triggering {gear_name} with the following args:")
+        log.info(f"config: {kwargs.get('config')}")
+        log.info(f"inputs: {kwargs.get('inputs')}")
+        log.info(f"destination: {destination}")
+        log.info(f"analysis_label: {kwargs.get('analysis_label')}")
+        log.info(f"tags: {kwargs.get('tags')}")
 
     return gear.run(**kwargs)

--- a/common/src/python/gear_execution/gear_trigger.py
+++ b/common/src/python/gear_execution/gear_trigger.py
@@ -119,7 +119,7 @@ class GearInfo(BaseModel):
             log.info('No inputs specified for gear %s', self.gear_name)
             return None
 
-        inputs_list = {}
+        inputs_list: Dict[str, List[GearInput]] = {}
         for gear_input in self.inputs:
             if gear_input.file_locator not in locators:
                 continue

--- a/common/src/python/gear_execution/gear_trigger.py
+++ b/common/src/python/gear_execution/gear_trigger.py
@@ -55,7 +55,12 @@ class GearConfigs(BaseModel):
     """Class to represent base gear configs."""
     model_config = ConfigDict(populate_by_name=True, extra='allow')
 
-    apikey_path_prefix: Optional[str] = None
+
+class CredentialGearConfigs(GearConfigs):
+    """Class to represent credentials gear configs."""
+    model_config = ConfigDict(populate_by_name=True, extra='allow')
+
+    apikey_path_prefix: str
 
 
 class GearInfo(BaseModel):
@@ -93,10 +98,6 @@ class GearInfo(BaseModel):
             return None
 
         input_configs = configs_data.get('configs')
-        if not input_configs:
-            log.error('No gear configs data found')
-            return None
-
         try:
             configs_data['configs'] = configs_class.model_validate(
                 input_configs)

--- a/common/src/python/jobs/job_poll.py
+++ b/common/src/python/jobs/job_poll.py
@@ -119,4 +119,30 @@ class JobPoll:
                 # of other submission pipelines, we just wait for it to finish
                 JobPoll.poll_job_status(job)
             else:
+
                 running = False
+
+    @classmethod
+    def is_another_gear_instance_running(cls, *, proxy: FlywheelProxy, gear_name: str,
+                                         project_id: str,
+                                         current_job: str) -> bool:
+        """Find whether another instance of the specified gear is running
+        Args:
+            proxy: the proxy for the Flywheel instance
+            gear_name: gear name to check
+            project_id: Flywheel project to check
+            current_job: current job id
+
+        Returns:
+            bool: True if another job found, else False
+        """
+        search_str = JobPoll.generate_search_string(
+            project_ids_list=[project_id],
+            gears_list=[gear_name],
+            states_list=['running', 'pending'])
+
+        matched_jobs = proxy.find_jobs(search_str)
+        if len(matched_jobs) > 1:
+            return True
+
+        return (current_job != matched_jobs[0].id)

--- a/common/src/python/jobs/job_poll.py
+++ b/common/src/python/jobs/job_poll.py
@@ -123,8 +123,8 @@ class JobPoll:
                 running = False
 
     @classmethod
-    def is_another_gear_instance_running(cls, *, proxy: FlywheelProxy, gear_name: str,
-                                         project_id: str,
+    def is_another_gear_instance_running(cls, *, proxy: FlywheelProxy,
+                                         gear_name: str, project_id: str,
                                          current_job: str) -> bool:
         """Find whether another instance of the specified gear is running
         Args:

--- a/common/src/python/keys/keys.py
+++ b/common/src/python/keys/keys.py
@@ -68,6 +68,9 @@ class DefaultValues:
     UDS_IT_PACKET = 'IT'
     UDS_I4_PACKET = 'I4'
     UDS_F_PACKET = 'F'
+    SUBMISSION_PIPELINE = 'submission'
+    FINALIZATION_PIPELINE = 'finalization'
+    FINALIZED_TAG = 'submission-completed'
 
 
 class MetadataKeys:

--- a/common/src/python/keys/keys.py
+++ b/common/src/python/keys/keys.py
@@ -86,6 +86,12 @@ class MetadataKeys:
     TRANSFERS = 'transfers'
     MODULE_CONFIGS = 'module_configs'
     FORM_METADATA_PATH = 'file.info.forms.json'
+    VALIDATED_TIMESTAMP = 'validated-timestamp'
+    TRIGGERED_TIMESTAMP = 'triggered-timestamp'
+
+    @classmethod
+    def get_column_key(cls, column: str) -> str:
+        return f'{cls.FORM_METADATA_PATH}.{column}'
 
 
 class SysErrorCodes:

--- a/common/src/python/outputs/errors.py
+++ b/common/src/python/outputs/errors.py
@@ -19,6 +19,8 @@ from outputs.outputs import CSVWriter
 
 log = logging.getLogger(__name__)
 
+MetadataCleanupFlag = Literal['ALL', 'GEAR', 'NA']
+
 preprocess_errors = {
     SysErrorCodes.ADCID_MISMATCH:
     "ADCID must match the ADCID of the center uploading the data",
@@ -455,13 +457,14 @@ class ListHandler(Handler):
         return self.__logs
 
 
-def update_error_log_and_qc_metadata(*,
-                                     error_log_name: str,
-                                     destination_prj: ProjectAdaptor,
-                                     gear_name: str,
-                                     state: str,
-                                     errors: MutableSequence[Dict[str, Any]],
-                                     reset_metadata: bool = False) -> bool:
+def update_error_log_and_qc_metadata(
+        *,
+        error_log_name: str,
+        destination_prj: ProjectAdaptor,
+        gear_name: str,
+        state: str,
+        errors: MutableSequence[Dict[str, Any]],
+        reset_qc_metadata: MetadataCleanupFlag = 'NA') -> bool:
     """Update project level error log file and store error metadata in
     file.info.qc.
 
@@ -471,7 +474,10 @@ def update_error_log_and_qc_metadata(*,
         gear_name: gear that generated errors
         state: gear execution status [PASS|FAIL|NA]
         errors: list of error objects, expected to be JSON dicts
-        reset_metadata: reset metadata from previous runs, set to True for first gear
+        reset_qc_metadata: flag to reset metadata from previous runs:
+            ALL - clean all, set this for the first gear in submission pipeline.
+            GEAR - reset only current gear metadata from previous runs.
+            NA - do not reset (Default).
 
     Returns:
         bool: True if metadata update is successful, else False
@@ -484,7 +490,7 @@ def update_error_log_and_qc_metadata(*,
     # append to existing error details if any
     if current_log:
         current_log = current_log.reload()
-        if current_log.info and 'qc' in current_log.info and not reset_metadata:
+        if current_log.info and 'qc' in current_log.info and reset_qc_metadata != 'ALL':
             info = current_log.info
         contents = (current_log.read()).decode('utf-8')  # type: ignore
 
@@ -506,15 +512,16 @@ def update_error_log_and_qc_metadata(*,
                   f'{destination_prj.group}/{destination_prj.label}: {error}')
         return False
 
-    # if error data already exists, append to data
-    existing_errors = info.get('qc', {}).get(gear_name, {}) \
-        .get('validation', {}).get('data', [])
-    existing_errors.extend(errors)
+    if reset_qc_metadata == 'NA':
+        # if error data already exists, append to data
+        existing_errors = info.get('qc', {}).get(gear_name, {}) \
+            .get('validation', {}).get('data', [])
+        errors.extend(existing_errors)
 
     info["qc"][gear_name] = {
         "validation": {
             "state": state.upper(),
-            "data": existing_errors
+            "data": errors
         }
     }
     try:
@@ -562,3 +569,34 @@ def get_error_log_name(
     return (
         f'{cleaned_ptid}_{normalized_date}_{module.lower()}_{errorlog_template.suffix}.{errorlog_template.extension}'
     )
+
+
+def reset_error_log_metadata_for_gears(*, error_log_name: str,
+                                       destination_prj: ProjectAdaptor,
+                                       gear_names: List[str]) -> None:
+    """Reset error log file QC metadata in file.info.qc.<gear_name> for the
+    specified gears.
+
+    Args:
+        error_log_name: error log file name
+        destination_prj: Flywheel project adaptor
+        gear_names: list of gears to clear qc metadata
+    """
+    current_log = destination_prj.get_file(error_log_name)
+    if not current_log:
+        return
+
+    current_log = current_log.reload()
+    if not current_log.info or not current_log.info.get('qc'):
+        return
+
+    # make sure to load the existing metadata first and then modify
+    # update_info() will replace everything under the top-level key
+    qc_info: Dict[str, Any] = current_log.info.get('qc', {})
+
+    for gear_name in gear_names:
+        qc_info.pop(gear_name, None)
+
+    # Note: have to use update_info() here for reset to take effect
+    # Using update() will not delete any existing data
+    current_log.update_info({'qc': qc_info})

--- a/common/src/python/outputs/errors.py
+++ b/common/src/python/outputs/errors.py
@@ -8,7 +8,7 @@ from logging import Handler, Logger
 from typing import Any, Dict, List, Literal, MutableSequence, Optional, TextIO
 
 from configs.ingest_configs import ErrorLogTemplate
-from dates.form_dates import DEFAULT_DATE_FORMAT, convert_date
+from dates.form_dates import DEFAULT_DATE_FORMAT, DEFAULT_DATE_TIME_FORMAT, convert_date
 from flywheel.file_spec import FileSpec
 from flywheel.rest import ApiException
 from flywheel_adaptor.flywheel_proxy import ProjectAdaptor
@@ -329,7 +329,7 @@ class ErrorWriter(ABC):
 
     def __init__(self):
         """Initializer - sets the timestamp to time of creation."""
-        self.__timestamp = (dt.now()).strftime('%Y-%m-%d %H:%M:%S')
+        self.__timestamp = (dt.now()).strftime(DEFAULT_DATE_TIME_FORMAT)
 
     def set_timestamp(self, error: FileError) -> None:
         """Assigns the timestamp to the error."""
@@ -488,7 +488,7 @@ def update_error_log_and_qc_metadata(*,
             info = current_log.info
         contents = (current_log.read()).decode('utf-8')  # type: ignore
 
-    timestamp = (dt.now()).strftime('%Y-%m-%d %H:%M:%S')
+    timestamp = (dt.now()).strftime(DEFAULT_DATE_TIME_FORMAT)
     contents += f'{timestamp} QC Status: {gear_name.upper()} - {state.upper()}\n'
     for error in errors:
         contents += json.dumps(error) + '\n'

--- a/common/src/python/outputs/errors.py
+++ b/common/src/python/outputs/errors.py
@@ -512,16 +512,17 @@ def update_error_log_and_qc_metadata(
                   f'{destination_prj.group}/{destination_prj.label}: {error}')
         return False
 
+    updated_errors = []
     if reset_qc_metadata == 'NA':
-        # if error data already exists, append to data
-        existing_errors = info.get('qc', {}).get(gear_name, {}) \
+        # if not to reset, pull error data that already exists
+        updated_errors = info.get('qc', {}).get(gear_name, {}) \
             .get('validation', {}).get('data', [])
-        errors.extend(existing_errors)
+    updated_errors.extend(errors)
 
     info["qc"][gear_name] = {
         "validation": {
             "state": state.upper(),
-            "data": errors
+            "data": updated_errors
         }
     }
     try:

--- a/common/src/python/utils/utils.py
+++ b/common/src/python/utils/utils.py
@@ -3,38 +3,8 @@ import logging
 from typing import Any, Dict, List, MutableMapping, Optional, Tuple
 
 from configs.ingest_configs import FormProjectConfigs
-from flywheel.models.file_entry import FileEntry
-from flywheel.rest import ApiException
 
 log = logging.getLogger(__name__)
-
-
-def update_file_info_metadata(file: FileEntry,
-                              input_record: Dict[str, Any],
-                              modality: str = 'Form') -> bool:
-    """Set file modality and info.forms.json metadata.
-
-    Args:
-        file: Flywheel file object
-        input_record: input visit data
-        modality: file modality (defaults to Form)
-
-    Returns:
-        True if metadata update is successful
-    """
-
-    # remove empty fields
-    non_empty_fields = {k: v for k, v in input_record.items() if v is not None}
-    info = {"forms": {"json": non_empty_fields}}
-
-    try:
-        file.update(modality=modality)
-        file.update_info(info)
-    except ApiException as error:
-        log.error('Error in setting file %s metadata - %s', file.name, error)
-        return False
-
-    return True
 
 
 def parse_string_to_list(input_str: Optional[str],

--- a/common/test/python/gear_execution/data/custom-configs-with-invalid-input.json
+++ b/common/test/python/gear_execution/data/custom-configs-with-invalid-input.json
@@ -1,0 +1,26 @@
+{
+    "gear_name": "custom-configs",
+    "inputs": [
+        {
+            "label": "input_file1",
+            "file_locator": "fixed"
+        },
+        {
+            "label": "input_file2",
+            "file_locator": "module",
+            "file_name": "${module}-schema.json"
+        }
+    ],
+    "configs": {
+        "test_str": "hello",
+        "test_int": 1,
+        "test_list": [
+            {
+                "key": "value"
+            },
+            2,
+            "world"
+        ],
+        "apikey_path_prefix": "/test/dummy/gearbot"
+    }
+}

--- a/common/test/python/gear_execution/data/custom-configs-with-valid-input.json
+++ b/common/test/python/gear_execution/data/custom-configs-with-valid-input.json
@@ -1,0 +1,26 @@
+{
+    "gear_name": "custom-configs",
+    "inputs": [
+        {
+            "label": "input_file1",
+            "file_locator": "matched"
+        },
+        {
+            "label": "input_file2",
+            "file_locator": "module",
+            "file_name": "${module}-schema.json"
+        }
+    ],
+    "configs": {
+        "test_str": "hello",
+        "test_int": 1,
+        "test_list": [
+            {
+                "key": "value"
+            },
+            2,
+            "world"
+        ],
+        "apikey_path_prefix": "/test/dummy/gearbot"
+    }
+}

--- a/common/test/python/gear_execution/test_gear_info.py
+++ b/common/test/python/gear_execution/test_gear_info.py
@@ -8,7 +8,6 @@ TEST_FILES_DIR = Path(__file__).parent.resolve() / 'data'
 
 
 class DummyGearConfigs(GearConfigs):
-
     test_str: str
     test_int: int
     test_list: List[Any]
@@ -18,7 +17,7 @@ class DummyGearConfigs(GearConfigs):
 class TestGearInfo:
     """Tests the GearInfo and GearConfigs pydantic classes."""
 
-    def test_basic_create(self):
+    def test_basic_configs(self):
         """Test a basic create with default GearConfigs class."""
 
         # assert that when empty fails/returns None
@@ -40,10 +39,11 @@ class TestGearInfo:
             "gear_name": "basic-configs",
             "configs": {
                 "apikey_path_prefix": "/test/dummy/gearbot"
-            }
+            },
+            "inputs": None
         }
 
-    def test_custom_create(self):
+    def test_custom_configs(self):
         """Test a create with custom GearConfigs class."""
         # assert that without apikey_path_prefix this fails/returns None
         assert GearInfo.load_from_file(
@@ -77,4 +77,48 @@ class TestGearInfo:
         assert result.configs.test_optional == 'optional'
         assert result.model_dump() != configs
         configs['configs']['test_optional'] = 'optional'
+        configs['inputs'] = None
+        assert result.model_dump() == configs
+
+    def test_config_with_input_info(self):
+        """Test a custom GearConfigs class with input info."""
+        # assert that config with invalid input returns None
+        assert GearInfo.load_from_file(
+            str(TEST_FILES_DIR / 'custom-configs-with-invalid-input.json'),
+            DummyGearConfigs) is None
+
+        # now make sure that valid input passes
+        result = GearInfo.load_from_file(
+            str(TEST_FILES_DIR / 'custom-configs-with-valid-input.json'),
+            DummyGearConfigs)
+        assert result is not None
+
+        # however output will not be exactly the same, as optional configs and inputs
+        # were not explicitly passed; test the behavior is as expected
+        configs: Dict[str, Any] = {
+            "gear_name":
+            "custom-configs",
+            "inputs": [{
+                "label": "input_file1",
+                "file_locator": "matched"
+            }, {
+                "label": "input_file2",
+                "file_locator": "module",
+                "file_name": "${module}-schema.json"
+            }],
+            "configs": {
+                "test_str": "hello",
+                "test_int": 1,
+                "test_list": [{
+                    "key": "value"
+                }, 2, "world"],
+                "apikey_path_prefix": "/test/dummy/gearbot"
+            }
+        }
+
+        assert result.configs.test_optional == 'optional'
+        assert not result.inputs[0].file_name
+        assert result.model_dump() != configs
+        configs['configs']['test_optional'] = 'optional'
+        configs['inputs'][0]['file_name'] = None
         assert result.model_dump() == configs

--- a/common/test/python/gear_execution/test_gear_info.py
+++ b/common/test/python/gear_execution/test_gear_info.py
@@ -2,12 +2,12 @@
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from gear_execution.gear_trigger import GearConfigs, GearInfo
+from gear_execution.gear_trigger import CredentialGearConfigs, GearInfo
 
 TEST_FILES_DIR = Path(__file__).parent.resolve() / 'data'
 
 
-class DummyGearConfigs(GearConfigs):
+class DummyGearConfigs(CredentialGearConfigs):
     test_str: str
     test_int: int
     test_list: List[Any]
@@ -24,15 +24,29 @@ class TestGearInfo:
         assert GearInfo.load_from_file(str(TEST_FILES_DIR /
                                            'empty-file.json')) is None
 
-        # assert without apikey_path_prefix fails/returns None
         assert GearInfo.load_from_file(str(TEST_FILES_DIR /
                                            'no-configs.json')) is None
-        assert GearInfo.load_from_file(
-            str(TEST_FILES_DIR / 'empty-configs.json')) is None
-
-        # now assert that it matches
         result = GearInfo.load_from_file(
-            str(TEST_FILES_DIR / 'basic-configs.json'))
+            str(TEST_FILES_DIR / 'empty-configs.json'))
+
+        assert result is not None
+        assert result.model_dump() == {
+            "gear_name": "empty-configs",
+            "configs": {},
+            "inputs": None
+        }
+
+    def test_credential_gear_configs(self):
+        """Test credential gear config class."""
+
+        # assert without apikey_path_prefix fails/returns None
+        assert GearInfo.load_from_file(
+            str(TEST_FILES_DIR / 'empty-configs.json'),
+            CredentialGearConfigs) is None
+
+        # assert valid credentials gear configs
+        result = GearInfo.load_from_file(
+            str(TEST_FILES_DIR / 'basic-configs.json'), CredentialGearConfigs)
 
         assert result is not None
         assert result.model_dump() == {

--- a/docs/form_qc_checker/CHANGELOG.md
+++ b/docs/form_qc_checker/CHANGELOG.md
@@ -3,8 +3,8 @@
 All notable changes to this gear are documented in this file.
 
 
-## 1.4.1
-* Rebuild for handling multiple pipelines (submission, finalization)
+## 1.5.0
+* Adds support for handling multiple pipelines (submission, finalization)
 * Updates to read in files with `utf-8-sig` to handle BOM encoding
 
 ## 1.4.0

--- a/docs/form_qc_checker/CHANGELOG.md
+++ b/docs/form_qc_checker/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 All notable changes to this gear are documented in this file.
 
-## Unreleased
 
+## 1.4.1
+* Rebuild for handling multiple pipelines (submission, finalization)
 * Updates to read in files with `utf-8-sig` to handle BOM encoding
 
 ## 1.4.0

--- a/docs/form_qc_coordinator/CHANGELOG.md
+++ b/docs/form_qc_coordinator/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 All notable changes to this gear are documented in this file.
 
-## Unreleased
-
+## 1.2.0
+* Adds functionality for handling multiple pipelines (submission, finalization)
 * Updates to read in files with `utf-8-sig` to handle BOM encoding
 
 ## 1.1.0

--- a/docs/form_scheduler/CHANGELOG.md
+++ b/docs/form_scheduler/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this gear are documented in this file.
 
+## 1.1.0
+* Adds functionality for handling multiple pipelines (submission, finalization)
+  
 ## 1.0.5
 * Updates to process all files in a given queue before moving to next queue/module
   

--- a/docs/form_screening/CHANGELOG.md
+++ b/docs/form_screening/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this gear are documented in this file.
 
+## 1.2.0
+* Adds functionality for handling multiple pipelines (submission, finalization)
+
 ## 1.1.2
 * Fixes a bug in saving error metadata
   

--- a/docs/form_transformer/CHANGELOG.md
+++ b/docs/form_transformer/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 All notable changes to this gear are documented in this file.
 
-## Unreleased
-
+## 1.4.1
+* Rebuild for handling multiple pipelines (submission, finalization)
 * Updates to read in files with `utf-8-sig` to handle BOM encoding
 
 ## 1.4.0

--- a/docs/identifier_lookup/CHANGELOG.md
+++ b/docs/identifier_lookup/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 All notable changes to this gear are documented in this file.
 
-## Unreleased
-
+## 1.2.1
+* Rebuild for handling multiple pipelines (submission, finalization)
 * Updates to read in files with `utf-8-sig` to handle BOM encoding
 
 ## 1.2.0

--- a/docs/identifier_provisioning/CHANGELOG.md
+++ b/docs/identifier_provisioning/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 All notable changes to this gear are documented in this file.
 
-## Unreleased
-
+## 1.2.5
+* Rebuild for handling multiple pipelines (submission, finalization)
 * Updates to read in files with `utf-8-sig` to handle BOM encoding
 
 ## 1.2.4

--- a/gear/form_qc_checker/src/docker/BUILD
+++ b/gear/form_qc_checker/src/docker/BUILD
@@ -6,5 +6,5 @@ docker_image(
     dependencies=[
         ":manifest", "gear/form_qc_checker/src/python/form_qc_app:bin"
     ],
-    image_tags=["1.4.1", "latest"],
+    image_tags=["1.5.0", "latest"],
 )

--- a/gear/form_qc_checker/src/docker/BUILD
+++ b/gear/form_qc_checker/src/docker/BUILD
@@ -6,5 +6,5 @@ docker_image(
     dependencies=[
         ":manifest", "gear/form_qc_checker/src/python/form_qc_app:bin"
     ],
-    image_tags=["1.4.0", "latest"],
+    image_tags=["1.4.1", "latest"],
 )

--- a/gear/form_qc_checker/src/docker/manifest.json
+++ b/gear/form_qc_checker/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "form-qc-checker",
     "label": "Form QC Checker",
     "description": "Gear to check form data as JSON with QC rule set",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/form-qc-checker:1.4.0"
+            "image": "naccdata/form-qc-checker:1.4.1"
         },
         "flywheel": {
             "suite": "Curation",

--- a/gear/form_qc_checker/src/docker/manifest.json
+++ b/gear/form_qc_checker/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "form-qc-checker",
     "label": "Form QC Checker",
     "description": "Gear to check form data as JSON with QC rule set",
-    "version": "1.4.1",
+    "version": "1.5.0",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/form-qc-checker:1.4.1"
+            "image": "naccdata/form-qc-checker:1.5.0"
         },
         "flywheel": {
             "suite": "Curation",

--- a/gear/form_qc_checker/src/docker/manifest.json
+++ b/gear/form_qc_checker/src/docker/manifest.json
@@ -27,11 +27,12 @@
             "base": "api-key"
         },
         "form_data_file": {
-            "description": "The form data JSON file",
+            "description": "The form data file (JSON or CSV)",
             "base": "file",
             "type": {
                 "enum": [
-                    "source code"
+                    "source code",
+                    "tabular data"
                 ]
             }
         },

--- a/gear/form_qc_checker/src/python/form_qc_app/enrollment.py
+++ b/gear/form_qc_checker/src/python/form_qc_app/enrollment.py
@@ -138,9 +138,8 @@ class EnrollmentFormVisitor(CSVVisitor):
             self.__error_writer.write(empty_field_error(
                 empty_fields, line_num))
             if self.__validator:
-                self.__processor.update_visit_error_log(input_record=row,
-                                                        qc_passed=False,
-                                                        reset_metadata=True)
+                self.__processor.update_visit_error_log(
+                    input_record=row, qc_passed=False, reset_qc_metadata='ALL')
             return False
 
         valid = True
@@ -149,7 +148,7 @@ class EnrollmentFormVisitor(CSVVisitor):
                                                          line_number=line_num)
             self.__processor.update_visit_error_log(input_record=row,
                                                     qc_passed=valid,
-                                                    reset_metadata=True)
+                                                    reset_qc_metadata='ALL')
 
         if valid and self.__output_stream:
             writer = self.__get_output_writer()

--- a/gear/form_qc_checker/src/python/form_qc_app/main.py
+++ b/gear/form_qc_checker/src/python/form_qc_app/main.py
@@ -83,28 +83,6 @@ def update_input_file_qc_status(
     return True
 
 
-def validate_input_file_type(mimetype: str) -> Optional[str]:
-    """Check whether the input file type is accepted.
-
-    Args:
-        mimetype: input file mimetype
-
-    Returns:
-        Optional[str]: If accepted file type, return the type, else None
-    """
-    if not mimetype:
-        return None
-
-    mimetype = mimetype.lower()
-    if mimetype.find('json') != -1:
-        return 'json'
-
-    if mimetype.find('csv') != -1:
-        return 'csv'
-
-    return None
-
-
 def load_supplement_input(
         supplement_input: InputFileWrapper) -> Optional[Dict[str, Any]]:
     with open(supplement_input.filepath, mode='r',
@@ -148,10 +126,13 @@ def run(  # noqa: C901
     if not input_wrapper.file_input:
         raise GearExecutionError('form_data_file input not found')
 
-    file_type = validate_input_file_type(input_wrapper.file_type)
+    accepted_extensions = ["json", "csv"]
+    file_type = input_wrapper.validate_file_extension(
+        accepted_extensions=accepted_extensions)
     if not file_type:
         raise GearExecutionError(
-            f'Unsupported input file type {input_wrapper.file_type}')
+            f"Unsupported input file type {input_wrapper.file_type}, "
+            f"supported extension(s): {accepted_extensions}")
 
     if file_type == 'json':
         separator = "_"

--- a/gear/form_qc_checker/src/python/form_qc_app/processor.py
+++ b/gear/form_qc_checker/src/python/form_qc_app/processor.py
@@ -9,8 +9,10 @@ from typing import Any, Dict, List, Literal, Mapping, Optional
 
 from configs.ingest_configs import ErrorLogTemplate, FormProjectConfigs
 from dates.form_dates import DEFAULT_DATE_TIME_FORMAT
+from flywheel.models.file_entry import FileEntry
 from flywheel_adaptor.flywheel_proxy import ProjectAdaptor
 from flywheel_adaptor.subject_adaptor import (
+    SubjectAdaptor,
     SubjectError,
     VisitInfo,
 )
@@ -192,6 +194,8 @@ class JSONFileProcessor(FileProcessor):
                          error_writer=error_writer,
                          form_configs=form_configs,
                          gear_name=gear_name)
+        self.__subject: SubjectAdaptor
+        self.__file_entry: FileEntry
         self.__supplement_data = supplement_data
 
     def __has_failed_visits(self) -> FailedStatus:

--- a/gear/form_qc_coordinator/src/docker/BUILD
+++ b/gear/form_qc_coordinator/src/docker/BUILD
@@ -7,4 +7,4 @@ docker_image(
         ":manifest",
         "gear/form_qc_coordinator/src/python/form_qc_coordinator_app:bin"
     ],
-    image_tags=["1.1.0", "latest"])
+    image_tags=["1.2.0", "latest"])

--- a/gear/form_qc_coordinator/src/docker/manifest.json
+++ b/gear/form_qc_coordinator/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "form-qc-coordinator",
     "label": "Form QC Coordinator",
     "description": "A gear to coordinate data quality checks for a given participant",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/form-qc-coordinator:1.1.0"
+            "image": "naccdata/form-qc-coordinator:1.2.0"
         },
         "flywheel": {
             "suite": "Utility",
@@ -27,7 +27,7 @@
             "base": "api-key"
         },
         "visits_file": {
-            "description": "YAML file with list of new/updated visits for the module/participant",
+            "description": "Input file to trigger the QC process for this participant",
             "base": "file",
             "type": {
                 "enum": [
@@ -59,6 +59,11 @@
             "description": "The instance specific AWS parameter path prefix for apikey",
             "type": "string",
             "default": "/prod/flywheel/gearbot"
+        },
+        "pipeline": {
+            "description": "Pipeline that triggered this gear",
+            "type": "string",
+            "default": "submission"
         },
         "check_all": {
             "description": "Whether to re-evaluate all visits for the given module for the participant",

--- a/gear/form_qc_coordinator/src/python/form_qc_coordinator_app/coordinator.py
+++ b/gear/form_qc_coordinator/src/python/form_qc_coordinator_app/coordinator.py
@@ -18,7 +18,7 @@ from flywheel_adaptor.subject_adaptor import (
 from flywheel_gear_toolkit import GearToolkitContext
 from flywheel_gear_toolkit.utils.metadata import Metadata, create_qc_result_dict
 from gear_execution.gear_execution import GearExecutionError
-from gear_execution.gear_trigger import GearConfigs, GearInfo, trigger_gear
+from gear_execution.gear_trigger import CredentialGearConfigs, GearInfo, trigger_gear
 from jobs.job_poll import JobPoll
 from keys.keys import DefaultValues, FieldNames, MetadataKeys, SysErrorCodes
 from outputs.errors import (
@@ -36,7 +36,7 @@ from form_qc_coordinator_app.visits import find_module_visits_with_matching_visi
 log = logging.getLogger(__name__)
 
 
-class QCGearConfigs(GearConfigs):
+class QCGearConfigs(CredentialGearConfigs):
     """Class to represent qc gear configs."""
     rules_s3_bucket: str
     qc_checks_db_path: str

--- a/gear/form_qc_coordinator/src/python/form_qc_coordinator_app/coordinator.py
+++ b/gear/form_qc_coordinator/src/python/form_qc_coordinator_app/coordinator.py
@@ -77,6 +77,8 @@ class QCCoordinator():
         self.__proxy = proxy
         self.__configs_file = configs_file
         self.__metadata = Metadata(context=gear_context)
+        self.__dependent_modules = form_project_configs.get_module_dependencies(
+            self.__module)
 
     def __passed_qc_checks(self, visit_file: FileEntry,
                            gear_name: str) -> bool:
@@ -377,6 +379,7 @@ class QCCoordinator():
             job_id = trigger_gear(
                 proxy=self.__proxy,
                 gear_name=gear_name,
+                log_ars=False,
                 config=self.__qc_gear_info.configs.model_dump(),
                 inputs=qc_gear_inputs,
                 destination=destination)
@@ -411,7 +414,8 @@ class QCCoordinator():
 
             # Add the submission complete tag
             # to trigger QC process on any dependent modules
-            visit_file.add_tag(DefaultValues.FINALIZED_TAG)
+            if self.__dependent_modules:
+                visit_file.add_tag(DefaultValues.FINALIZED_TAG)
 
         # If there are any visits left, update error metadata in the respective file
         if len(visits_queue) > 0:

--- a/gear/form_qc_coordinator/src/python/form_qc_coordinator_app/coordinator.py
+++ b/gear/form_qc_coordinator/src/python/form_qc_coordinator_app/coordinator.py
@@ -379,7 +379,7 @@ class QCCoordinator():
             job_id = trigger_gear(
                 proxy=self.__proxy,
                 gear_name=gear_name,
-                log_ars=False,
+                log_args=False,
                 config=self.__qc_gear_info.configs.model_dump(),
                 inputs=qc_gear_inputs,
                 destination=destination)

--- a/gear/form_qc_coordinator/src/python/form_qc_coordinator_app/coordinator.py
+++ b/gear/form_qc_coordinator/src/python/form_qc_coordinator_app/coordinator.py
@@ -137,7 +137,7 @@ class QCCoordinator():
         info = visit_file.info if (visit_file.info
                                    and 'qc' in visit_file.info) else {
                                        'qc': {}
-        }
+                                   }
 
         # add qc-coordinator gear info to visit file metadata
         updated_qc_info = self.__metadata.add_gear_info(
@@ -168,7 +168,8 @@ class QCCoordinator():
                                                proxy=self.__proxy),
                 gear_name=gear_name,
                 state=status,
-                errors=error_writer.errors()):
+                errors=error_writer.errors(),
+                reset_qc_metadata='GEAR'):
             raise GearExecutionError(
                 f'Failed to update error log for visit {ptid}, {visitdate}')
 

--- a/gear/form_qc_coordinator/src/python/form_qc_coordinator_app/main.py
+++ b/gear/form_qc_coordinator/src/python/form_qc_coordinator_app/main.py
@@ -1,169 +1,66 @@
 """Defines Form QC Coordinator."""
 
 import logging
-from typing import Dict, List
 
-from configs.ingest_configs import FormProjectConfigs, ModuleConfigs, PipelineType
+from configs.ingest_configs import FormProjectConfigs, PipelineType
+from flywheel.models.file_entry import FileEntry
 from flywheel_adaptor.flywheel_proxy import FlywheelProxy
 from flywheel_adaptor.subject_adaptor import (
     ParticipantVisits,
     SubjectAdaptor,
 )
 from flywheel_gear_toolkit import GearToolkitContext
-from gear_execution.gear_execution import (
-    ClientWrapper,
-    GearExecutionError,
-    InputFileWrapper,
-)
+from gear_execution.gear_execution import GearExecutionError
 from gear_execution.gear_trigger import GearInfo
 
-from form_qc_coordinator_app.coordinator import QCCoordinator
-from form_qc_coordinator_app.visits import find_visits_for_participant_for_module
+from form_qc_coordinator_app.pipelines import PipelineProcessor
 
 log = logging.getLogger(__name__)
 
 
-def update_file_tags(gear_context: GearToolkitContext,
-                     input_wrapper: InputFileWrapper):
-    """Add gear tag to file.
-
-    Args:
-        gear_context: Flywheel gear context
-        input_wrapper: gear input file wrapper
-    """
-
-    gear_name = gear_context.manifest.get('name', 'form-qc-coordinator')
-    gear_context.metadata.add_file_tags(input_wrapper.file_input,
-                                        tags=gear_name)
-
-
-def trigger_dependent_modules_qc_checks(
-        *, proxy: FlywheelProxy, gear_context: GearToolkitContext,
-        subject: SubjectAdaptor, form_project_configs: FormProjectConfigs,
-        configs_file_id: str, qc_gear_info: GearInfo,
-        dependent_visits_info: Dict[str, List[Dict[str, str]]]):
-    """Trigger QC checks for each dependent module for the given subject.
-
-    Args:
-        proxy: Flywheel proxy object
-        gear_context: Flywheel gear context
-        subject: Flywheel subject to run the QC checks
-        form_project_configs: form ingest configurations
-        configs_file_id: form ingest configurations file id
-        qc_gear_info: GearInfo containing info for the qc gear
-        dependent_visits_info: list of dependent visits by module
-    """
-
-    for dep_module, dep_visits in dependent_visits_info.items():
-        if not dep_visits:
-            log.warning('No visits found for dependent module %s', dep_module)
-            continue
-
-        # Create a QC Coordinator for each dependent module
-        log.info(
-            'Triggering QC Coordinator for dependent module %s #visits: %s',
-            dep_module, len(dep_visits))
-
-        qc_coordinator = QCCoordinator(
-            subject=subject,
-            module=dep_module,
-            form_project_configs=form_project_configs,
-            configs_file_id=configs_file_id,
-            qc_gear_info=qc_gear_info,
-            proxy=proxy,
-            gear_context=gear_context,
-            dependent_modules=form_project_configs.get_module_dependencies(
-                module=dep_module))
-
-        qc_coordinator.run_error_checks(visits=dep_visits)
-
-
 def run(*,
         gear_context: GearToolkitContext,
-        client_wrapper: ClientWrapper,
-        visits_file_wrapper: InputFileWrapper,
-        form_project_configs: FormProjectConfigs,
-        configs_file_id: str,
+        proxy: FlywheelProxy,
         subject: SubjectAdaptor,
         visits_info: ParticipantVisits,
+        form_project_configs: FormProjectConfigs,
+        configs_file: FileEntry,
         qc_gear_info: GearInfo,
         pipeline: PipelineType,
         check_all: bool = False):
-    """Invoke QC process for the given participant/module.
+    """Invoke QC process for the given subject and pipeline.
 
     Args:
         gear_context: Flywheel gear context
-        client_wrapper: Flywheel SDK client wrapper
-        visits_file_wrapper: Input file wrapper
+        proxy: Flywheel proxy object
         subject: Flywheel subject to run the QC checks
+        visits_info: Info on visits to process for the subject
         form_project_configs: form ingest configurations
         configs_file_id: form ingest configurations file id
-        visits_info: Info on new/updated visits for the participant/module
         qc_gear_info: QC gear name and configs
-        pipeline: Pipeline that triggered this gear instance
-        check_all: re-evaluate all visits for the participant/module
+        pipeline: pipeline that triggered this gear instance
+        check_all: re-evaluate all visits for the subject/module
 
     Raises:
         GearExecutionError if any problem occurs during the QC process
     """
 
-    if check_all:
-        cutoff = None
-    else:
-        curr_visit = sorted(visits_info.visits, key=lambda d: d.visitdate)[0]
-        cutoff = curr_visit.visitdate
-
     module = visits_info.module.upper()
-
-    if (module not in form_project_configs.accepted_modules
-            or not form_project_configs.module_configs.get(module)):
-        raise GearExecutionError(
-            f'Failed to find the configurations for module {module}')
-
-    module_configs: ModuleConfigs = form_project_configs.module_configs.get(
-        module)  # type: ignore
-
-    dependent_modules = form_project_configs.get_module_dependencies(
-        module=module)
-    log.info('List of other modules dependent on module %s: %s', module,
-             dependent_modules)
-
-    proxy = client_wrapper.get_proxy()
-
-    visits_list = find_visits_for_participant_for_module(
+    pipeline_processor = PipelineProcessor(
         proxy=proxy,
-        container_id=subject.id,
-        subject=subject.label,
+        gear_context=gear_context,
         module=module,
-        module_configs=module_configs,
-        cutoff_date=cutoff)
-    if not visits_list:
-        # This cannot happen, at least one file should exist with matching cutoff date
+        subject=subject,
+        visits_info=visits_info,
+        form_project_configs=form_project_configs,
+        qc_gear_info=qc_gear_info,
+        configs_file=configs_file,
+        check_all=check_all)
+
+    function_name = f'trigger_{pipeline}_pipeline_qc_process'
+    pipeline_function = getattr(pipeline_processor, function_name, None)
+    if pipeline_function and callable(pipeline_function):
+        pipeline_function()
+    else:
         raise GearExecutionError(
-            'Cannot find matching visits for subject '
-            f'{subject.label}/{module} with {module_configs.date_field}>={cutoff}'
-        )
-
-    qc_coordinator = QCCoordinator(subject=subject,
-                                   module=module,
-                                   form_project_configs=form_project_configs,
-                                   configs_file_id=configs_file_id,
-                                   qc_gear_info=qc_gear_info,
-                                   proxy=proxy,
-                                   gear_context=gear_context,
-                                   dependent_modules=dependent_modules)
-
-    qc_coordinator.run_error_checks(visits=visits_list)
-
-    dependent_visits_info = qc_coordinator.get_dependent_module_visits()
-    if dependent_visits_info:
-        trigger_dependent_modules_qc_checks(
-            proxy=proxy,
-            gear_context=gear_context,
-            subject=subject,
-            form_project_configs=form_project_configs,
-            configs_file_id=configs_file_id,
-            qc_gear_info=qc_gear_info,
-            dependent_visits_info=dependent_visits_info)
-
-    update_file_tags(gear_context, visits_file_wrapper)
+            f"{function_name} not defined in the Form QC Coordinator")

--- a/gear/form_qc_coordinator/src/python/form_qc_coordinator_app/pipelines.py
+++ b/gear/form_qc_coordinator/src/python/form_qc_coordinator_app/pipelines.py
@@ -1,0 +1,136 @@
+import logging
+
+from configs.ingest_configs import FormProjectConfigs, ModuleConfigs
+from flywheel.models.file_entry import FileEntry
+from flywheel_adaptor.flywheel_proxy import FlywheelProxy
+from flywheel_adaptor.subject_adaptor import ParticipantVisits, SubjectAdaptor
+from flywheel_gear_toolkit import GearToolkitContext
+from gear_execution.gear_execution import GearExecutionError
+from gear_execution.gear_trigger import GearInfo
+
+from form_qc_coordinator_app.coordinator import QCCoordinator
+from form_qc_coordinator_app.visits import VisitsLookupHelper
+
+log = logging.getLogger(__name__)
+
+
+class PipelineProcessor():
+    """Class to trigger the QC process for a pipeline."""
+
+    def __init__(self,
+                 *,
+                 proxy: FlywheelProxy,
+                 gear_context: GearToolkitContext,
+                 subject: SubjectAdaptor,
+                 module: str,
+                 visits_info: ParticipantVisits,
+                 form_project_configs: FormProjectConfigs,
+                 qc_gear_info: GearInfo,
+                 configs_file: FileEntry,
+                 check_all: bool = False) -> None:
+        """Initialize the Pipeline Processor.
+
+        Args:
+            proxy: Flywheel proxy object
+            gear_context: Flywheel gear context
+            subject: Flywheel subject to run the QC checks
+            module: module label
+            visits_info: Info on visits to process for the subject
+            form_project_configs: form ingest configurations for the project
+            qc_gear_info: QC gear name and configs
+            configs_file: form ingest configurations file entry object
+            check_all: re-evaluate all visits for the subject/module
+        """
+        self.__proxy = proxy
+        self.__gear_context = gear_context
+        self.__module = module
+        self.__subject = subject
+        self.__visits_info = visits_info
+        self.__form_configs = form_project_configs
+        self.__qc_gear_info = qc_gear_info
+        self.__configs_file = configs_file
+        self.__check_all = check_all
+
+        if (module not in form_project_configs.accepted_modules
+                or not form_project_configs.module_configs.get(module)):
+            raise GearExecutionError(
+                f'Failed to find the ingest configurations for module {module}'
+            )
+
+        self.__module_configs: ModuleConfigs = self.__form_configs.module_configs.get(
+            self.__module)  # type: ignore
+
+        self.__visits_lookup_helper = VisitsLookupHelper(
+            proxy=proxy,
+            subject=subject,
+            form_project_configs=form_project_configs)
+
+    def trigger_submission_pipeline_qc_process(self):
+        """Trigger the QC process for the `submission` pipeline.
+
+        Raises:
+            GearExecutionError: If errors occur during QC process
+        """
+
+        if self.__check_all:
+            cutoff = None
+        else:
+            curr_visit = sorted(self.__visits_info.visits,
+                                key=lambda d: d.visitdate)[0]
+            cutoff = curr_visit.visitdate
+
+        visits_list = self.__visits_lookup_helper.find_visits_for_module(
+            module=self.__module,
+            module_configs=self.__module_configs,
+            cutoff_date=cutoff)
+        if not visits_list:
+            # This cannot happen,
+            # at least one file should exist with matching cutoff date
+            raise GearExecutionError(
+                "Cannot find matching visits for subject "
+                f"{self.__subject.label}/{self.__module} with "
+                f"{self.__module_configs.date_field}>={cutoff}")
+
+        qc_coordinator = QCCoordinator(
+            subject=self.__subject,
+            module=self.__module,
+            form_project_configs=self.__form_configs,
+            configs_file=self.__configs_file,
+            qc_gear_info=self.__qc_gear_info,
+            proxy=self.__proxy,
+            gear_context=self.__gear_context)
+
+        qc_coordinator.run_error_checks(visits=visits_list)
+
+    def trigger_finalization_pipeline_qc_process(self):
+        """Trigger the QC process for the `finalization` pipeline.
+
+        Raises:
+            GearExecutionError: If errors occur during QC process
+        """
+
+        dependent_visits_info = self.__visits_lookup_helper.get_dependent_module_visits(
+            current_module=self.__module,
+            current_visits=self.__visits_info.visits)
+
+        if not dependent_visits_info:
+            log.info(
+                f"No dependent module visits found for module {self.__module}")
+            return
+
+        for dep_module, dep_visits in dependent_visits_info.items():
+            # Create a QC Coordinator for each dependent module
+            log.info(
+                'Triggering QC Coordinator for dependent module %s #visits: %s',
+                dep_module, len(dep_visits))
+
+            qc_coordinator = QCCoordinator(
+                subject=self.__subject,
+                module=dep_module,
+                form_project_configs=self.__form_configs,
+                configs_file=self.__configs_file,
+                qc_gear_info=self.__qc_gear_info,
+                proxy=self.__proxy,
+                gear_context=self.__gear_context)
+
+            qc_coordinator.run_error_checks(visits=dep_visits)

--- a/gear/form_qc_coordinator/src/python/form_qc_coordinator_app/pipelines.py
+++ b/gear/form_qc_coordinator/src/python/form_qc_coordinator_app/pipelines.py
@@ -1,12 +1,15 @@
 import logging
+from abc import ABC, abstractmethod
+from typing import Optional
 
-from configs.ingest_configs import FormProjectConfigs, ModuleConfigs
+from configs.ingest_configs import FormProjectConfigs, ModuleConfigs, PipelineType
 from flywheel.models.file_entry import FileEntry
 from flywheel_adaptor.flywheel_proxy import FlywheelProxy
 from flywheel_adaptor.subject_adaptor import ParticipantVisits, SubjectAdaptor
 from flywheel_gear_toolkit import GearToolkitContext
 from gear_execution.gear_execution import GearExecutionError
 from gear_execution.gear_trigger import GearInfo
+from keys.keys import DefaultValues
 
 from form_qc_coordinator_app.coordinator import QCCoordinator
 from form_qc_coordinator_app.visits import VisitsLookupHelper
@@ -14,8 +17,8 @@ from form_qc_coordinator_app.visits import VisitsLookupHelper
 log = logging.getLogger(__name__)
 
 
-class PipelineProcessor():
-    """Class to trigger the QC process for a pipeline."""
+class PipelineProcessor(ABC):
+    """Abstract class to trigger the QC process for a pipeline."""
 
     def __init__(self,
                  *,
@@ -41,15 +44,15 @@ class PipelineProcessor():
             configs_file: form ingest configurations file entry object
             check_all: re-evaluate all visits for the subject/module
         """
-        self.__proxy = proxy
-        self.__gear_context = gear_context
-        self.__module = module
-        self.__subject = subject
-        self.__visits_info = visits_info
-        self.__form_configs = form_project_configs
-        self.__qc_gear_info = qc_gear_info
-        self.__configs_file = configs_file
-        self.__check_all = check_all
+        self._proxy = proxy
+        self._gear_context = gear_context
+        self._module = module
+        self._subject = subject
+        self._visits_info = visits_info
+        self._form_configs = form_project_configs
+        self._qc_gear_info = qc_gear_info
+        self._configs_file = configs_file
+        self._check_all = check_all
 
         if (module not in form_project_configs.accepted_modules
                 or not form_project_configs.module_configs.get(module)):
@@ -57,65 +60,77 @@ class PipelineProcessor():
                 f'Failed to find the ingest configurations for module {module}'
             )
 
-        self.__module_configs: ModuleConfigs = self.__form_configs.module_configs.get(
-            self.__module)  # type: ignore
+        self._module_configs: ModuleConfigs = self._form_configs.module_configs.get(
+            self._module)  # type: ignore
 
-        self.__visits_lookup_helper = VisitsLookupHelper(
+        self._visits_lookup_helper = VisitsLookupHelper(
             proxy=proxy,
             subject=subject,
             form_project_configs=form_project_configs)
 
-    def trigger_submission_pipeline_qc_process(self):
+    @abstractmethod
+    def trigger_qc_process(self) -> None:
+        """Trigger the QC process for the pipeline."""
+        pass
+
+
+class SubmissionPipelineProcessor(PipelineProcessor):
+    """Subclass to handle submission pipeline QC process."""
+
+    def trigger_qc_process(self):
         """Trigger the QC process for the `submission` pipeline.
 
         Raises:
             GearExecutionError: If errors occur during QC process
         """
 
-        if self.__check_all:
+        if self._check_all:
             cutoff = None
         else:
-            curr_visit = sorted(self.__visits_info.visits,
+            curr_visit = sorted(self._visits_info.visits,
                                 key=lambda d: d.visitdate)[0]
             cutoff = curr_visit.visitdate
 
-        visits_list = self.__visits_lookup_helper.find_visits_for_module(
-            module=self.__module,
-            module_configs=self.__module_configs,
+        visits_list = self._visits_lookup_helper.find_visits_for_module(
+            module=self._module,
+            module_configs=self._module_configs,
             cutoff_date=cutoff)
         if not visits_list:
             # This cannot happen,
             # at least one file should exist with matching cutoff date
             raise GearExecutionError(
                 "Cannot find matching visits for subject "
-                f"{self.__subject.label}/{self.__module} with "
-                f"{self.__module_configs.date_field}>={cutoff}")
+                f"{self._subject.label}/{self._module} with "
+                f"{self._module_configs.date_field}>={cutoff}")
 
-        qc_coordinator = QCCoordinator(
-            subject=self.__subject,
-            module=self.__module,
-            form_project_configs=self.__form_configs,
-            configs_file=self.__configs_file,
-            qc_gear_info=self.__qc_gear_info,
-            proxy=self.__proxy,
-            gear_context=self.__gear_context)
+        qc_coordinator = QCCoordinator(subject=self._subject,
+                                       module=self._module,
+                                       form_project_configs=self._form_configs,
+                                       configs_file=self._configs_file,
+                                       qc_gear_info=self._qc_gear_info,
+                                       proxy=self._proxy,
+                                       gear_context=self._gear_context)
 
         qc_coordinator.run_error_checks(visits=visits_list)
 
-    def trigger_finalization_pipeline_qc_process(self):
+
+class FinalizationPipelineProcessor(PipelineProcessor):
+    """Subclass to handle finalization pipeline QC process."""
+
+    def trigger_qc_process(self):
         """Trigger the QC process for the `finalization` pipeline.
 
         Raises:
             GearExecutionError: If errors occur during QC process
         """
 
-        dependent_visits_info = self.__visits_lookup_helper.get_dependent_module_visits(
-            current_module=self.__module,
-            current_visits=self.__visits_info.visits)
+        dependent_visits_info = self._visits_lookup_helper.get_dependent_module_visits(
+            current_module=self._module,
+            current_visits=self._visits_info.visits)
 
         if not dependent_visits_info:
             log.info(
-                f"No dependent module visits found for module {self.__module}")
+                f"No dependent module visits found for module {self._module}")
             return
 
         for dep_module, dep_visits in dependent_visits_info.items():
@@ -125,12 +140,41 @@ class PipelineProcessor():
                 dep_module, len(dep_visits))
 
             qc_coordinator = QCCoordinator(
-                subject=self.__subject,
+                subject=self._subject,
                 module=dep_module,
-                form_project_configs=self.__form_configs,
-                configs_file=self.__configs_file,
-                qc_gear_info=self.__qc_gear_info,
-                proxy=self.__proxy,
-                gear_context=self.__gear_context)
+                form_project_configs=self._form_configs,
+                configs_file=self._configs_file,
+                qc_gear_info=self._qc_gear_info,
+                proxy=self._proxy,
+                gear_context=self._gear_context)
 
             qc_coordinator.run_error_checks(visits=dep_visits)
+
+
+def create_pipeline_processor(pipeline: PipelineType,
+                              **kwargs) -> Optional[PipelineProcessor]:
+    """Creates the pipeline processor for the specified pipeline.
+
+    Args:
+        pipeline: pipeline name that triggered this gear instance
+        kwargs: keyword arguments to create PipelineProcessor, which include:
+            proxy: Flywheel proxy object
+            gear_context: Flywheel gear context
+            subject: Flywheel subject to run the QC checks
+            module: module label
+            visits_info: Info on visits to process for the subject
+            form_project_configs: form ingest configurations for the project
+            qc_gear_info: QC gear name and configs
+            configs_file: form ingest configurations file entry object
+            check_all: re-evaluate all visits for the subject/module
+
+    Returns:
+        PipelineProcessor: if successful else None
+    """
+
+    if pipeline == DefaultValues.SUBMISSION_PIPELINE:
+        return SubmissionPipelineProcessor(**kwargs)
+    elif pipeline == DefaultValues.FINALIZATION_PIPELINE:
+        return FinalizationPipelineProcessor(**kwargs)
+    else:
+        return None

--- a/gear/form_qc_coordinator/src/python/form_qc_coordinator_app/run.py
+++ b/gear/form_qc_coordinator/src/python/form_qc_coordinator_app/run.py
@@ -254,7 +254,8 @@ class FormQCCoordinator(GearExecutionEnvironment):
         """
 
         gear_name = gear_context.manifest.get('name', 'form-qc-coordinator')
-        gear_context.metadata.add_file_tags(self.__file_input, tags=gear_name)
+        gear_context.metadata.add_file_tags(self.__file_input.file_input,
+                                            tags=gear_name)
 
     def run(self, context: GearToolkitContext) -> None:
         """Validates input files, runs the form-qc-coordinator app.

--- a/gear/form_qc_coordinator/src/python/form_qc_coordinator_app/run.py
+++ b/gear/form_qc_coordinator/src/python/form_qc_coordinator_app/run.py
@@ -162,7 +162,7 @@ class FormQCCoordinator(GearExecutionEnvironment):
                                           {}).get(module_configs.date_field)
         if not visitdate:
             raise GearExecutionError(
-                f"{MetadataKeys.FORM_METADATA_PATH}.{module_configs.date_field} "
+                f"{MetadataKeys.get_column_key(module_configs.date_field)} "
                 f"not found in file {self.__file_input.filename} metadata")
 
         visitnum = file.info.get('forms', {}).get("json",
@@ -171,7 +171,9 @@ class FormQCCoordinator(GearExecutionEnvironment):
         visit = VisitInfo(filename=self.__file_input.filename,
                           file_id=file_id,
                           visitdate=visitdate,
-                          visitnum=visitnum)
+                          visitnum=visitnum,
+                          validated_timestamp=file.info.get(
+                              MetadataKeys.VALIDATED_TIMESTAMP))
 
         visits_info = ParticipantVisits(participant=subject.label,
                                         module=module,

--- a/gear/form_qc_coordinator/src/python/form_qc_coordinator_app/run.py
+++ b/gear/form_qc_coordinator/src/python/form_qc_coordinator_app/run.py
@@ -3,8 +3,14 @@
 import logging
 from typing import Any, Optional
 
+from configs.ingest_configs import FormProjectConfigs, PipelineType
+from flywheel import Subject
 from flywheel.rest import ApiException
-from flywheel_adaptor.subject_adaptor import ParticipantVisits, SubjectAdaptor
+from flywheel_adaptor.subject_adaptor import (
+    ParticipantVisits,
+    SubjectAdaptor,
+    VisitInfo,
+)
 from flywheel_gear_toolkit import GearToolkitContext
 from gear_execution.gear_execution import (
     ClientWrapper,
@@ -17,47 +23,14 @@ from gear_execution.gear_execution import (
 from gear_execution.gear_trigger import GearInfo
 from inputs.parameter_store import ParameterStore
 from inputs.yaml import YAMLReadError, load_from_stream
+from keys.keys import MetadataKeys
 from pydantic import ValidationError
+from utils.utils import load_form_ingest_configurations
 
 from form_qc_coordinator_app.coordinator import QCGearConfigs
 from form_qc_coordinator_app.main import run
 
 log = logging.getLogger(__name__)
-
-
-def validate_input_data(input_file_path: str,
-                        subject_lbl: str) -> Optional[ParticipantVisits]:
-    """Validate the input file - visits_file.
-
-    Args:
-        input_file_path: Gear input 'visits_file' file path
-        subject_lbl: Flywheel subject label
-
-    Returns:
-        Optional[ParticipantVisits]: Info on the set of new/updated visits
-    """
-
-    try:
-        with open(input_file_path, 'r', encoding='utf-8-sig ') as input_file:
-            input_data = load_from_stream(input_file)
-    except (FileNotFoundError, YAMLReadError) as error:
-        log.error('Failed to read the input file %s - %s', input_file_path,
-                  error)
-        return None
-
-    try:
-        visits_info = ParticipantVisits.model_validate(input_data)
-    except ValidationError as error:
-        log.error('Visit information not in expected format - %s', error)
-        return None
-
-    if visits_info and subject_lbl != visits_info.participant:
-        log.error(
-            'Participant label in visits file %s does not match with subject label %s',
-            visits_info.participant, subject_lbl)
-        return None
-
-    return visits_info
 
 
 class FormQCCoordinator(GearExecutionEnvironment):
@@ -69,7 +42,8 @@ class FormQCCoordinator(GearExecutionEnvironment):
                  file_input: InputFileWrapper,
                  form_config_input: InputFileWrapper,
                  qc_config_input: InputFileWrapper,
-                 subject: SubjectAdaptor,
+                 subject_id: str,
+                 pipeline: PipelineType,
                  check_all: bool = False):
         """
         Args:
@@ -77,13 +51,15 @@ class FormQCCoordinator(GearExecutionEnvironment):
             file_input: Gear input file wrapper
             form_config_input: forms module configurations file
             qc_config_input: QC gear configurations file
-            subject: Flywheel subject adaptor
+            subject_id: Flywheel subject id
+            pipeline: Pipeline that triggered this gear instance
             check_all: If True, re-evaluate all visits for the module/participant
         """
         self.__file_input = file_input
         self.__form_config_input = form_config_input
         self.__qc_config_input = qc_config_input
-        self.__subject = subject
+        self.__subject_id = subject_id
+        self.__pipeline = pipeline
         self.__check_all = check_all
         super().__init__(client=client)
 
@@ -113,6 +89,14 @@ class FormQCCoordinator(GearExecutionEnvironment):
             raise GearExecutionError(
                 f'Cannot find destination container: {error}') from error
 
+        if dest_container.container_type == 'subject':
+            subject_id = dest_container.id
+        elif dest_container.container_type == 'acquisition':
+            subject_id = dest_container.parents['subject']
+        else:
+            raise GearExecutionError(
+                f"Unsupported container type {dest_container.container_type}")
+
         if dest_container.container_type != 'subject':
             raise GearExecutionError(
                 'This gear must be executed at subject level - '
@@ -132,13 +116,135 @@ class FormQCCoordinator(GearExecutionEnvironment):
         assert qc_configs_input, "missing expected input, qc_configs_file"
 
         check_all = context.config.get('check_all', False)
+        pipeline = context.config.get('pipeline', 'submission')
 
         return FormQCCoordinator(client=client,
                                  file_input=visits_file_input,
                                  form_config_input=form_configs_input,
                                  qc_config_input=qc_configs_input,
-                                 subject=SubjectAdaptor(dest_container),
+                                 subject_id=subject_id,
+                                 pipeline=pipeline,
                                  check_all=check_all)
+
+    def parse_json_input(
+            self, subject: SubjectAdaptor,
+            form_configs: FormProjectConfigs) -> Optional[ParticipantVisits]:
+        """Parse the JSON input file and return visits info.
+
+        Args:
+            subject: Flywheel subject adaptor
+            form_configs: form ingest configurations
+
+        Raises:
+            GearExecutionError: if error occurs while parsing the input
+
+        Returns:
+            ParticipantVisits(optional): visits info if input parsed successfully
+        """
+
+        module = self.__file_input.get_module_name_from_file_suffix(
+            separator="_", allowed="a-z", split=None, extension="json")
+        if not module:
+            raise GearExecutionError(
+                "Failed to extract module information from file "
+                f"{self.__file_input.filename}")
+        module = module.upper()
+
+        file_id = self.__file_input.file_id
+        try:
+            file = self.proxy.get_file(file_id)
+        except ApiException as error:
+            raise GearExecutionError(
+                f"Failed to find the input file {self.__file_input.filename}: {error}"
+            ) from error
+
+        module_configs = form_configs.module_configs.get(module)
+        if not module_configs:
+            raise GearExecutionError(
+                f"Failed to find module configurations for {module} module")
+
+        visitdate = file.info.get('forms',
+                                  {}).get("json",
+                                          {}).get(module_configs.date_field)
+        if not visitdate:
+            raise GearExecutionError(
+                f"{MetadataKeys.FORM_METADATA_PATH}.{module_configs.date_field} "
+                f"not found in file {self.__file_input.filename} metadata")
+
+        visit = VisitInfo(filename=self.__file_input.filename,
+                          file_id=file_id,
+                          visitdate=visitdate)
+        visits_info = ParticipantVisits(participant=subject.label,
+                                        module=module,
+                                        visits=[visit])
+
+        return visits_info
+
+    def parse_yaml_input(
+            self, subject: SubjectAdaptor) -> Optional[ParticipantVisits]:
+        """Parse the YAML input file and return visits info.
+
+        Args:
+            subject: Flywheel subject adaptor
+
+        Returns:
+            ParticipantVisits(optional): visits info if input parsed successfully
+        """
+
+        try:
+            with open(self.__file_input.filepath, 'r',
+                      encoding='utf-8-sig ') as input_file:
+                input_data = load_from_stream(input_file)
+        except (FileNotFoundError, YAMLReadError) as error:
+            log.error(
+                f"Failed to read the input file {self.__file_input.filename}: {error}"
+            )
+            return None
+
+        try:
+            visits_info = ParticipantVisits.model_validate(input_data)
+        except ValidationError as error:
+            log.error('Visit information not in expected format - %s', error)
+            return None
+
+        if visits_info and subject.label != visits_info.participant:
+            log.error(
+                f"Participant label in visits file {visits_info.participant} "
+                f"does not match with subject label {subject.label}")
+            return None
+
+        return visits_info
+
+    def validate_input_data(
+            self, subject: SubjectAdaptor,
+            form_configs: FormProjectConfigs) -> Optional[ParticipantVisits]:
+        """Validate the input file - visits_file.
+
+        Args:
+            input_file_path: Gear input 'visits_file' file path
+            subject_lbl: Flywheel subject label
+
+        Returns:
+            Optional[ParticipantVisits]: Info on the set of new/updated visits
+        """
+
+        accepted_extensions = ["yaml", "json"]
+        file_type = self.__file_input.validate_file_extension(
+            accepted_extensions=accepted_extensions)
+        if not file_type:
+            raise GearExecutionError(
+                f"Unsupported input file type {self.__file_input.file_type}, "
+                f"supported extension(s): {accepted_extensions}")
+
+        if self.__pipeline == 'submission' and file_type != "yaml":
+            raise GearExecutionError(
+                f"Unsupported input file type `{file_type}` for pipeline "
+                f"`{self.__pipeline}` - expected yaml file")
+
+        if file_type == "json":
+            return self.parse_json_input(subject, form_configs=form_configs)
+
+        return self.parse_yaml_input(subject)
 
     def run(self, context: GearToolkitContext) -> None:
         """Validates input files, runs the form-qc-coordinator app.
@@ -150,12 +256,28 @@ class FormQCCoordinator(GearExecutionEnvironment):
           GearExecutionError
         """
 
-        visits_info = validate_input_data(self.__file_input.filepath,
-                                          self.__subject.label)
+        try:
+            subject: Subject = self.proxy.get_container_by_id(
+                self.__subject_id)  # type: ignore
+        except ApiException as error:
+            raise GearExecutionError(
+                f"Cannot find subject with ID {self.__subject_id}: {error}"
+            ) from error
+
+        try:
+            form_project_configs = load_form_ingest_configurations(
+                self.__form_config_input.filepath)
+        except ValidationError as error:
+            raise GearExecutionError(
+                'Error reading form configurations file '
+                f'{self.__form_config_input.filename}: {error}') from error
+
+        subject_adaptor = SubjectAdaptor(subject)
+        visits_info = self.validate_input_data(
+            subject=subject_adaptor, form_configs=form_project_configs)
         if not visits_info:
             raise GearExecutionError(
-                f'Error reading visits info file - {self.__file_input.filename}'
-            )
+                f"Error reading visits info file {self.__file_input.filename}")
 
         qc_gear_info = GearInfo.load_from_file(self.__qc_config_input.filepath,
                                                configs_class=QCGearConfigs)
@@ -163,13 +285,16 @@ class FormQCCoordinator(GearExecutionEnvironment):
             raise GearExecutionError('Error reading qc gear configs file '
                                      f'{self.__qc_config_input.filename}')
 
-        run(gear_context=context,
+        run(
+            gear_context=context,
             client_wrapper=self.client,
             visits_file_wrapper=self.__file_input,
-            configs_file_wrapper=self.__form_config_input,
-            subject=self.__subject,
+            form_project_configs=form_project_configs,
+            configs_file_id=self.__form_config_input.file_id,
+            subject=subject_adaptor,
             visits_info=visits_info,
             qc_gear_info=qc_gear_info,
+            pipeline=self.__pipeline,  # type: ignore
             check_all=self.__check_all)
 
 

--- a/gear/form_qc_coordinator/src/python/form_qc_coordinator_app/run.py
+++ b/gear/form_qc_coordinator/src/python/form_qc_coordinator_app/run.py
@@ -97,12 +97,6 @@ class FormQCCoordinator(GearExecutionEnvironment):
             raise GearExecutionError(
                 f"Unsupported container type {dest_container.container_type}")
 
-        if dest_container.container_type != 'subject':
-            raise GearExecutionError(
-                'This gear must be executed at subject level - '
-                'invalid gear destination type '
-                f'{dest_container.container_type}')
-
         visits_file_input = InputFileWrapper.create(input_name='visits_file',
                                                     context=context)
         assert visits_file_input, "missing expected input, visits_file"

--- a/gear/form_qc_coordinator/src/python/form_qc_coordinator_app/visits.py
+++ b/gear/form_qc_coordinator/src/python/form_qc_coordinator_app/visits.py
@@ -1,100 +1,187 @@
+import logging
 from typing import Dict, List, Optional
 
-from configs.ingest_configs import ModuleConfigs
+from configs.ingest_configs import FormProjectConfigs, ModuleConfigs
 from flywheel_adaptor.flywheel_proxy import FlywheelProxy
+from flywheel_adaptor.subject_adaptor import SubjectAdaptor, VisitInfo
+from gear_execution.gear_execution import GearExecutionError
 from keys.keys import FieldNames, MetadataKeys
 
-
-def find_visits_for_participant_for_module(
-        *,
-        proxy: FlywheelProxy,
-        container_id: str,
-        subject: str,
-        module: str,
-        module_configs: ModuleConfigs,
-        cutoff_date: Optional[str] = None) -> Optional[List[Dict[str, str]]]:
-    """Get the list of visits for the specified participant for the specified
-    module. If cutoff_date specified, filter visits on date_col >= cutoff_date.
-
-    Note: This method assumes visit date in file metadata is normalized to
-    YYYY-MM-DD format at a previous stage of the submission pipeline.
-
-    Args:
-        proxy: Flywheel proxy
-        container_id: Flywheel subject container ID
-        subject: Flywheel subject label for participant
-        module: module label, matched with Flywheel acquisition label
-        module_configs: form ingest configs for the module
-        cutoff_date (optional): If specified, filter visits on date_col >= cutoff_date
-
-    Returns:
-        List[Dict]: List of visits matching with the specified cutoff date
-    """
-
-    title = f'{module} visits for participant {subject}'
-
-    ptid_key = f'{MetadataKeys.FORM_METADATA_PATH}.{FieldNames.PTID}'
-    date_col_key = f'{MetadataKeys.FORM_METADATA_PATH}.{module_configs.date_field}'
-    columns = [
-        ptid_key, date_col_key, 'file.name', 'file.file_id',
-        'file.parents.acquisition'
-    ]
-
-    if FieldNames.VISITNUM in module_configs.required_fields:
-        visitnum_key = f'{MetadataKeys.FORM_METADATA_PATH}.{FieldNames.VISITNUM}'
-        columns.append(visitnum_key)
-
-    filters = f'acquisition.label={module}'
-
-    if cutoff_date:
-        filters += f',{date_col_key}>={cutoff_date}'
-
-    return proxy.get_matching_acquisition_files_info(container_id=container_id,
-                                                     dv_title=title,
-                                                     columns=columns,
-                                                     filters=filters)
+log = logging.getLogger(__name__)
 
 
-def find_module_visits_with_matching_visitdate(
-        *, proxy: FlywheelProxy, container_id: str, subject: str, module: str,
-        module_configs: ModuleConfigs, visitdate: str,
-        visitnum: Optional[str]) -> Optional[List[Dict[str, str]]]:
-    """Get the list of visits for the specified participant for the specified
-    module matching with the given visitdate and visitnum (if specified).
+class VisitsLookupHelper():
+    """Helper class to lookup visits files for a participant matching with any
+    specified constraints."""
 
-    Note: This method assumes visit date in file metadata is normalized to
-    YYYY-MM-DD format at a previous stage of the submission pipeline.
+    def __init__(self, *, proxy: FlywheelProxy, subject: SubjectAdaptor,
+                 form_project_configs: FormProjectConfigs) -> None:
+        """Initialize the Visits Lookup Helper.
 
-    Args:
-        proxy: Flywheel proxy
-        container_id: Flywheel subject container ID
-        subject: Flywheel subject label for participant
-        module: module label, matched with Flywheel acquisition label
-        module_configs: form ingest configs for the module
-        visitdate: visitdate to match
-        visitnum(optional): visit number to match
+        Args:
+            proxy: Flywheel proxy object
+            subject: Flywheel subject to run the QC checks
+            form_project_configs: form ingest configurations
+        """
+        self.__proxy = proxy
+        self.__subject = subject
+        self.__form_project_configs = form_project_configs
 
-    Returns:
-        List[Dict]: List of visits matching with the specified visitdate and visitnum
-    """
+    @property
+    def proxy(self) -> FlywheelProxy:
+        return self.__proxy
 
-    title = f'{module} visits for participant {subject}'
+    @property
+    def subject(self) -> SubjectAdaptor:
+        return self.__subject
 
-    ptid_key = f'{MetadataKeys.FORM_METADATA_PATH}.{FieldNames.PTID}'
-    date_col_key = f'{MetadataKeys.FORM_METADATA_PATH}.{module_configs.date_field}'
-    columns = [
-        ptid_key, date_col_key, 'file.name', 'file.file_id',
-        'file.parents.acquisition'
-    ]
+    @property
+    def form_configs(self) -> FormProjectConfigs:
+        return self.__form_project_configs
 
-    filters = f'acquisition.label={module},{date_col_key}={visitdate}'
+    def find_visits_for_module(
+            self,
+            *,
+            module: str,
+            module_configs: ModuleConfigs,
+            cutoff_date: Optional[str] = None
+    ) -> Optional[List[Dict[str, str]]]:
+        """Get the list of visits for this participant for the specified
+        module. If cutoff_date specified, get the visits having a visit date on
+        or later than the cutoff_date.
 
-    if visitnum and FieldNames.VISITNUM in module_configs.required_fields:
-        visitnum_key = f'{MetadataKeys.FORM_METADATA_PATH}.{FieldNames.VISITNUM}'
-        columns.append(visitnum_key)
-        filters += f',{visitnum_key}={visitnum}'
+        Note: This method assumes visit date in file metadata is normalized to
+        YYYY-MM-DD format at a previous stage of the submission pipeline.
 
-    return proxy.get_matching_acquisition_files_info(container_id=container_id,
-                                                     dv_title=title,
-                                                     columns=columns,
-                                                     filters=filters)
+        Args:
+            module: module label, matched with Flywheel acquisition label
+            module_configs: form ingest configs for the module
+            cutoff_date (optional): If specified, filter visits on date_col>=cutoff_date
+
+        Returns:
+            List[Dict]: List of visits matching with the specified cutoff date
+        """
+
+        title = f'{module} visits for participant {self.__subject.label}'
+
+        ptid_key = f'{MetadataKeys.FORM_METADATA_PATH}.{FieldNames.PTID}'
+        date_col_key = f'{MetadataKeys.FORM_METADATA_PATH}.{module_configs.date_field}'
+        columns = [
+            ptid_key, date_col_key, 'file.name', 'file.file_id',
+            'file.parents.acquisition'
+        ]
+
+        if FieldNames.VISITNUM in module_configs.required_fields:
+            visitnum_key = f'{MetadataKeys.FORM_METADATA_PATH}.{FieldNames.VISITNUM}'
+            columns.append(visitnum_key)
+
+        filters = f'acquisition.label={module}'
+
+        if cutoff_date:
+            filters += f',{date_col_key}>={cutoff_date}'
+
+        return self.__proxy.get_matching_acquisition_files_info(
+            container_id=self.__subject.id,
+            dv_title=title,
+            columns=columns,
+            filters=filters)
+
+    def find_module_visits_with_matching_visitdate(
+            self, *, module: str, module_configs: ModuleConfigs,
+            visitdate: str,
+            visitnum: Optional[str]) -> Optional[List[Dict[str, str]]]:
+        """Get the list of visits for the specified participant for the
+        specified module matching with the given visitdate and visitnum (if
+        specified).
+
+        Note: This method assumes visit date in file metadata is normalized to
+        YYYY-MM-DD format at a previous stage of the submission pipeline.
+
+        Args:
+            module: module label, matched with Flywheel acquisition label
+            module_configs: form ingest configs for the module
+            visitdate: visitdate to match
+            visitnum(optional): visit number to match
+
+        Returns:
+            List[Dict]: List of visits matching with the specified date and visitnum
+        """
+
+        title = f'{module} visits for participant {self.__subject.label}'
+
+        ptid_key = f'{MetadataKeys.FORM_METADATA_PATH}.{FieldNames.PTID}'
+        date_col_key = f'{MetadataKeys.FORM_METADATA_PATH}.{module_configs.date_field}'
+        columns = [
+            ptid_key, date_col_key, 'file.name', 'file.file_id',
+            'file.parents.acquisition'
+        ]
+
+        filters = f'acquisition.label={module},{date_col_key}={visitdate}'
+
+        if visitnum and FieldNames.VISITNUM in module_configs.required_fields:
+            visitnum_key = f'{MetadataKeys.FORM_METADATA_PATH}.{FieldNames.VISITNUM}'
+            columns.append(visitnum_key)
+            filters += f',{visitnum_key}={visitnum}'
+
+        return self.__proxy.get_matching_acquisition_files_info(
+            container_id=self.__subject.id,
+            dv_title=title,
+            columns=columns,
+            filters=filters)
+
+    def get_dependent_module_visits(
+        self, *, current_module: str, current_visits: List[VisitInfo]
+    ) -> Optional[Dict[str, List[Dict[str, str]]]]:
+        """Check whether there are any module visits dependent on the specified
+        visits that needs to be re-validated.
+
+        Args:
+            current_module: current module
+            current_visits: list of visits for current module
+        Raises:
+            GearExecutionError: if errors occur while looking up dependent visits
+        """
+
+        dependent_modules = self.__form_project_configs.get_module_dependencies(
+            module=current_module)
+
+        if not dependent_modules:
+            return None
+
+        log.info('List of other modules dependent on module %s: %s',
+                 current_module, dependent_modules)
+
+        dependent_visits: Dict[str, List[Dict[str, str]]] = {}
+        for dep_module in dependent_modules:
+            dep_module_configs = self.__form_project_configs.module_configs.get(
+                dep_module)
+
+            if not dep_module_configs:
+                raise GearExecutionError(
+                    f"Failed to find module configs for dependent module {dep_module}"
+                )
+
+            for visit in current_visits:
+                matched_visits = self.find_module_visits_with_matching_visitdate(
+                    module=dep_module,
+                    module_configs=dep_module_configs,
+                    visitdate=visit.visitdate,
+                    visitnum=visit.visitnum)
+
+                if not matched_visits:
+                    log.info(f"No module visits dependent on {current_module} "
+                             f"visit with visitdate: {visit.visitdate} "
+                             f"visitnum: {visit.visitnum}")
+                    continue
+
+                if len(matched_visits) > 1:  # this cannot happen
+                    raise GearExecutionError(
+                        f"Multiple {dep_module} visits found with "
+                        f"visitdate: {visit.visitdate} visitnum: {visit.visitnum}"
+                    )
+
+                if dep_module not in dependent_visits:
+                    dependent_visits[dep_module] = []
+                dependent_visits[dep_module].append(matched_visits[0])
+
+        return dependent_visits

--- a/gear/form_qc_coordinator/src/python/form_qc_coordinator_app/visits.py
+++ b/gear/form_qc_coordinator/src/python/form_qc_coordinator_app/visits.py
@@ -128,7 +128,7 @@ class VisitsLookupHelper():
         return self.__proxy.get_matching_acquisition_files_info(
             container_id=self.__subject.id,
             dv_title=title,
-            columns=columns,
+            columns=columns,  # type: ignore
             filters=filters,
             missing_data_strategy='none')
 

--- a/gear/form_qc_coordinator/src/python/form_qc_coordinator_app/visits.py
+++ b/gear/form_qc_coordinator/src/python/form_qc_coordinator_app/visits.py
@@ -64,15 +64,15 @@ class VisitsLookupHelper():
 
         title = f'{module} visits for participant {self.__subject.label}'
 
-        ptid_key = f'{MetadataKeys.FORM_METADATA_PATH}.{FieldNames.PTID}'
-        date_col_key = f'{MetadataKeys.FORM_METADATA_PATH}.{module_configs.date_field}'
+        ptid_key = MetadataKeys.get_column_key(FieldNames.PTID)
+        date_col_key = MetadataKeys.get_column_key(module_configs.date_field)
         columns = [
             ptid_key, date_col_key, 'file.name', 'file.file_id',
             'file.parents.acquisition'
         ]
 
         if FieldNames.VISITNUM in module_configs.required_fields:
-            visitnum_key = f'{MetadataKeys.FORM_METADATA_PATH}.{FieldNames.VISITNUM}'
+            visitnum_key = MetadataKeys.get_column_key(FieldNames.VISITNUM)
             columns.append(visitnum_key)
 
         filters = f'acquisition.label={module}'
@@ -109,17 +109,19 @@ class VisitsLookupHelper():
 
         title = f'{module} visits for participant {self.__subject.label}'
 
-        ptid_key = f'{MetadataKeys.FORM_METADATA_PATH}.{FieldNames.PTID}'
-        date_col_key = f'{MetadataKeys.FORM_METADATA_PATH}.{module_configs.date_field}'
+        ptid_key = MetadataKeys.get_column_key(FieldNames.PTID)
+        date_col_key = MetadataKeys.get_column_key(module_configs.date_field)
+        timestamp_key = f'file.info.{MetadataKeys.VALIDATED_TIMESTAMP}'
+        timestamp_label = f'{module}-{MetadataKeys.VALIDATED_TIMESTAMP}'
         columns = [
             ptid_key, date_col_key, 'file.name', 'file.file_id',
-            'file.parents.acquisition'
+            'file.parents.acquisition', (timestamp_key, timestamp_label)
         ]
 
         filters = f'acquisition.label={module},{date_col_key}={visitdate}'
 
         if visitnum and FieldNames.VISITNUM in module_configs.required_fields:
-            visitnum_key = f'{MetadataKeys.FORM_METADATA_PATH}.{FieldNames.VISITNUM}'
+            visitnum_key = MetadataKeys.get_column_key(FieldNames.VISITNUM)
             columns.append(visitnum_key)
             filters += f',{visitnum_key}={visitnum}'
 
@@ -127,7 +129,8 @@ class VisitsLookupHelper():
             container_id=self.__subject.id,
             dv_title=title,
             columns=columns,
-            filters=filters)
+            filters=filters,
+            missing_data_strategy='none')
 
     def get_dependent_module_visits(
         self, *, current_module: str, current_visits: List[VisitInfo]
@@ -183,6 +186,10 @@ class VisitsLookupHelper():
 
                 if dep_module not in dependent_visits:
                     dependent_visits[dep_module] = []
+
+                matched_visits[0][MetadataKeys.TRIGGERED_TIMESTAMP] = (
+                    visit.validated_timestamp
+                    if visit.validated_timestamp else "")
                 dependent_visits[dep_module].append(matched_visits[0])
 
         return dependent_visits

--- a/gear/form_qc_coordinator/src/python/form_qc_coordinator_app/visits.py
+++ b/gear/form_qc_coordinator/src/python/form_qc_coordinator_app/visits.py
@@ -169,9 +169,10 @@ class VisitsLookupHelper():
                     visitnum=visit.visitnum)
 
                 if not matched_visits:
-                    log.info(f"No module visits dependent on {current_module} "
-                             f"visit with visitdate: {visit.visitdate} "
-                             f"visitnum: {visit.visitnum}")
+                    log.info(
+                        f"No {dep_module} visits dependent on {current_module} "
+                        f"visit with visitdate: {visit.visitdate} "
+                        f"visitnum: {visit.visitnum}")
                     continue
 
                 if len(matched_visits) > 1:  # this cannot happen

--- a/gear/form_qc_coordinator/src/python/form_qc_coordinator_app/visits.py
+++ b/gear/form_qc_coordinator/src/python/form_qc_coordinator_app/visits.py
@@ -1,0 +1,100 @@
+from typing import Dict, List, Optional
+
+from configs.ingest_configs import ModuleConfigs
+from flywheel_adaptor.flywheel_proxy import FlywheelProxy
+from keys.keys import FieldNames, MetadataKeys
+
+
+def find_visits_for_participant_for_module(
+        *,
+        proxy: FlywheelProxy,
+        container_id: str,
+        subject: str,
+        module: str,
+        module_configs: ModuleConfigs,
+        cutoff_date: Optional[str] = None) -> Optional[List[Dict[str, str]]]:
+    """Get the list of visits for the specified participant for the specified
+    module. If cutoff_date specified, filter visits on date_col >= cutoff_date.
+
+    Note: This method assumes visit date in file metadata is normalized to
+    YYYY-MM-DD format at a previous stage of the submission pipeline.
+
+    Args:
+        proxy: Flywheel proxy
+        container_id: Flywheel subject container ID
+        subject: Flywheel subject label for participant
+        module: module label, matched with Flywheel acquisition label
+        module_configs: form ingest configs for the module
+        cutoff_date (optional): If specified, filter visits on date_col >= cutoff_date
+
+    Returns:
+        List[Dict]: List of visits matching with the specified cutoff date
+    """
+
+    title = f'{module} visits for participant {subject}'
+
+    ptid_key = f'{MetadataKeys.FORM_METADATA_PATH}.{FieldNames.PTID}'
+    date_col_key = f'{MetadataKeys.FORM_METADATA_PATH}.{module_configs.date_field}'
+    columns = [
+        ptid_key, date_col_key, 'file.name', 'file.file_id',
+        'file.parents.acquisition'
+    ]
+
+    if FieldNames.VISITNUM in module_configs.required_fields:
+        visitnum_key = f'{MetadataKeys.FORM_METADATA_PATH}.{FieldNames.VISITNUM}'
+        columns.append(visitnum_key)
+
+    filters = f'acquisition.label={module}'
+
+    if cutoff_date:
+        filters += f',{date_col_key}>={cutoff_date}'
+
+    return proxy.get_matching_acquisition_files_info(container_id=container_id,
+                                                     dv_title=title,
+                                                     columns=columns,
+                                                     filters=filters)
+
+
+def find_module_visits_with_matching_visitdate(
+        *, proxy: FlywheelProxy, container_id: str, subject: str, module: str,
+        module_configs: ModuleConfigs, visitdate: str,
+        visitnum: Optional[str]) -> Optional[List[Dict[str, str]]]:
+    """Get the list of visits for the specified participant for the specified
+    module matching with the given visitdate and visitnum (if specified).
+
+    Note: This method assumes visit date in file metadata is normalized to
+    YYYY-MM-DD format at a previous stage of the submission pipeline.
+
+    Args:
+        proxy: Flywheel proxy
+        container_id: Flywheel subject container ID
+        subject: Flywheel subject label for participant
+        module: module label, matched with Flywheel acquisition label
+        module_configs: form ingest configs for the module
+        visitdate: visitdate to match
+        visitnum(optional): visit number to match
+
+    Returns:
+        List[Dict]: List of visits matching with the specified visitdate and visitnum
+    """
+
+    title = f'{module} visits for participant {subject}'
+
+    ptid_key = f'{MetadataKeys.FORM_METADATA_PATH}.{FieldNames.PTID}'
+    date_col_key = f'{MetadataKeys.FORM_METADATA_PATH}.{module_configs.date_field}'
+    columns = [
+        ptid_key, date_col_key, 'file.name', 'file.file_id',
+        'file.parents.acquisition'
+    ]
+
+    filters = f'acquisition.label={module},{date_col_key}={visitdate}'
+
+    if visitnum and FieldNames.VISITNUM in module_configs.required_fields:
+        visitnum_key = f'{MetadataKeys.FORM_METADATA_PATH}.{FieldNames.VISITNUM}'
+        columns.append(visitnum_key)
+        filters += f',{visitnum_key}={visitnum}'
+
+    return proxy.get_matching_acquisition_files_info(container_id=container_id,
+                                                     dv_title=title,
+                                                     columns=columns,
+                                                     filters=filters)

--- a/gear/form_scheduler/src/data/pipeline-configs.json
+++ b/gear/form_scheduler/src/data/pipeline-configs.json
@@ -37,7 +37,8 @@
                     "debug": false,
                     "add_parents": false
                 }
-            }
+            },
+            "notify_user": true
         },
         {
             "name": "finalization",

--- a/gear/form_scheduler/src/data/pipeline-configs.json
+++ b/gear/form_scheduler/src/data/pipeline-configs.json
@@ -70,7 +70,7 @@
                     }
                 ],
                 "configs": {
-                    "apikey_path_prefix": "/prod/flywheel/gearbot",
+                    "apikey_path_prefix": "/sandbox/flywheel/gearbot",
                     "check_all": false
                 }
             }

--- a/gear/form_scheduler/src/data/pipeline-configs.json
+++ b/gear/form_scheduler/src/data/pipeline-configs.json
@@ -1,0 +1,78 @@
+{
+    "gears": [
+        "file-validator",
+        "identifier-lookup",
+        "form-transformer",
+        "form-qc-coordinator",
+        "form-qc-checker"
+    ],
+    "pipelines": [
+        {
+            "name": "submission",
+            "modules": [
+                "UDS",
+                "FTLD",
+                "LBD"
+            ],
+            "tags": [
+                "queued"
+            ],
+            "extensions": [
+                ".csv"
+            ],
+            "starting_gear": {
+                "gear_name": "file-validator",
+                "inputs": [
+                    {
+                        "label": "input_file",
+                        "file_locator": "matched"
+                    },
+                    {
+                        "label": "validation_schema",
+                        "file_locator": "module",
+                        "file_name": "${module}-schema.json"
+                    }
+                ],
+                "configs": {
+                    "debug": false,
+                    "add_parents": false
+                }
+            }
+        },
+        {
+            "name": "finalization",
+            "modules": [
+                "UDS"
+            ],
+            "tags": [
+                "submission-complete"
+            ],
+            "extensions": [
+                ".json"
+            ],
+            "starting_gear": {
+                "gear_name": "form-qc-coordinator",
+                "inputs": [
+                    {
+                        "label": "visits_file",
+                        "file_locator": "matched"
+                    },
+                    {
+                        "label": "form_configs_file",
+                        "file_locator": "fixed",
+                        "file_name": "form-data-module-configs.json"
+                    },
+                    {
+                        "label": "qc_configs_file",
+                        "file_locator": "fixed",
+                        "file_name": "form-qc-checker-configs.json"
+                    }
+                ],
+                "configs": {
+                    "apikey_path_prefix": "/prod/flywheel/gearbot",
+                    "check_all": false
+                }
+            }
+        }
+    ]
+}

--- a/gear/form_scheduler/src/docker/BUILD
+++ b/gear/form_scheduler/src/docker/BUILD
@@ -6,4 +6,4 @@ docker_image(name="form-scheduler",
                  ":manifest",
                  "gear/form_scheduler/src/python/form_scheduler_app:bin"
              ],
-             image_tags=["1.0.5", "latest"])
+             image_tags=["1.1.0", "latest"])

--- a/gear/form_scheduler/src/docker/manifest.json
+++ b/gear/form_scheduler/src/docker/manifest.json
@@ -25,24 +25,18 @@
     "inputs": {
         "api-key": {
             "base": "api-key"
+        },
+        "pipeline_configs_file": {
+            "description": "A JSON file with pipeline configurations",
+            "base": "file",
+            "type": {
+                "enum": [
+                    "source code"
+                ]
+            }
         }
     },
     "config": {
-        "submission_pipeline": {
-            "description": "Comma-delimited list of gears representing a submission pipeline",
-            "type": "string",
-            "default": "file-validator,identifier-lookup,form-transformer,form-qc-coordinator,form-qc-checker"
-        },
-        "accepted_modules": {
-            "description": "Comma-delimited list of accepted modules, listed in order of priority. There will be one queue for each",
-            "type": "string",
-            "default": "UDS,FTLD,LBD"
-        },
-        "queue_tags": {
-            "description": "Comma-delimited list of queue tags to filter project files for to determine which need to be queued",
-            "type": "string",
-            "default": "queued"
-        },
         "source_email": {
             "description": "The source email to send the submission completion notification",
             "type": "string",

--- a/gear/form_scheduler/src/docker/manifest.json
+++ b/gear/form_scheduler/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "form-scheduler",
     "label": "Form Scheduler",
     "description": "Queues project files for the submission pipeline",
-    "version": "1.0.5",
+    "version": "1.1.0",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/form-scheduler:1.0.5"
+            "image": "naccdata/form-scheduler:1.1.0"
         },
         "flywheel": {
             "suite": "NACC Admin Gears",

--- a/gear/form_scheduler/src/python/form_scheduler_app/email_user.py
+++ b/gear/form_scheduler/src/python/form_scheduler_app/email_user.py
@@ -2,7 +2,7 @@
 import logging
 
 from flywheel import Project
-from flywheel.models.file_output import FileOutput  # type: ignore
+from flywheel.models.file_entry import FileEntry
 from flywheel_adaptor.flywheel_proxy import FlywheelProxy
 from inputs.parameter_store import URLParameter
 from notifications.email import (
@@ -23,7 +23,7 @@ class SubmissionCompleteTemplateModel(BaseTemplateModel):
 
 
 def send_email(proxy: FlywheelProxy, email_client: EmailClient,
-               file: FileOutput, project: Project,
+               file: FileEntry, project: Project,
                portal_url: URLParameter) -> None:
     """Sends an email notifying user that their submission pipeline has
     completed.
@@ -31,8 +31,8 @@ def send_email(proxy: FlywheelProxy, email_client: EmailClient,
     Args:
         proxy: the proxy for the Flywheel instance
         email_client: EmailClient to send emails from
-        file: The FileOutput; will pull details from it
-        project: The ProjectOutput; will pull details from it
+        file: The FileEntry object to will pull details
+        project: Flywheel project container
         portal_url: The portal URL
     """
 

--- a/gear/form_scheduler/src/python/form_scheduler_app/form_scheduler_queue.py
+++ b/gear/form_scheduler/src/python/form_scheduler_app/form_scheduler_queue.py
@@ -130,8 +130,9 @@ class FormSchedulerQueue:
         pipeline_function = getattr(self, function_name, None)
         if pipeline_function and callable(pipeline_function):
             num_files = pipeline_function(project=project, pipeline=pipeline)
-            log.info('Number of files queued for pipeline %s: %s',
-                     pipeline.name, num_files)
+            log.info(
+                f"Number of files queued for pipeline `{pipeline.name}`: {num_files}"
+            )
             return num_files  # type: ignore
         else:
             raise GearExecutionError(
@@ -158,8 +159,8 @@ class FormSchedulerQueue:
 
         if len(files) == 0:
             log.info(
-                'No matching files for pipeline %s with tags: %s and extensions: %s',
-                pipeline.name, pipeline.tags, pipeline.extensions)
+                f"No matching files for pipeline `{pipeline.name}` with "
+                f"tags: {pipeline.tags} and extensions: {pipeline.extensions}")
             return 0
 
         pipeline_queue = PipelineQueue.create_from_pipeline(pipeline=pipeline)
@@ -173,7 +174,7 @@ class FormSchedulerQueue:
             # by something else
             if not match:
                 log.warning(
-                    'File %s is incorrectly tagged with one or more tags %s',
+                    "File %s is incorrectly tagged with one or more tags %s",
                     file.name, pipeline.tags)
                 continue
 
@@ -182,7 +183,7 @@ class FormSchedulerQueue:
             # these files could be incorrectly tagged
             if module.upper() not in pipeline.modules:
                 log.warning(
-                    'File %s is not in the accepted modules %s for pipeline %s',
+                    "File %s is not in the accepted modules %s for pipeline `%s`",
                     file.name, pipeline.modules, pipeline.name)
                 continue
 
@@ -227,7 +228,7 @@ class FormSchedulerQueue:
 
         if not finalized_visits:
             log.info(
-                'No matching files for pipeline %s with tags: %s and extensions: %s',
+                "No matching files for pipeline `%s` with tags: %s and extensions: %s",
                 pipeline.name, pipeline.tags, pipeline.extensions)
             return 0
 
@@ -325,7 +326,7 @@ class FormSchedulerQueue:
                     notify_user=pipeline.notify_user)
             except ValueError as error:
                 raise GearExecutionError(
-                    f"Failed to process pipeline {pipeline.name}: {error}"
+                    f"Failed to process pipeline `{pipeline.name}`: {error}"
                 ) from error
 
     def _process_pipeline_queue(self, *, pipeline: Pipeline,
@@ -380,7 +381,7 @@ class FormSchedulerQueue:
             #    but left in as a safeguard
             JobPoll.wait_for_pipeline(self.__proxy, job_search)
 
-            log.info('Start processing pipeline %s module queue %s',
+            log.info("Start processing pipeline: `%s` module queue: `%s`",
                      pipeline.name, module)
 
             while len(subqueue) > 0:
@@ -413,17 +414,18 @@ class FormSchedulerQueue:
                 # Should we check that the first gear is always the file-validator?
 
                 log.info(
-                    f"Kicking off pipeline: {pipeline.name} on module {module}"
+                    f"Kicking off pipeline `{pipeline.name}` on module {module}"
                 )
                 log.info(
                     f"Triggering {pipeline.starting_gear.gear_name} for {file.name}"
                 )
 
-                trigger_gear(proxy=self.__proxy,
-                             gear_name=pipeline.starting_gear.gear_name,
-                             log_args=False,
-                             inputs=gear_inputs,
-                             config=pipeline.starting_gear.configs)
+                trigger_gear(
+                    proxy=self.__proxy,
+                    gear_name=pipeline.starting_gear.gear_name,
+                    log_args=False,
+                    inputs=gear_inputs,
+                    config=pipeline.starting_gear.configs.model_dump())
 
                 # d. wait for the above submission pipeline to finish
                 JobPoll.wait_for_pipeline(self.__proxy, job_search)

--- a/gear/form_scheduler/src/python/form_scheduler_app/form_scheduler_queue.py
+++ b/gear/form_scheduler/src/python/form_scheduler_app/form_scheduler_queue.py
@@ -1,91 +1,476 @@
 """Defines the Form Scheduler Queue."""
+import json
+import logging
 import re
+from json.decoder import JSONDecodeError
+from string import Template
 from typing import Dict, List, Optional, Tuple
 
+from configs.ingest_configs import Pipeline, PipelineConfigs
+from dataview.dataview import ColumnModel, make_builder
 from flywheel import Project
-from flywheel.models.file_output import FileOutput
+from flywheel.models.file_entry import FileEntry
+from flywheel_adaptor.flywheel_proxy import FlywheelProxy
+from gear_execution.gear_execution import GearExecutionError
+from gear_execution.gear_trigger import GearInput, LocatorType, trigger_gear
+from inputs.parameter_store import URLParameter
+from jobs.job_poll import JobPoll
+from notifications.email import EmailClient
+from pydantic import BaseModel
+
+from form_scheduler_app.email_user import send_email
 
 MODULE_PATTERN = re.compile(r"^.+-([a-zA-Z]+)(\..+)$")
 
+log = logging.getLogger(__name__)
+
+
+class PipelineQueue(BaseModel):
+    """Class to represent a file queue for a given pipeline, with subqueues
+    defined for each module accepted for the pipeline."""
+
+    index: int = -1
+    name: str
+    tags: List[str]
+    modules: List[str]
+    subqueues: Dict[str, List[FileEntry]]
+
+    @classmethod
+    def create_from_pipeline(cls, pipeline: Pipeline) -> 'PipelineQueue':
+        """Initialize the pipeline queue from pipeline configs.
+
+        Args:
+            pipeline: pipeline configurations
+
+        Returns:
+            PipelineQueue: file queue for the pipeline
+        """
+        return PipelineQueue(name=pipeline.name,
+                             tags=pipeline.tags,
+                             modules=pipeline.modules,
+                             subqueues={k: []
+                                        for k in pipeline.modules})
+
+    def add_file_to_subqueue(self, module: str, file: FileEntry):
+        """Add the file to given module subqueue.
+
+        Args:
+            module: module name
+            file: file to add
+        """
+        self.subqueues[module].append(file)
+
+    def sort_subqueues(self):
+        """Sort each queue by ascending order of file modified date."""
+        for subqueue in self.subqueues.values():
+            subqueue.sort(key=lambda file: file.modified)
+
+    def next_queue(self) -> Tuple[str, List[FileEntry]]:
+        """Returns the next module queue for the pipeline.
+
+        Returns:
+            Tuple with the module name and its corresponding
+            queue to be processed.
+        """
+        self.index = (self.index + 1) % len(self.modules)
+        module = self.modules[self.index]
+        return module, self.subqueues[module]
+
+    def empty(self) -> bool:
+        """Returns whether or not all the subqueues are empty.
+
+        Returns:
+            True if all subqueues are empty, False otherwise.
+        """
+        return all(not x for x in self.subqueues.values())
+
 
 class FormSchedulerQueue:
-    """Class to define a queue for each accepted module, with prioritization
-    allowed."""
+    """Class to handle scheduling of different form pipelines defined in the
+    pipeline configs file."""
 
-    def __init__(self, module_order: List[str], queue_tags: List[str]) -> None:
+    def __init__(self,
+                 proxy: FlywheelProxy,
+                 project: Project,
+                 pipeline_configs: PipelineConfigs,
+                 email_client: Optional[EmailClient] = None,
+                 portal_url: Optional[URLParameter] = None) -> None:
         """Initializer.
 
         Args:
-            module_order: The modules and the order to process them in
-            queue_tags: The queue tags to filter project files for
-                to determine which need to be queued
+            proxy: the proxy for the Flywheel instance
+            project: Flywheel project container
+            pipeline_configs: form pipeline configurations
+            email_client: EmailClient to send emails from
+            portal_url: The portal URL
         """
-        self.__module_order = module_order
-        self.__index = -1
-        self.queue_tags = set(queue_tags)  # make set for comparison later
-        self.__queue: Dict[str, List[FileOutput]] = {
-            k: []
-            for k in self.__module_order
-        }
+        self.__proxy = proxy
+        self.__project = project
+        self.__pipeline_configs = pipeline_configs
+        self.__email_client = email_client
+        self.__portal_url = portal_url
+        self.__pipeline_queues: Dict[str, PipelineQueue] = {}
 
-    def add_files(self,
-                  project: Project,
-                  file_extensions: Optional[List[str]] = None) -> int:
-        """Add the files (filtered by queue tags) to queue.
+    def queue_files_for_pipeline(self, *, project: Project,
+                                 pipeline: Pipeline) -> int:
+        """Queue the matching files for the given pipeline.
+
+        Args:
+            project: Flywheel project container
+            pipeline: Pipeline configurations
+
+        Returns:
+            int: Number of files added to the pipeline queue
+        """
+
+        function_name = f'_add_{pipeline.name}_pipeline_files'
+        pipeline_function = getattr(self, function_name, None)
+        if pipeline_function and callable(pipeline_function):
+            num_files = pipeline_function(project=project, pipeline=pipeline)
+            log.info('Number of files queued for pipeline %s: %s',
+                     pipeline.name, num_files)
+            return num_files  # type: ignore
+        else:
+            raise GearExecutionError(
+                f"{function_name} not defined in the Form Scheduler")
+
+    def _add_submission_pipeline_files(self, *, project: Project,
+                                       pipeline: Pipeline) -> int:
+        """Add the files (filtered by queue tags) to submission pipeline queue.
 
         Args:
             project: Project to pull queue files from
-            file_extensions: List of file extensions to grab
-        Returns:
-            The number of files added to the queue
-        """
-        if not file_extensions:
-            file_extensions = ['.csv']
+            pipeline: Pipeline configurations
 
-        files: List[FileOutput] = [
-            x for x in project.files if self.queue_tags.issubset(set(x.tags))
+        Returns:
+            The number of files added to the submission pipeline queue
+        """
+
+        # filter project files with matching tags and extensions
+        files: List[FileEntry] = [
+            x for x in project.files
+            if (set(pipeline.tags).issubset(set(x.tags))
+                and x.name.lower().endswith(tuple(pipeline.extensions)))
         ]
-        num_files = 0
+
+        if len(files) == 0:
+            log.info(
+                'No matching files for pipeline %s with tags: %s and extensions: %s',
+                pipeline.name, pipeline.tags, pipeline.extensions)
+            return 0
+
+        pipeline_queue = PipelineQueue.create_from_pipeline(pipeline=pipeline)
 
         # grabs files in the format *-<module>.<ext>
+        num_files = 0
         for file in files:
             match = re.search(MODULE_PATTERN, file.name.lower())
             # skip over files that do not match regex - form-screening gear should
             # check this so these should just be files that were incorrectly tagged
             # by something else
             if not match:
+                log.warning(
+                    'File %s is incorrectly tagged with one or more tags %s',
+                    file.name, pipeline.tags)
                 continue
 
             module = match.group(1)
-            ext = match.group(2)
-            if ext not in file_extensions:
+            # skip over files that do not match the accepted modules for the pipeline
+            # these files could be incorrectly tagged
+            if module.upper() not in pipeline.modules:
+                log.warning(
+                    'File %s is not in the accepted modules %s for pipeline %s',
+                    file.name, pipeline.modules, pipeline.name)
                 continue
 
-            # add to queue
-            self.__queue[module].append(file)
+            # add the file to the respective module queue
+            pipeline_queue.add_file_to_subqueue(module=module, file=file)
             num_files += 1
 
-        # sort each queue by last modified date
-        for subqueue in self.__queue.values():
-            subqueue.sort(key=lambda file: file.modified)
+        # sort the files in each subqueue by ascending order of last modified date
+        pipeline_queue.sort_subqueues()
+        self.__pipeline_queues[pipeline.name] = pipeline_queue
 
         return num_files
 
-    def next_queue(self) -> Tuple[str, List[FileOutput]]:
-        """Returns the next queue in the round robin.
+    def _add_finalization_pipeline_files(self, *, project: Project,
+                                         pipeline: Pipeline) -> int:
+        """Add the files (filtered by queue tags) to finalization pipeline
+        queue.
+
+        Args:
+            project: Project to pull queue files from
+            pipeline: Pipeline configurations
 
         Returns:
-            Tuple with the module name and its corresponding
-            queue to be processed.
+            The number of files added to the finalization pipeline queue
         """
-        self.__index = (self.__index + 1) % len(self.__module_order)
-        module = self.__module_order[self.__index]
-        return module, self.__queue[module]
 
-    def empty(self) -> bool:
-        """Returns whether or not the queue is empty.
+        # TODO: Find a way to search multiple tags
+        # Checked with FW and multi tag OR search currently doesn't work
+        # finalization pipeline currently only has one tag, so no issue for now
+        if len(pipeline.tags) > 0:
+            raise GearExecutionError(
+                f"Cannot support searching for multiple file tags {pipeline.tags}"
+            )
+
+        # find the list of visits with matching tags and extensions
+        # for the modules accepted for this pipeline
+        finalized_visits = self.__get_visits_with_matching_tag(
+            project=project,
+            modules=pipeline.modules,
+            tag=pipeline.tags[0],
+            extensions=pipeline.extensions)
+
+        if not finalized_visits:
+            log.info(
+                'No matching files for pipeline %s with tags: %s and extensions: %s',
+                pipeline.name, pipeline.tags, pipeline.extensions)
+            return 0
+
+        pipeline_queue = PipelineQueue.create_from_pipeline(pipeline=pipeline)
+
+        num_files = 0
+        for visit in finalized_visits:
+            visit_file = self.__proxy.get_file(visit['file_id'])
+            # add the file to the respective module queue
+            pipeline_queue.add_file_to_subqueue(module=visit['module'],
+                                                file=visit_file)
+            num_files += 1
+
+        # sort the files in each subqueue by ascending order of last modified date
+        pipeline_queue.sort_subqueues()
+        self.__pipeline_queues[pipeline.name] = pipeline_queue
+
+        return num_files
+
+    def __get_visits_with_matching_tag(
+            self, *, project: Project, modules: List[str], tag: str,
+            extensions: List[str]) -> Optional[List[Dict[str, str]]]:
+        """Find the visit files with matching modules, tags and extensions.
+
+        Args:
+            project: Flywheel project container
+            modules: List of modules to match
+            tag: file tag to match
+            extensions: List of file extensions to match
 
         Returns:
-            True if the queue is empty, False otherwise.
+            List[Dict[str, str]](optional): matching visits if found
         """
-        return all(not x for x in self.__queue.values())
+
+        filename_pattern = ''
+        for i, extension in enumerate(extensions):
+            filename_pattern += f'^.*\\{extension}$'
+            if i < len(extensions) - 1:
+                filename_pattern += '|'
+
+        builder = make_builder(
+            label=f'Participant visits with tags {tag}',
+            description='List of finalized visits for the module',
+            columns=[
+                ColumnModel(data_key="file.name", label="filename"),
+                ColumnModel(data_key="file.file_id", label="file_id"),
+                ColumnModel(data_key="acquisition.label", label="module"),
+                ColumnModel(data_key="file.tags", label="file_tags")
+            ],
+            container='acquisition',
+            filter_str=
+            f'acquisition.label=|[{",".join(modules)}],file.tags={tag}',
+            missing_data_strategy='drop-row')
+
+        builder.file_filter(value=filename_pattern, regex=True)
+        # need to set the container again (should be same as "container" given above)
+        # if only file_filter is set, FW reports following error
+        # ValueError: Both file_container and file_filter are required to process files
+        builder.file_container('acquisition')
+        view = builder.build()
+
+        with self.__proxy.read_view_data(view=view,
+                                         container_id=project.id) as resp:
+            try:
+                result = json.load(resp)
+            except JSONDecodeError as error:
+                log.error('Error in loading dataview %s on container %s: %s',
+                          view.label, project.id, error)
+                return None
+
+        if not result or 'data' not in result:
+            return None
+
+        return result['data']
+
+    def process_pipeline_queues(self):
+        """Process the pipeline queues.
+
+        Raises:
+            GearExecutionError: if problems occur while processing
+        """
+        # search string to use for looking up running pipelines
+        search_str = JobPoll.generate_search_string(
+            project_ids_list=[self.__project.id],
+            gears_list=self.__pipeline_configs.gears,
+            states_list=['running', 'pending'])
+
+        # Pipelines are processed in the order they are listed in the pipeline configs
+        for pipeline in self.__pipeline_configs.pipelines:
+            try:
+                self._process_pipeline_queue(
+                    pipeline=pipeline,
+                    pipeline_queue=self.__pipeline_queues[pipeline.name],
+                    job_search=search_str,
+                    notify_user=(pipeline.name == 'submission'))
+            except ValueError as error:
+                raise GearExecutionError(
+                    f"Failed to process pipeline {pipeline.name}: {error}"
+                ) from error
+
+    def _process_pipeline_queue(self, *, pipeline: Pipeline,
+                                pipeline_queue: PipelineQueue, job_search: str,
+                                notify_user: bool):
+        """Process the files in the specified pipeline queue. Trigger the
+        starting gear for the pipeline for each file in pipeline queue.
+
+        Args:
+            pipeline: pipeline configs
+            pipeline_queue: files queued for this pipeline
+            job_search: lookup string to find running pipelines
+            notify_user: whether to notify the user about completion of pipeline
+        """
+
+        # get the starting gear input file configurations
+        gear_input_info = pipeline.starting_gear.get_inputs_by_file_locator_type(
+            locators=['fixed', 'matched', 'module'])
+
+        gear_inputs = {}
+
+        # set gear inputs of file locator type fixed
+        # these are the project level files with fixed filename specified in the configs
+        if gear_input_info and 'fixed' in gear_input_info:
+            self.__set_gear_inputs(gear_name=pipeline.starting_gear.gear_name,
+                                   locator='fixed',
+                                   gear_inputs_list=gear_input_info['fixed'],
+                                   gear_inputs=gear_inputs)
+
+        while not pipeline_queue.empty():
+            # Grab the next module subqueue for this pipeline
+            module, subqueue = pipeline_queue.next_queue()
+            if not subqueue:
+                continue
+
+            # set gear inputs of file locator type module
+            # for these inputs, each module has a module specific file at project level
+            # need to substitute module in the filename specified in the configs
+            if gear_input_info and 'module' in gear_input_info:
+                self.__set_gear_inputs(
+                    gear_name=pipeline.starting_gear.gear_name,
+                    locator='module',
+                    gear_inputs_list=gear_input_info['module'],
+                    gear_inputs=gear_inputs,
+                    module=module)
+
+            # a. Check if any submission pipelines are already running for
+            #    this project. If one is found, wait for it to finish before continuing.
+            #    This should actually not happen as it would mean that this gear
+            #    instance is not the owner/trigger of this submission pipeline,
+            #    but left in as a safeguard
+            JobPoll.wait_for_pipeline(self.__proxy, job_search)
+
+            log.info('Start processing pipeline %s module queue %s',
+                     pipeline.name, module)
+
+            while len(subqueue) > 0:
+                # b. Pull the next file from subqueue and clear the queue tags
+                file = subqueue.pop(0)
+                for tag in pipeline_queue.tags:
+                    file.delete_tag(tag)
+
+                # need to reload else the next gear may add the same queue tags back in
+                # causing an infinite loop
+                file = file.reload()
+
+                # set gear inputs of file locator type matched
+                # for these inputs, use the file entry pulled from the queue
+                if gear_input_info and 'matched' in gear_input_info:
+                    self.__set_gear_inputs(
+                        gear_name=pipeline.starting_gear.gear_name,
+                        locator='matched',
+                        gear_inputs_list=gear_input_info['matched'],
+                        gear_inputs=gear_inputs,
+                        matched_file=file)
+
+                # c. Trigger the submission pipeline.
+                # Here's where it isn't actually parameterized - we assume that
+                # the first gear is the file-validator regardless, and passes
+                # the corresponding inputs + uses the default configuration
+                # If the first gear changes and has different inputs/needs updated
+                # configurations, this may break as a result and will need to be updated
+                # Should we check that the first gear is always the file-validator?
+
+                log.info(
+                    f"Kicking off pipeline: {pipeline.name} on module {module}"
+                )
+                log.info(
+                    f"Triggering {pipeline.starting_gear.gear_name} for {file.name}"
+                )
+
+                trigger_gear(proxy=self.__proxy,
+                             gear_name=pipeline.starting_gear.gear_name,
+                             log_args=False,
+                             inputs=gear_inputs,
+                             config=pipeline.starting_gear.configs)
+
+                # d. wait for the above submission pipeline to finish
+                JobPoll.wait_for_pipeline(self.__proxy, job_search)
+
+                # e. if notifications enabled,
+                #    email to user who uploaded the file that pipeline has completed
+                if notify_user and self.__email_client:
+                    send_email(proxy=self.__proxy,
+                               email_client=self.__email_client,
+                               file=file,
+                               project=self.__project,
+                               portal_url=self.__portal_url)  # type: ignore
+
+                # f. repeat until current subqueue is empty
+
+            # Move to next subqueue, repeat a - f until all subqueues are empty
+
+    def __set_gear_inputs(self,
+                          *,
+                          gear_name: str,
+                          locator: LocatorType,
+                          gear_inputs_list: List[GearInput],
+                          gear_inputs: Dict[str, FileEntry],
+                          module: Optional[str] = None,
+                          matched_file: Optional[FileEntry] = None):
+
+        if locator == 'matched' and not matched_file:
+            raise ValueError(
+                "matched_file is required when locator is 'matched'")
+
+        if locator == 'module' and not module:
+            raise ValueError("module is required when locator is 'module'")
+
+        for input_info in gear_inputs_list:
+            label = input_info.label
+
+            if locator == 'matched':
+                gear_inputs[label] = matched_file  # type: ignore
+                continue
+
+            filename = input_info.file_name
+            # Build filename (substitute module if needed)
+            if locator == 'module':
+                filename = Template(
+                    input_info.file_name).substitute(  # type: ignore
+                        {"module": module.lower()})  # type: ignore
+
+            gear_input_file = self.__project.get_file(
+                name=filename)  # type: ignore
+            if not gear_input_file:
+                raise GearExecutionError(
+                    f"Cannot find required input file {filename} "
+                    f"for gear {gear_name}")
+
+            gear_inputs[label] = gear_input_file

--- a/gear/form_scheduler/src/python/form_scheduler_app/form_scheduler_queue.py
+++ b/gear/form_scheduler/src/python/form_scheduler_app/form_scheduler_queue.py
@@ -180,7 +180,8 @@ class FormSchedulerQueue:
 
             module = match.group(1)
             # skip over files that do not match the accepted modules for the pipeline
-            # these files could be incorrectly tagged
+            # Note: Issue Manager currently tag all files when they are finalized
+            #       without checking for any dependent modules
             if module.upper() not in pipeline.modules:
                 log.warning(
                     "File %s is not in the accepted modules %s for pipeline `%s`",

--- a/gear/form_scheduler/src/python/form_scheduler_app/form_scheduler_queue.py
+++ b/gear/form_scheduler/src/python/form_scheduler_app/form_scheduler_queue.py
@@ -22,7 +22,7 @@ from pydantic import BaseModel, ConfigDict
 
 from form_scheduler_app.email_user import send_email
 
-MODULE_PATTERN = re.compile(r"^.+-([a-zA-Z]+)(\..+)$")
+MODULE_PATTERN = re.compile(r"^.*-([a-zA-Z]+)(\..+)$")
 
 log = logging.getLogger(__name__)
 
@@ -61,7 +61,7 @@ class PipelineQueue(BaseModel):
             module: module name
             file: file to add
         """
-        self.subqueues[module].append(file)
+        self.subqueues[module.upper()].append(file)
 
     def sort_subqueues(self):
         """Sort each queue by ascending order of file modified date."""

--- a/gear/form_scheduler/src/python/form_scheduler_app/form_scheduler_queue.py
+++ b/gear/form_scheduler/src/python/form_scheduler_app/form_scheduler_queue.py
@@ -212,7 +212,7 @@ class FormSchedulerQueue:
         # TODO: Find a way to search multiple tags
         # Checked with FW and multi tag OR search currently doesn't work
         # finalization pipeline currently only has one tag, so no issue for now
-        if len(pipeline.tags) > 0:
+        if len(pipeline.tags) > 1:
             raise GearExecutionError(
                 f"Cannot support searching for multiple file tags {pipeline.tags}"
             )

--- a/gear/form_scheduler/src/python/form_scheduler_app/form_scheduler_queue.py
+++ b/gear/form_scheduler/src/python/form_scheduler_app/form_scheduler_queue.py
@@ -319,7 +319,7 @@ class FormSchedulerQueue:
                     pipeline=pipeline,
                     pipeline_queue=self.__pipeline_queues[pipeline.name],
                     job_search=search_str,
-                    notify_user=(pipeline.name == 'submission'))
+                    notify_user=pipeline.notify_user)
             except ValueError as error:
                 raise GearExecutionError(
                     f"Failed to process pipeline {pipeline.name}: {error}"

--- a/gear/form_scheduler/src/python/form_scheduler_app/form_scheduler_queue.py
+++ b/gear/form_scheduler/src/python/form_scheduler_app/form_scheduler_queue.py
@@ -5,7 +5,7 @@ import re
 from json.decoder import JSONDecodeError
 from typing import Dict, List, Optional, Tuple
 
-from configs.ingest_configs import Pipeline, PipelineConfigs
+from configs.ingest_configs import Pipeline, PipelineConfigs, PipelineType
 from dataview.dataview import ColumnModel, make_builder
 from flywheel import Project
 from flywheel.models.file_entry import FileEntry
@@ -33,7 +33,7 @@ class PipelineQueue(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     index: int = -1
-    name: str
+    name: PipelineType
     tags: List[str]
     modules: List[str]
     subqueues: Dict[str, List[FileEntry]]

--- a/gear/form_scheduler/src/python/form_scheduler_app/form_scheduler_queue.py
+++ b/gear/form_scheduler/src/python/form_scheduler_app/form_scheduler_queue.py
@@ -318,6 +318,10 @@ class FormSchedulerQueue:
 
         # Pipelines are processed in the order they are listed in the pipeline configs
         for pipeline in self.__pipeline_configs.pipelines:
+            # Skip pipelines with no queued files
+            if pipeline.name not in self.__pipeline_queues:
+                continue
+
             try:
                 self._process_pipeline_queue(
                     pipeline=pipeline,

--- a/gear/form_scheduler/src/python/form_scheduler_app/form_scheduler_queue.py
+++ b/gear/form_scheduler/src/python/form_scheduler_app/form_scheduler_queue.py
@@ -342,7 +342,7 @@ class FormSchedulerQueue:
         gear_input_info = pipeline.starting_gear.get_inputs_by_file_locator_type(
             locators=['fixed', 'matched', 'module'])
 
-        gear_inputs = {}
+        gear_inputs: Dict[str, FileEntry] = {}
 
         # set gear inputs of file locator type fixed
         # these are the project level files with fixed filename specified in the configs

--- a/gear/form_scheduler/src/python/form_scheduler_app/form_scheduler_queue.py
+++ b/gear/form_scheduler/src/python/form_scheduler_app/form_scheduler_queue.py
@@ -424,12 +424,15 @@ class FormSchedulerQueue:
                     f"Triggering {pipeline.starting_gear.gear_name} for {file.name}"
                 )
 
+                destination = self.__proxy.get_container_by_id(
+                    file.parent_ref.id)  # type: ignore
                 trigger_gear(
                     proxy=self.__proxy,
                     gear_name=pipeline.starting_gear.gear_name,
                     log_args=False,
                     inputs=gear_inputs,
-                    config=pipeline.starting_gear.configs.model_dump())
+                    config=pipeline.starting_gear.configs.model_dump(),
+                    destination=destination)
 
                 # d. wait for the above submission pipeline to finish
                 JobPoll.wait_for_pipeline(self.__proxy, job_search)

--- a/gear/form_scheduler/src/python/form_scheduler_app/form_scheduler_queue.py
+++ b/gear/form_scheduler/src/python/form_scheduler_app/form_scheduler_queue.py
@@ -18,7 +18,7 @@ from gear_execution.gear_trigger import (
 from inputs.parameter_store import URLParameter
 from jobs.job_poll import JobPoll
 from notifications.email import EmailClient
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from form_scheduler_app.email_user import send_email
 
@@ -30,6 +30,7 @@ log = logging.getLogger(__name__)
 class PipelineQueue(BaseModel):
     """Class to represent a file queue for a given pipeline, with subqueues
     defined for each module accepted for the pipeline."""
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     index: int = -1
     name: str

--- a/gear/form_scheduler/src/python/form_scheduler_app/main.py
+++ b/gear/form_scheduler/src/python/form_scheduler_app/main.py
@@ -57,16 +57,17 @@ def run(*,
                                email_client=email_client,
                                portal_url=portal_url)
 
-    total_files = -1
-    while total_files != 0:
+    num_files = -1
+    while num_files != 0:
         # force a project reload with each outer loop
         project = project.reload()
 
+        num_files = 0  # reset counter for next iteration
         # Pull and queue the tagged files for each pipeline
         # Pipelines are processed in order they are specified in the configs file
         for pipeline in pipeline_configs.pipelines:
-            total_files += queue.queue_files_for_pipeline(project=project,
-                                                          pipeline=pipeline)
+            num_files += queue.queue_files_for_pipeline(project=project,
+                                                        pipeline=pipeline)
 
         # Process the subqueues for each pipeline until all pipeline queues are empty
         queue.process_pipeline_queues()

--- a/gear/form_scheduler/src/python/form_scheduler_app/main.py
+++ b/gear/form_scheduler/src/python/form_scheduler_app/main.py
@@ -1,30 +1,30 @@
 """Defines the Form Scheduler.
 
-1. Pulls the current list of project files with the specified
-   queue tags and adds them to processing queues for each module
-   sorted by file timestamp
-2. Process the queues in a round robin
-    a. Check whether there are any submission pipelines running/pending;
+1. Pull and queue the tagged files for each pipeline by module sorted by file timestamp
+2. Pipelines are processed in the order they are listed in the pipeline configs file
+   For each pipeline, process the module subqueues
+3. Modules are processed in the order they are listed in pipeline configs
+   Move to next module subqueue,
+    a. Check whether there are any pipeline gears running/pending;
        if so, wait for them to finish
-    b. Pull the next CSV from the queue and clear queue tags
-    c. Trigger the submission pipeline
-    d. Wait for the triggered submission pipeline to finish
+    b. Pull the next file from the subqueue and clear queue tags
+    c. Trigger the starting gear for the pipeline on the pulled file
+    d. Wait for the triggered pipeline to finish
     e. Send email to user that the submission pipeline is complete
-    f. Move to next queue
-3. Repeat 2) until all queues are empty
-4. Repeat from the beginning until there are no more files to be queued
+    f. Repeat 3a - 3e until current subqueue is empty
+   Repeat 3a - 3e until all subqueues are empty for the current pipeline
+4. Move to next pipeline, and repeat 3)
+5. Repeat from the beginning until there are no more files to be queued
 """
 import logging
-from typing import List, Optional
+from typing import Optional
 
+from configs.ingest_configs import PipelineConfigs
 from flywheel_adaptor.flywheel_proxy import FlywheelProxy
 from gear_execution.gear_execution import GearExecutionError
-from gear_execution.gear_trigger import trigger_gear
 from inputs.parameter_store import URLParameter
-from jobs.job_poll import JobPoll
 from notifications.email import EmailClient
 
-from .email_user import send_email
 from .form_scheduler_queue import FormSchedulerQueue
 
 log = logging.getLogger(__name__)
@@ -32,9 +32,8 @@ log = logging.getLogger(__name__)
 
 def run(*,
         proxy: FlywheelProxy,
-        queue: FormSchedulerQueue,
         project_id: str,
-        submission_pipeline: List[str],
+        pipeline_configs: PipelineConfigs,
         email_client: Optional[EmailClient] = None,
         portal_url: Optional[URLParameter] = None):
     """Runs the Form Scheduler process.
@@ -43,95 +42,35 @@ def run(*,
         proxy: the proxy for the Flywheel instance
         queue: The FormSchedulerQueue which handles the queues
         project_id: The project ID
-        submission_pipeline: List of gear names representing the submission
-            pipeline
+        pipeline_configs: Form pipeline configurations
         email_client: EmailClient to send emails from
         portal_url: The portal URL
     """
+
     project = proxy.get_project_by_id(project_id)
     if not project:
         raise GearExecutionError(f"Cannot find project with ID {project_id}")
 
-    # search string to use for looking for running submission pipelines
-    search_str = JobPoll.generate_search_string(
-        project_ids_list=[project_id],
-        gears_list=submission_pipeline,
-        states_list=['running', 'pending'])
-    log.info("Starting Form Scheduler queue")
+    queue = FormSchedulerQueue(proxy=proxy,
+                               project=project,
+                               pipeline_configs=pipeline_configs,
+                               email_client=email_client,
+                               portal_url=portal_url)
 
-    # 1. Pull the current list of files
-    num_files = -1
-    while num_files != 0:
+    total_files = -1
+    while total_files != 0:
         # force a project reload with each outer loop
         project = project.reload()
-        num_files = queue.add_files(project)
-        log.info(f"Pulled {num_files} queued files, beginning queue process")
 
-        # 2. Process queue in round robin
-        while not queue.empty():
-            # grab the next subqueue with files in it in the round robin
-            module, subqueue = queue.next_queue()
-            if not subqueue:
-                continue
+        # Pull and queue the tagged files for each pipeline
+        # Pipelines are processed in order they are specified in the configs file
+        for pipeline in pipeline_configs.pipelines:
+            total_files += queue.queue_files_for_pipeline(project=project,
+                                                          pipeline=pipeline)
 
-            # a. Check if any submission pipelines are already running for
-            #    this project. If one is found, wait for it to finish before continuing.
-            #    This should actually not happen as it would mean that this gear
-            #    instance is not the owner/trigger of this submission pipeline,
-            #    but left in as a safeguard
-            JobPoll.wait_for_pipeline(proxy, search_str)
+        # Process the subqueues for each pipeline until all pipeline queues are empty
+        queue.process_pipeline_queues()
 
-            log.info(f"Start processing {module} queue.")
-
-            validation_schema = project.get_file(f'{module}-schema.json')
-            if not validation_schema:
-                raise GearExecutionError(
-                    f"Missing validation schema for {module}")
-
-            while len(subqueue) > 0:
-                # b. Pull the next CSV from queue and clear the queue tags
-                file = subqueue.pop(0)
-                for tag in queue.queue_tags:
-                    file.delete_tag(tag)
-
-                # need to reload else the next gear may add the same queue tags back in
-                # causing an infinite loop
-                file = file.reload()
-
-                # c. Trigger the submission pipeline.
-                # Here's where it isn't actually parameterized - we assume that
-                # the first gear is the file-validator regardless, and passes
-                # the corresponding inputs + uses the default configuration
-                # If the first gear changes and has different inputs/needs updated
-                # configurations, this may break as a result and will need to be updated
-                # Should we check that the first gear is always the file-validator?
-
-                log.info(
-                    f"Kicking off {submission_pipeline[0]} for {file.name}, " +
-                    f"module {module}")
-
-                inputs = {
-                    "input_file": file,
-                    "validation_schema": validation_schema
-                }
-                trigger_gear(proxy=proxy,
-                             gear_name=submission_pipeline[0],
-                             inputs=inputs)
-
-                # d. wait for the above submission pipeline to finish
-                JobPoll.wait_for_pipeline(proxy, search_str)
-
-                # e. send email to user who uploaded the file that their
-                #    submission pipeline has completed
-                if email_client:
-                    send_email(proxy=proxy,
-                               email_client=email_client,
-                               file=file,
-                               project=project,
-                               portal_url=portal_url)  # type: ignore
-
-        # 3. repeat until all queues empty
-
-    # 4. Repeat from beginning (pulling files) until no more files are found
+        # Repeat from beginning (pulling files) until no more matching files are found
 
     log.info("No more queued files to process, exiting Form Scheduler gear")

--- a/gear/form_scheduler/src/python/form_scheduler_app/run.py
+++ b/gear/form_scheduler/src/python/form_scheduler_app/run.py
@@ -1,7 +1,8 @@
 """Entry script for form_scheduler."""
 import logging
-from typing import Any, List, Optional
+from typing import Any, Optional
 
+from configs.ingest_configs import PipelineConfigs
 from flywheel.rest import ApiException
 from flywheel_gear_toolkit import GearToolkitContext
 from gear_execution.gear_execution import (
@@ -10,18 +11,39 @@ from gear_execution.gear_execution import (
     GearEngine,
     GearExecutionEnvironment,
     GearExecutionError,
+    InputFileWrapper,
 )
 from inputs.parameter_store import (
     ParameterError,
     ParameterStore,
     URLParameter,
 )
+from jobs.job_poll import JobPoll
 from notifications.email import EmailClient, create_ses_client
-from utils.utils import parse_string_to_list
+from pydantic import ValidationError
 
-from form_scheduler_app.main import FormSchedulerQueue, run
+from form_scheduler_app.main import run
 
 log = logging.getLogger(__name__)
+
+
+def load_form_pipeline_configurations(
+        config_file_path: str) -> PipelineConfigs:
+    """Load the form pipeline configs from the pipeline configs file.
+
+    Args:
+      config_file_path: the form module configs file path
+
+    Returns:
+      PipelineConfigs
+
+    Raises:
+      ValidationError if failed to load the configs file
+    """
+
+    with open(config_file_path, mode='r',
+              encoding='utf-8-sig') as configs_file:
+        return PipelineConfigs.model_validate_json(configs_file.read())
 
 
 class FormSchedulerVisitor(GearExecutionEnvironment):
@@ -29,16 +51,12 @@ class FormSchedulerVisitor(GearExecutionEnvironment):
 
     def __init__(self,
                  client: ClientWrapper,
-                 queue_tags: List[str],
-                 submission_pipeline: List[str],
-                 module_order: List[str],
+                 pipeline_configs_input: InputFileWrapper,
                  source_email: Optional[str] = None,
                  portal_url: Optional[URLParameter] = None):
         super().__init__(client=client)
 
-        self.__submission_pipeline = submission_pipeline
-        self.__module_order = module_order
-        self.__queue_tags = queue_tags
+        self.__configs_input = pipeline_configs_input
         self.__source_email = source_email
         self.__portal_url = portal_url
 
@@ -61,13 +79,10 @@ class FormSchedulerVisitor(GearExecutionEnvironment):
         client = GearBotClient.create(context=context,
                                       parameter_store=parameter_store)
 
-        submission_pipeline = parse_string_to_list(
-            context.config.get('submission_pipeline', None))
-        accepted_modules = parse_string_to_list(
-            context.config.get('accepted_modules', None))
-        queue_tags = parse_string_to_list(context.config.get(
-            'queue_tags', None),
-                                          to_lower=False)
+        pipeline_configs_input = InputFileWrapper.create(
+            input_name='pipeline_configs_file', context=context)
+        assert pipeline_configs_input, "missing expected input, pipeline_configs_file"
+
         source_email = context.config.get('source_email', 'nacchelp@uw.edu')
 
         portal_url = None
@@ -83,24 +98,11 @@ class FormSchedulerVisitor(GearExecutionEnvironment):
                 raise GearExecutionError(
                     f'Parameter error: {error}') from error
 
-        if not submission_pipeline:
-            raise GearExecutionError("No submission pipeline provided")
-        if not accepted_modules:
-            raise GearExecutionError("No accepted modules provided")
-        if not queue_tags:
-            raise GearExecutionError("No queue tags to search for provided")
-
-        if submission_pipeline[0] != 'file-validator':
-            raise GearExecutionError(
-                "First gear in submission pipeline must be " +
-                "the file validator")
-
-        return FormSchedulerVisitor(client=client,
-                                    submission_pipeline=submission_pipeline,
-                                    module_order=accepted_modules,
-                                    queue_tags=queue_tags,
-                                    source_email=source_email,
-                                    portal_url=portal_url)
+        return FormSchedulerVisitor(
+            client=client,
+            pipeline_configs_input=pipeline_configs_input,
+            source_email=source_email,
+            portal_url=portal_url)
 
     def run(self, context: GearToolkitContext) -> None:
         """Runs the Form Scheduler app."""
@@ -110,21 +112,40 @@ class FormSchedulerVisitor(GearExecutionEnvironment):
             raise GearExecutionError(
                 f'Cannot find destination container: {error}') from error
 
-        if not dest_container.container_type == 'project':
-            raise GearExecutionError("Destination container must be a project")
+        if dest_container.container_type == 'project':
+            project_id = dest_container.id
+        elif dest_container.container_type == 'acquisition':
+            project_id = dest_container.parents['project']
+        else:
+            raise GearExecutionError(
+                f"Unsupported container type {dest_container.container_type}")
+
+        gear_name = context.manifest.get('name', 'form-scheduler')
+        search_str = JobPoll.generate_search_string(
+            project_ids_list=[project_id],
+            gears_list=[gear_name],
+            states_list=['running', 'pending'])
+
+        if self.proxy.find_job(search_str):
+            log.info("Form Scheduler gear already running, exiting")
+            return
+
+        try:
+            pipeline_configs = load_form_pipeline_configurations(
+                self.__configs_input.filepath)
+        except ValidationError as error:
+            raise GearExecutionError(
+                'Error reading pipeline configurations file'
+                f'{self.__configs_input.filename}: {error}') from error
 
         # if source email specified, set up client to send emails
         email_client = EmailClient(client=create_ses_client(),
                                    source=self.__source_email) \
             if self.__source_email else None
 
-        queue = FormSchedulerQueue(module_order=self.__module_order,
-                                   queue_tags=self.__queue_tags)
-
         run(proxy=self.proxy,
-            queue=queue,
-            project_id=dest_container.id,
-            submission_pipeline=self.__submission_pipeline,
+            project_id=project_id,
+            pipeline_configs=pipeline_configs,
             email_client=email_client,
             portal_url=self.__portal_url)
 

--- a/gear/form_scheduler/src/python/form_scheduler_app/run.py
+++ b/gear/form_scheduler/src/python/form_scheduler_app/run.py
@@ -2,9 +2,8 @@
 import logging
 from typing import Any, Optional
 
-from configs.ingest_configs import PipelineConfigs
+from configs.ingest_configs import ConfigsError, PipelineConfigs
 from flywheel.rest import ApiException
-from flywheel_adaptor.flywheel_proxy import FlywheelProxy
 from flywheel_gear_toolkit import GearToolkitContext
 from gear_execution.gear_execution import (
     ClientWrapper,
@@ -21,55 +20,10 @@ from inputs.parameter_store import (
 )
 from jobs.job_poll import JobPoll
 from notifications.email import EmailClient, create_ses_client
-from pydantic import ValidationError
 
 from form_scheduler_app.main import run
 
 log = logging.getLogger(__name__)
-
-
-def load_form_pipeline_configurations(
-        config_file_path: str) -> PipelineConfigs:
-    """Load the form pipeline configs from the pipeline configs file.
-
-    Args:
-      config_file_path: the form module configs file path
-
-    Returns:
-      PipelineConfigs
-
-    Raises:
-      ValidationError if failed to load the configs file
-    """
-
-    with open(config_file_path, mode='r',
-              encoding='utf-8-sig') as configs_file:
-        return PipelineConfigs.model_validate_json(configs_file.read())
-
-
-def is_another_gear_instance_running(proxy: FlywheelProxy, gear_name: str,
-                                     project_id: str,
-                                     current_job: str) -> bool:
-    """Find whether another instance of the specified gear is running
-    Args:
-        proxy: the proxy for the Flywheel instance
-        gear_name: gear name to check
-        project_id: FLywheel project to check
-        current_job: current job id
-
-    Returns:
-        bool: True if another job found, else False
-    """
-    search_str = JobPoll.generate_search_string(
-        project_ids_list=[project_id],
-        gears_list=[gear_name],
-        states_list=['running', 'pending'])
-
-    matched_jobs = proxy.find_jobs(search_str)
-    if len(matched_jobs) > 1:
-        return True
-
-    return (current_job != matched_jobs[0].id)
 
 
 class FormSchedulerVisitor(GearExecutionEnvironment):
@@ -149,17 +103,17 @@ class FormSchedulerVisitor(GearExecutionEnvironment):
         # there shouldn't be any
         gear_name = context.manifest.get('name', 'form-scheduler')
         job_id = context.config_json.get('job', {}).get('id')
-        if is_another_gear_instance_running(proxy=self.proxy,
-                                            gear_name=gear_name,
-                                            project_id=project_id,
-                                            current_job=job_id):
+        if JobPoll.is_another_gear_instance_running(proxy=self.proxy,
+                                                    gear_name=gear_name,
+                                                    project_id=project_id,
+                                                    current_job=job_id):
             raise GearExecutionError(
                 "Another Form Scheduler gear already running on this project")
 
         try:
-            pipeline_configs = load_form_pipeline_configurations(
+            pipeline_configs = PipelineConfigs.load_form_pipeline_configurations(
                 self.__configs_input.filepath)
-        except ValidationError as error:
+        except ConfigsError as error:
             raise GearExecutionError(
                 'Error reading pipeline configurations file'
                 f'{self.__configs_input.filename}: {error}') from error

--- a/gear/form_scheduler/src/python/form_scheduler_app/run.py
+++ b/gear/form_scheduler/src/python/form_scheduler_app/run.py
@@ -138,13 +138,12 @@ class FormSchedulerVisitor(GearExecutionEnvironment):
             raise GearExecutionError(
                 f'Cannot find destination container: {error}') from error
 
-        if dest_container.container_type == 'project':
-            project_id = dest_container.id
-        elif dest_container.container_type == 'acquisition':
-            project_id = dest_container.parents['project']
-        else:
+        if dest_container.container_type != 'project':
             raise GearExecutionError(
-                f"Unsupported container type {dest_container.container_type}")
+                f"Unsupported container type {dest_container.container_type}, "
+                f"this gear must be executed at project level")
+
+        project_id = dest_container.id
 
         # check for other form-scheduler gear jobs running on this project
         # there shouldn't be any

--- a/gear/form_scheduler/test/python/BUILD
+++ b/gear/form_scheduler/test/python/BUILD
@@ -1,0 +1,3 @@
+python_tests(name="tests", dependencies=[":test_data"])
+
+files(name="test_data", sources=["data/*.json"])

--- a/gear/form_scheduler/test/python/data/invalid-pipeline-configs.json
+++ b/gear/form_scheduler/test/python/data/invalid-pipeline-configs.json
@@ -1,0 +1,40 @@
+{
+    "gears": [
+        "gear_one",
+        "gear_two"
+    ],
+    "pipelines": [
+        {
+            "name": "unknown",
+            "modules": [
+                "module1",
+                "module2",
+                "module3"
+            ],
+            "tags": [
+                "unknown-tag"
+            ],
+            "extensions": [
+                ".csv"
+            ],
+            "starting_gear": {
+                "gear_name": "gear_one",
+                "inputs": [
+                    {
+                        "label": "input_file1",
+                        "file_locator": "matched"
+                    },
+                    {
+                        "label": "input_file2",
+                        "file_locator": "module",
+                        "file_name": "${module}-schema.json"
+                    }
+                ],
+                "configs": {
+                    "debug": false
+                }
+            },
+            "notify_user": true
+        }
+    ]
+}

--- a/gear/form_scheduler/test/python/data/valid-pipeline-configs.json
+++ b/gear/form_scheduler/test/python/data/valid-pipeline-configs.json
@@ -1,0 +1,41 @@
+{
+    "gears": [
+        "gear_one",
+        "gear_two"
+    ],
+    "pipelines": [
+        {
+            "name": "submission",
+            "modules": [
+                "module1",
+                "module2",
+                "module3"
+            ],
+            "tags": [
+                "submission-tag"
+            ],
+            "extensions": [
+                ".csv"
+            ],
+            "starting_gear": {
+                "gear_name": "gear_one",
+                "inputs": [
+                    {
+                        "label": "input_file1",
+                        "file_locator": "matched"
+                    },
+                    {
+                        "label": "input_file2",
+                        "file_locator": "module",
+                        "file_name": "${module}-schema.json"
+                    }
+                ],
+                "configs": {
+                    "config1": "value1",
+                    "config2": 10
+                }
+            },
+            "notify_user": true
+        }
+    ]
+}

--- a/gear/form_scheduler/test/python/data/valid-pipeline-with-empty-configs.json
+++ b/gear/form_scheduler/test/python/data/valid-pipeline-with-empty-configs.json
@@ -1,0 +1,27 @@
+{
+    "gears": [
+        "gear_one",
+        "gear_two"
+    ],
+    "pipelines": [
+        {
+            "name": "submission",
+            "modules": [
+                "module1",
+                "module2",
+                "module3"
+            ],
+            "tags": [
+                "submission-tag"
+            ],
+            "extensions": [
+                ".csv"
+            ],
+            "starting_gear": {
+                "gear_name": "gear_one",
+                "configs": {}
+            },
+            "notify_user": true
+        }
+    ]
+}

--- a/gear/form_scheduler/test/python/test_pipeline_configs.py
+++ b/gear/form_scheduler/test/python/test_pipeline_configs.py
@@ -31,7 +31,7 @@ class TestPipelineConfigs:
                 'valid-pipeline-with-empty-configs.json')) is not None
 
         # assert PipelineConfigs
-        pipeline_configs: PipelineConfigs = PipelineConfigs.load_form_pipeline_configurations(
+        pipeline_configs = PipelineConfigs.load_form_pipeline_configurations(
             str(TEST_FILES_DIR / 'valid-pipeline-configs.json'))
 
         assert pipeline_configs is not None

--- a/gear/form_scheduler/test/python/test_pipeline_configs.py
+++ b/gear/form_scheduler/test/python/test_pipeline_configs.py
@@ -3,10 +3,8 @@
 from pathlib import Path
 from typing import Any, Dict
 
-from configs.ingest_configs import PipelineConfigs
+from configs.ingest_configs import ConfigsError, PipelineConfigs
 from form_scheduler_app.form_scheduler_queue import PipelineQueue
-from form_scheduler_app.run import load_form_pipeline_configurations
-from pydantic import ValidationError
 
 TEST_FILES_DIR = Path(__file__).parent.resolve() / 'data'
 
@@ -19,21 +17,21 @@ class TestPipelineConfigs:
 
         # assert that config with invalid input raises ValidationError
         try:
-            load_form_pipeline_configurations(
+            PipelineConfigs.load_form_pipeline_configurations(
                 str(TEST_FILES_DIR / 'invalid-pipeline-configs.json'))
-        except ValidationError as error:
+        except ConfigsError as error:
             assert str(error).find('validation error') != -1
 
     def test_valid_config(self):
         """Test a valid configurations file."""
 
         # assert Pipeline with no inputs and empty gear configs
-        assert load_form_pipeline_configurations(
+        assert PipelineConfigs.load_form_pipeline_configurations(
             str(TEST_FILES_DIR /
                 'valid-pipeline-with-empty-configs.json')) is not None
 
         # assert PipelineConfigs
-        pipeline_configs: PipelineConfigs = load_form_pipeline_configurations(
+        pipeline_configs: PipelineConfigs = PipelineConfigs.load_form_pipeline_configurations(
             str(TEST_FILES_DIR / 'valid-pipeline-configs.json'))
 
         assert pipeline_configs is not None

--- a/gear/form_scheduler/test/python/test_pipeline_configs.py
+++ b/gear/form_scheduler/test/python/test_pipeline_configs.py
@@ -1,0 +1,87 @@
+"""Tests the PipelineConfigs and PipelineQueue pydantic classes."""
+
+from pathlib import Path
+from typing import Any, Dict
+
+from configs.ingest_configs import PipelineConfigs
+from form_scheduler_app.form_scheduler_queue import PipelineQueue
+from form_scheduler_app.run import load_form_pipeline_configurations
+from pydantic import ValidationError
+
+TEST_FILES_DIR = Path(__file__).parent.resolve() / 'data'
+
+
+class TestPipelineConfigs:
+    """Tests the PipelineConfigs and PipelineQueue pydantic classes."""
+
+    def test_invalid_config(self):
+        """Test an invalid configurations file."""
+
+        # assert that config with invalid input raises ValidationError
+        try:
+            load_form_pipeline_configurations(
+                str(TEST_FILES_DIR / 'invalid-pipeline-configs.json'))
+        except ValidationError as error:
+            assert str(error).find('validation error') != -1
+
+    def test_valid_config(self):
+        """Test a valid configurations file."""
+
+        # assert Pipeline with no inputs and empty gear configs
+        pipeline_configs: PipelineConfigs = load_form_pipeline_configurations(
+            str(TEST_FILES_DIR / 'valid-pipeline-with-empty-configs.json'))
+        assert pipeline_configs is not None
+
+        # assert PipelineConfigs
+        pipeline_configs: PipelineConfigs = load_form_pipeline_configurations(
+            str(TEST_FILES_DIR / 'valid-pipeline-configs.json'))
+
+        assert pipeline_configs is not None
+
+        configs: Dict[str, Any] = {
+            "gears": ["gear_one", "gear_two"],
+            "pipelines": [{
+                "name": "submission",
+                "modules": ["module1", "module2", "module3"],
+                "tags": ["submission-tag"],
+                "extensions": [".csv"],
+                "starting_gear": {
+                    "gear_name":
+                    "gear_one",
+                    "inputs": [{
+                        "label": "input_file1",
+                        "file_locator": "matched",
+                        "file_name": None
+                    }, {
+                        "label": "input_file2",
+                        "file_locator": "module",
+                        "file_name": "${module}-schema.json"
+                    }],
+                    "configs": {
+                        "config1": "value1",
+                        "config2": 10
+                    }
+                },
+                "notify_user": True
+            }]
+        }
+
+        assert pipeline_configs.model_dump() == configs
+
+        pipeline_queue = PipelineQueue.create_from_pipeline(
+            pipeline_configs.pipelines[0])
+
+        assert pipeline_queue is not None
+
+        pipeline = {
+            "index": -1,
+            "name": "submission",
+            "modules": ["module1", "module2", "module3"],
+            "tags": ["submission-tag"],
+            "subqueues": {
+                "module1": [],
+                "module2": [],
+                "module3": []
+            }
+        }
+        assert pipeline_queue.model_dump() == pipeline

--- a/gear/form_scheduler/test/python/test_pipeline_configs.py
+++ b/gear/form_scheduler/test/python/test_pipeline_configs.py
@@ -28,9 +28,9 @@ class TestPipelineConfigs:
         """Test a valid configurations file."""
 
         # assert Pipeline with no inputs and empty gear configs
-        pipeline_configs: PipelineConfigs = load_form_pipeline_configurations(
-            str(TEST_FILES_DIR / 'valid-pipeline-with-empty-configs.json'))
-        assert pipeline_configs is not None
+        assert load_form_pipeline_configurations(
+            str(TEST_FILES_DIR /
+                'valid-pipeline-with-empty-configs.json')) is not None
 
         # assert PipelineConfigs
         pipeline_configs: PipelineConfigs = load_form_pipeline_configurations(

--- a/gear/form_screening/src/data/form-scheduler-configs.json
+++ b/gear/form_screening/src/data/form-scheduler-configs.json
@@ -1,9 +1,6 @@
 {
     "gear_name": "form-scheduler",
     "configs": {
-        "submission_pipeline": "file-validator,identifier-lookup,form-transformer,form-qc-coordinator,form-qc-checker",
-        "accepted_modules": "UDS,ENROLL,FTLD,LBD",
-        "queue_tags": "queued",
         "source_email": "no-reply@naccdata.org",
         "portal_url_path": "/sandbox/flywheel/portal",
         "apikey_path_prefix": "/sandbox/flywheel/gearbot"

--- a/gear/form_screening/src/docker/BUILD
+++ b/gear/form_screening/src/docker/BUILD
@@ -6,4 +6,4 @@ docker_image(name="form-screening",
                  ":manifest",
                  "gear/form_screening/src/python/form_screening_app:bin"
              ],
-             image_tags=["1.1.2", "latest"])
+             image_tags=["1.1.3", "latest"])

--- a/gear/form_screening/src/docker/BUILD
+++ b/gear/form_screening/src/docker/BUILD
@@ -6,4 +6,4 @@ docker_image(name="form-screening",
                  ":manifest",
                  "gear/form_screening/src/python/form_screening_app:bin"
              ],
-             image_tags=["1.1.3", "latest"])
+             image_tags=["1.2.0", "latest"])

--- a/gear/form_screening/src/docker/manifest.json
+++ b/gear/form_screening/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "form-screening",
     "label": "Form Screening",
     "description": "Screens input files and queue for the form-scheduler gear",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/form-screening:1.1.2"
+            "image": "naccdata/form-screening:1.1.3"
         },
         "flywheel": {
             "suite": "NACC Admin Gears",
@@ -27,11 +27,12 @@
             "base": "api-key"
         },
         "input_file": {
-            "description": "The input file",
+            "description": "The input file to screen",
             "base": "file",
             "type": {
                 "enum": [
-                    "tabular data"
+                    "tabular data",
+                    "source code"
                 ]
             }
         },
@@ -56,10 +57,14 @@
             "type": "string",
             "default": "UDS,FTLD,LBD"
         },
-        "queue_tags": {
-            "description": "Comma-delimited list of queue tags to add",
+        "file_tags": {
+            "description": "Comma-delimited list of tags to add to the file or check whether already tagged",
             "type": "string",
             "default": "queued"
+        },
+        "format_and_tag": {
+            "description": "Whether to format the input file and add file_tags",
+            "type": "boolean"
         },
         "apikey_path_prefix": {
             "description": "The instance specific AWS parameter path prefix for apikey",

--- a/gear/form_screening/src/docker/manifest.json
+++ b/gear/form_screening/src/docker/manifest.json
@@ -54,7 +54,7 @@
         "accepted_modules": {
             "description": "Comma-delimited list of accepted modules",
             "type": "string",
-            "default": "ENROLL,UDS,FTLD,LBD"
+            "default": "UDS,FTLD,LBD"
         },
         "queue_tags": {
             "description": "Comma-delimited list of queue tags to add",

--- a/gear/form_screening/src/docker/manifest.json
+++ b/gear/form_screening/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "form-screening",
     "label": "Form Screening",
     "description": "Screens input files and queue for the form-scheduler gear",
-    "version": "1.1.3",
+    "version": "1.2.0",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/form-screening:1.1.3"
+            "image": "naccdata/form-screening:1.2.0"
         },
         "flywheel": {
             "suite": "NACC Admin Gears",

--- a/gear/form_screening/src/python/form_screening_app/main.py
+++ b/gear/form_screening/src/python/form_screening_app/main.py
@@ -10,7 +10,7 @@ from flywheel_adaptor.flywheel_proxy import FlywheelProxy
 from flywheel_gear_toolkit import GearToolkitContext
 from gear_execution.gear_execution import InputFileWrapper
 from gear_execution.gear_trigger import (
-    GearConfigs,
+    CredentialGearConfigs,
     GearInfo,
     set_gear_inputs,
     trigger_gear,
@@ -25,7 +25,7 @@ from form_screening_app.format import CSVFormatterVisitor
 log = logging.getLogger(__name__)
 
 
-class FormSchedulerGearConfigs(GearConfigs):
+class FormSchedulerGearConfigs(CredentialGearConfigs):
     """Form Scheduler-specific gear configs."""
     source_email: str
     portal_url_path: str

--- a/gear/form_screening/src/python/form_screening_app/main.py
+++ b/gear/form_screening/src/python/form_screening_app/main.py
@@ -27,9 +27,6 @@ log = logging.getLogger(__name__)
 
 class FormSchedulerGearConfigs(GearConfigs):
     """Form Scheduler-specific gear configs."""
-    submission_pipeline: str
-    accepted_modules: str
-    queue_tags: str
     source_email: str
     portal_url_path: str
 

--- a/gear/form_screening/src/python/form_screening_app/main.py
+++ b/gear/form_screening/src/python/form_screening_app/main.py
@@ -169,7 +169,7 @@ def run(*, proxy: FlywheelProxy, context: GearToolkitContext,
         trigger_scheduler_gear(proxy=proxy,
                                project=project,
                                scheduler_gear=scheduler_gear)
-        return
+        return None
 
     file_type = file_input.validate_file_extension(accepted_extensions=["csv"])
     if not file_type:

--- a/gear/form_screening/src/python/form_screening_app/main.py
+++ b/gear/form_screening/src/python/form_screening_app/main.py
@@ -8,7 +8,7 @@ from flywheel import Project
 from flywheel.models.file_entry import FileEntry
 from flywheel_adaptor.flywheel_proxy import FlywheelProxy
 from flywheel_gear_toolkit import GearToolkitContext
-from gear_execution.gear_execution import InputFileWrapper
+from gear_execution.gear_execution import GearExecutionError, InputFileWrapper
 from gear_execution.gear_trigger import (
     CredentialGearConfigs,
     GearInfo,
@@ -92,39 +92,98 @@ def get_scheduler_gear_inputs(scheduler_gear: GearInfo,
     return gear_inputs
 
 
-def run(*, proxy: FlywheelProxy, context: GearToolkitContext,
-        file_input: InputFileWrapper, accepted_modules: List[str],
-        queue_tags: List[str],
-        scheduler_gear: GearInfo) -> Optional[ListErrorWriter]:
-    """Runs the form screening process. Checks that the file suffix matches any
-    accepted modules; if so, tags the file with the specified tags, and run the
-    form-scheduler gear if it's not already running. If the suffix does not
-    match, report an error.
-
-    Also formats the input CSV:
-    removes any REDCap specific ID columns,
-    converts column headers to lowercase,
-    removes BOM characters and saves the file in UTF-8.
+def trigger_scheduler_gear(*, proxy: FlywheelProxy, project: Project,
+                           scheduler_gear: GearInfo):
+    """Trigger the form-scheduler gear if it's not already running on the given
+    project.
 
     Args:
         proxy: the proxy for the Flywheel instance
-        file_input: The InputFileWrapper representing the file to
+        project: Flywheel project container
+        scheduler_gear: form-scheduler gear info
+    """
+    # check if the scheduler gear is pending/running
+    log.info(f"Checking status of {scheduler_gear.gear_name}")
+
+    search_str = JobPoll.generate_search_string(
+        project_ids_list=[project.id],
+        gears_list=[scheduler_gear.gear_name],
+        states_list=['running', 'pending'])
+
+    if proxy.find_job(search_str):
+        log.info(f"{scheduler_gear.gear_name} gear already running, exiting")
+        return None
+
+    # otherwise invoke the gear
+    log.info(f"No {scheduler_gear.gear_name} gears running, triggering")
+    trigger_gear(proxy=proxy,
+                 gear_name=scheduler_gear.gear_name,
+                 config=scheduler_gear.configs.model_dump(),
+                 inputs=get_scheduler_gear_inputs(
+                     scheduler_gear=scheduler_gear, project=project),
+                 destination=project)
+
+
+def run(*, proxy: FlywheelProxy, context: GearToolkitContext,
+        file_input: InputFileWrapper, accepted_modules: List[str],
+        queue_tags: List[str], scheduler_gear: GearInfo,
+        format_and_tag: bool) -> Optional[ListErrorWriter]:
+    """Runs the form screening process. Checks that the file suffix matches any
+    accepted modules, if the suffix does not match, report an error.
+        If format_and_tag=True (only supported for CSVs):
+            formats the input file:
+                removes any REDCap specific ID columns,
+                converts column headers to lowercase,
+                removes BOM characters and saves the file in UTF-8.
+            tags the file with the specified queue_tags
+        Else:
+            check whether the input file is already tagged with one or more queue_tags
+
+        If the conditions met, trigger form-scheduler gear if it's not already running.
+
+    Args:
+        proxy: the proxy for the Flywheel instance
+        file_input: the InputFileWrapper representing the file to
             potentially queue
-        accepted_modules: List of accepted modules (case-insensitive)
-        queue_tags: List of tags to add if the file passes prescreening
+        accepted_modules: list of accepted modules (case-insensitive)
+        queue_tags: list of tags to add to the file or check whether already tagged
         scheduler_gear: GearInfo of the scheduler gear to trigger
+        format_and_tag: if True format input file and add queue_tags,
+                        else check whether the file is already tagged with queue_tags
 
     Returns:
         ListErrorWriter(optional): If file didn't pass screening checks
     """
-    module = file_input.basename.split('-')[-1]
 
     file = proxy.get_file(file_input.file_id)
+    project = file_input.get_parent_project(proxy=proxy, file=file)
+
+    if not format_and_tag:
+        # check whether the input file has pipeline trigger tag(s)
+        if not (set(file.tags) & set(queue_tags)):
+            raise GearExecutionError(
+                f"Input file tags {file.tags} does not contain "
+                f"the expected pipeline trigger tags {queue_tags}")
+
+        # if matching tags present start form-scheduler gear if it's not already running
+        trigger_scheduler_gear(proxy=proxy,
+                               project=project,
+                               scheduler_gear=scheduler_gear)
+        return
+
+    file_type = file_input.validate_file_extension(accepted_extensions=["csv"])
+    if not file_type:
+        raise GearExecutionError(
+            f'Unsupported input file type {file_input.file_type}, expected CSV file'
+        )
+
+    module = file_input.basename.split('-')[-1]
     error_writer = ListErrorWriter(container_id=file_input.file_id,
                                    fw_path=proxy.get_lookup_path(file))
 
     if module.lower() not in accepted_modules:
-        log.error(f"Un-accepted module suffix: {module}")
+        log.error(
+            f"Module suffix {module} not in the list of accepted modules")
         error_writer.write(
             preprocessing_error(field=FieldNames.MODULE,
                                 value=module,
@@ -139,7 +198,6 @@ def run(*, proxy: FlywheelProxy, context: GearToolkitContext,
             queue_tags)
         return None
 
-    project = file_input.get_parent_project(proxy=proxy, file=file)
     out_stream = StringIO()
     formatter_visitor = CSVFormatterVisitor(output_stream=out_stream,
                                             error_writer=error_writer)
@@ -173,25 +231,7 @@ def run(*, proxy: FlywheelProxy, context: GearToolkitContext,
                 tags=queue_tags,
                 info=info)
 
-    # check if the scheduler gear is pending/running
-    log.info(f"Checking status of {scheduler_gear.gear_name}")
-
-    search_str = JobPoll.generate_search_string(
-        project_ids_list=[project.id],
-        gears_list=[scheduler_gear.gear_name],
-        states_list=['running', 'pending'])
-
-    if proxy.find_job(search_str):
-        log.info("Scheduler gear already running, exiting")
-        return None
-
-    # otherwise invoke the gear
-    log.info(f"No {scheduler_gear.gear_name} gears running, triggering")
-    trigger_gear(proxy=proxy,
-                 gear_name=scheduler_gear.gear_name,
-                 config=scheduler_gear.configs.model_dump(),
-                 inputs=get_scheduler_gear_inputs(
-                     scheduler_gear=scheduler_gear, project=project),
-                 destination=project)
-
+    trigger_scheduler_gear(proxy=proxy,
+                           project=project,
+                           scheduler_gear=scheduler_gear)
     return None

--- a/gear/form_transformer/src/docker/BUILD
+++ b/gear/form_transformer/src/docker/BUILD
@@ -6,4 +6,4 @@ docker_image(name="form-transformer",
                  ":manifest",
                  "gear/form_transformer/src/python/form_csv_app:bin"
              ],
-             image_tags=["1.4.0", "latest"])
+             image_tags=["1.4.1", "latest"])

--- a/gear/form_transformer/src/docker/manifest.json
+++ b/gear/form_transformer/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "form-transformer",
     "label": "Form CSV to JSON Transformer",
     "description": "Form specific transformation from CSV to JSON",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/form-transformer:1.4.0"
+            "image": "naccdata/form-transformer:1.4.1"
         },
         "flywheel": {
             "suite": "Curation",

--- a/gear/form_transformer/test/python/test_uds_transform.py
+++ b/gear/form_transformer/test/python/test_uds_transform.py
@@ -358,7 +358,3 @@ class TestUDSTransform:
         assert visitor.visit_row(record, 1)
 
         assert visitor.process_current_batch()
-
-
-# test = TestUDSTransform()
-# test.test_bad_transform()

--- a/gear/form_transformer/test/python/test_uds_transform.py
+++ b/gear/form_transformer/test/python/test_uds_transform.py
@@ -167,13 +167,17 @@ class TestUDSTransform:
     def test_mismatched_modules(self):
         """Test records in CSV belong to different modules."""
         visitor, project, _ = create_uds_visitor()
+
         record = create_record({'module': 'ftld'})
         assert not visitor.visit_row(record, 0)
+        qc = get_qc_errors(project)
+        assert len(qc) == 1
+
         record = create_record({'module': 'lbd'})
         assert not visitor.visit_row(record, 1)
-
         qc = get_qc_errors(project)
         assert len(qc) == 2
+
         assert qc[0]['code'] == 'unexpected-value'
         assert qc[0]['message'] == 'Expected UDS for field module'
         assert qc[0]['expected'] == 'UDS'
@@ -209,6 +213,8 @@ class TestUDSTransform:
             'bad3': 4
         })
         assert not visitor.visit_row(record, 0)
+        qc = get_qc_errors(project)
+        assert len(qc) == 1
 
         # will pass this
         record = create_record({'bad1': None, 'bad2': None, 'bad3': None})
@@ -352,3 +358,7 @@ class TestUDSTransform:
         assert visitor.visit_row(record, 1)
 
         assert visitor.process_current_batch()
+
+
+# test = TestUDSTransform()
+# test.test_bad_transform()

--- a/gear/identifier_lookup/src/docker/BUILD
+++ b/gear/identifier_lookup/src/docker/BUILD
@@ -6,5 +6,5 @@ docker_image(
     dependencies=[
         ":manifest", "gear/identifier_lookup/src/python/identifier_app:bin"
     ],
-    image_tags=["1.2.0", "latest"],
+    image_tags=["1.2.1", "latest"],
 )

--- a/gear/identifier_lookup/src/docker/manifest.json
+++ b/gear/identifier_lookup/src/docker/manifest.json
@@ -74,7 +74,7 @@
         "preserve_case": {
             "description": "Whether or not to preserve the case of the header keys in the input file",
             "type": "boolean",
-            "default": false
+            "default": true
         }
     },
     "command": "/bin/run"

--- a/gear/identifier_lookup/src/docker/manifest.json
+++ b/gear/identifier_lookup/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "identifier-lookup",
     "label": "Identifier Lookup",
     "description": "Gear to look up participant identifiers for incoming data",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/identifier-lookup:1.2.0"
+            "image": "naccdata/identifier-lookup:1.2.1"
         },
         "flywheel": {
             "suite": "NACC Data Gears",

--- a/gear/identifier_lookup/src/python/identifier_app/main.py
+++ b/gear/identifier_lookup/src/python/identifier_app/main.py
@@ -173,14 +173,14 @@ class NACCIDLookupVisitor(CSVVisitor):
             errorlog_template=errorlog_template)
 
         # This is first gear in pipeline validating individual rows
-        # therefore, clear metadata from previous runs `reset_metadata=True`
+        # therefore, clear metadata from previous runs `reset_qc_metadata=ALL`
         if not error_log_name or not update_error_log_and_qc_metadata(
                 error_log_name=error_log_name,
                 destination_prj=self.__project,
                 gear_name=self.__gear_name,
                 state='PASS' if qc_passed else 'FAIL',
                 errors=self.__error_writer.errors(),
-                reset_metadata=True):
+                reset_qc_metadata='ALL'):
             raise GearExecutionError(
                 'Failed to update error log for visit '
                 f'{input_record[FieldNames.PTID]}_{input_record[self.__module_configs.date_field]}'

--- a/gear/identifier_provisioning/src/docker/BUILD
+++ b/gear/identifier_provisioning/src/docker/BUILD
@@ -7,5 +7,5 @@ docker_image(
         ":manifest",
         "gear/identifier_provisioning/src/python/identifier_provisioning_app:bin",
     ],
-    image_tags=["1.2.4", "latest"],
+    image_tags=["1.2.5", "latest"],
 )

--- a/gear/identifier_provisioning/src/docker/manifest.json
+++ b/gear/identifier_provisioning/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "identifier-provisioning",
     "label": "Identifier Provisioning",
     "description": "Gear for provisioning NACCIDs from Enrollment forms",
-    "version": "1.2.4",
+    "version": "1.2.5",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",

--- a/gear/identifier_provisioning/src/docker/manifest.json
+++ b/gear/identifier_provisioning/src/docker/manifest.json
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/identifier-provisioning:1.2.4"
+            "image": "naccdata/identifier-provisioning:1.2.5"
         },
         "flywheel": {
             "suite": "NACC Admin Gears",

--- a/gear/identifier_provisioning/src/python/identifier_provisioning_app/main.py
+++ b/gear/identifier_provisioning/src/python/identifier_provisioning_app/main.py
@@ -422,10 +422,10 @@ class NewEnrollmentVisitor(CSVVisitor):
             self.__batch.add(
                 EnrollmentRecord(center_identifier=CenterIdentifiers(
                     adcid=row[FieldNames.ADCID], ptid=row[FieldNames.PTID]),
-                    guid=row.get(FieldNames.GUID)
-                    if row.get(FieldNames.GUID) else None,
-                    naccid=None,
-                    start_date=enroll_date))
+                                 guid=row.get(FieldNames.GUID)
+                                 if row.get(FieldNames.GUID) else None,
+                                 naccid=None,
+                                 start_date=enroll_date))
             return True
         except ValidationError as validation_error:
             for error in validation_error.errors():
@@ -590,9 +590,10 @@ def run(*, input_file: TextIO, center_id: int, repo: IdentifierRepository,
     for record in enrollment_batch:
         error_writer.clear()
         record_info = {
-            FieldNames.PTID: record.center_identifier.ptid,
-            FieldNames.ENRLFRM_DATE: record.start_date.strftime(
-                DEFAULT_DATE_FORMAT)
+            FieldNames.PTID:
+            record.center_identifier.ptid,
+            FieldNames.ENRLFRM_DATE:
+            record.start_date.strftime(DEFAULT_DATE_FORMAT)
         }
         if not record.naccid:
             message = ('Failed to generate NACCID for enrollment record '

--- a/gear/identifier_provisioning/src/python/identifier_provisioning_app/main.py
+++ b/gear/identifier_provisioning/src/python/identifier_provisioning_app/main.py
@@ -4,7 +4,12 @@ import logging
 from typing import Any, Dict, Iterator, List, MutableSequence, Optional, TextIO
 
 from configs.ingest_configs import ErrorLogTemplate
-from dates.form_dates import DATE_FORMATS, DateFormatException, parse_date
+from dates.form_dates import (
+    DATE_FORMATS,
+    DEFAULT_DATE_FORMAT,
+    DateFormatException,
+    parse_date,
+)
 from enrollment.enrollment_project import EnrollmentProject, TransferInfo
 from enrollment.enrollment_transfer import (
     CenterValidator,
@@ -417,10 +422,10 @@ class NewEnrollmentVisitor(CSVVisitor):
             self.__batch.add(
                 EnrollmentRecord(center_identifier=CenterIdentifiers(
                     adcid=row[FieldNames.ADCID], ptid=row[FieldNames.PTID]),
-                                 guid=row.get(FieldNames.GUID)
-                                 if row.get(FieldNames.GUID) else None,
-                                 naccid=None,
-                                 start_date=enroll_date))
+                    guid=row.get(FieldNames.GUID)
+                    if row.get(FieldNames.GUID) else None,
+                    naccid=None,
+                    start_date=enroll_date))
             return True
         except ValidationError as validation_error:
             for error in validation_error.errors():
@@ -586,7 +591,8 @@ def run(*, input_file: TextIO, center_id: int, repo: IdentifierRepository,
         error_writer.clear()
         record_info = {
             FieldNames.PTID: record.center_identifier.ptid,
-            FieldNames.ENRLFRM_DATE: record.start_date.strftime("%Y-%m-%d")
+            FieldNames.ENRLFRM_DATE: record.start_date.strftime(
+                DEFAULT_DATE_FORMAT)
         }
         if not record.naccid:
             message = ('Failed to generate NACCID for enrollment record '

--- a/gear/redcap_fw_transfer/src/python/redcap_fw_transfer_app/main.py
+++ b/gear/redcap_fw_transfer/src/python/redcap_fw_transfer_app/main.py
@@ -7,6 +7,7 @@ from json.decoder import JSONDecodeError
 from typing import Any, Dict, List
 
 import pandas as pd
+from dates.form_dates import DEFAULT_DATE_TIME_FORMAT
 from flywheel import FileSpec
 from flywheel.rest import ApiException
 from flywheel_adaptor.flywheel_proxy import ProjectAdaptor
@@ -85,7 +86,7 @@ def reset_upload_checkbox(redcap_prj: REDCapProject,
             update['redcap_event_name'] = visit['redcap_event_name']
             update['redcap_repeat_instance'] = visit['redcap_repeat_instance']
         update['upld_ready___1'] = '0'
-        update['upld_time'] = timestamp.strftime('%Y-%m-%d %H:%M:%S')
+        update['upld_time'] = timestamp.strftime(DEFAULT_DATE_TIME_FORMAT)
         updates.append(update)
 
     try:

--- a/mypy-stubs/src/python/flywheel/models/file_entry.pyi
+++ b/mypy-stubs/src/python/flywheel/models/file_entry.pyi
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Any, Dict, List
 
 from flywheel.models.container_parents import ContainerParents
@@ -65,6 +66,10 @@ class FileEntry:
 
     @tags.setter
     def tags(self, tags: List[str]):
+        ...
+
+    @property
+    def modified(self) -> datetime:
         ...
 
     def add_tag(self, tag, **kwargs):

--- a/mypy-stubs/src/python/flywheel/models/project.pyi
+++ b/mypy-stubs/src/python/flywheel/models/project.pyi
@@ -53,7 +53,7 @@ class Project:
         ...
 
     @property
-    def files(self) -> List[FileOutput]:
+    def files(self) -> List[FileEntry]:
         ...
 
     # TODO: determine return type

--- a/mypy-stubs/src/python/flywheel/view_builder.pyi
+++ b/mypy-stubs/src/python/flywheel/view_builder.pyi
@@ -25,3 +25,9 @@ class ViewBuilder:
 
     def missing_data_strategy(self, value) -> 'ViewBuilder':
         ...
+
+    def file_filter(self, value=None, regex=False) -> 'ViewBuilder':
+        ...
+
+    def file_container(self, container) -> 'ViewBuilder':
+        ...

--- a/mypy-stubs/src/python/flywheel_gear_toolkit/context/context.pyi
+++ b/mypy-stubs/src/python/flywheel_gear_toolkit/context/context.pyi
@@ -31,6 +31,11 @@ class GearToolkitContext:
     def destination(self) -> Dict[str, Any]:
         ...
 
+    @property
+    def config_json(self) -> Dict[str, Any]:
+        """Dictionary representation of `config.json`"""
+        ...
+
     def get_destination_container(self) -> Container:
         ...
 


### PR DESCRIPTION
This turned out to be a larger change than originally expected. Apologies for the giant PR :(
- Requirement was to trigger QC checks on any dependent module packets when a UDS visit is finalized. 
- To avoid race conditions due to concurrent actions from user, triggering of dependent module checks needs to be handled through form-screening and form-scheduler gears. 
- Modified form-screening, form-scheduler, and form-qc-coordinator gears to support multiple pipeline configurations. Currently two pipelines are defined "submission" and "finalization", it is possible to add new pipelines in the future if required.

Please review the gear changes in following order for ease of understanding the workflow.

1. form-screening
    - Update to support both CSV and JSON input
    - Add `format_and_tag` config to identify the different workflows
    - If `format_and_tag=True` format the input CSV and tag the input file with tags specified in `file_tags` config
    - If `format_and_tag=False` check whether the input file is tagged with any of the tags specified in `file_tags` config
    - Trigger the form-scheduler gear if it's not already running

2. form-scheduler
    - Add input `pipeline_configs_file` to specify the configurations for different pipelines
    - Here is an example [pipeline-configs.json](gear/form_scheduler/src/data/pipeline-configs.json) file
    - Queue the files for each pipeline by modules and process in the order the pipeline/modules are listed in the pipeline configs file
    - Trigger the starting gear on each matched file
    - Repeat until no more pending files

3. form-qc-coordinator
    - Add `pipeline` config to identify which pipeline triggered the gear
    - For `submission` pipeline, 
        - Run QC checks on the module visit packets matching to the input file module
        - If there are any dependent modules for the current input, add the `submission-completed` tag to the input file
        - A gear rule is set to trigger `form-screening` gear on JSON files that has `submission-completed` tag
    - For `finalization` pipeline, 
        - Find the set of modules dependent on the input file module
        - Run QC checks on the visit packets for those dependent modules

Note: If a visit has alerts and when those alerts are verified and visit is finalized in Issue Manager UI, it will add the `submission-completed` tag to the input file, which will then trigger the `finalization` pipeline.

**TODO:** Need to update the Issue Manager to update validation timestamp to file.info metadata when a visit is finalized (to prevent duplicate runs of QC checks)