### PR TITLE
Fix issue of id being passed instead of file_id

### DIFF
--- a/docs/form_qc_coordinator/CHANGELOG.md
+++ b/docs/form_qc_coordinator/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this gear are documented in this file.
 
+## 1.2.1
+
+* Fixes bug where Flywheel ID was being passed instead of the file ID on system error
+
 ## 1.2.0
 * Adds functionality for handling multiple pipelines (submission, finalization)
 * Updates to read in files with `utf-8-sig` to handle BOM encoding

--- a/gear/form_qc_coordinator/src/docker/BUILD
+++ b/gear/form_qc_coordinator/src/docker/BUILD
@@ -7,5 +7,5 @@ docker_image(
         ":manifest",
         "gear/form_qc_coordinator/src/python/form_qc_coordinator_app:bin",
     ],
-    image_tags=["1.2.0", "latest"],
+    image_tags=["1.2.1", "latest"],
 )

--- a/gear/form_qc_coordinator/src/docker/manifest.json
+++ b/gear/form_qc_coordinator/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "form-qc-coordinator",
     "label": "Form QC Coordinator",
     "description": "A gear to coordinate data quality checks for a given participant",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/form-qc-coordinator:1.2.0"
+            "image": "naccdata/form-qc-coordinator:1.2.1"
         },
         "flywheel": {
             "suite": "Utility",

--- a/gear/form_qc_coordinator/src/python/form_qc_coordinator_app/coordinator.py
+++ b/gear/form_qc_coordinator/src/python/form_qc_coordinator_app/coordinator.py
@@ -273,7 +273,7 @@ class QCCoordinator:
             error_obj: error metadata to report
         """
         self.__update_last_failed_visit(
-            file_id=visit_file.id, filename=visit_file.name, visitdate=visitdate
+            file_id=visit_file.file_id, filename=visit_file.name, visitdate=visitdate
         )
         self.__update_qc_error_metadata(
             visit_file=visit_file,


### PR DESCRIPTION
`id` was being passed instead of `file_id`, which caused the Issue Manager to be unable to look up the file.

That being said, in the FW data it is listed as `container_id` but what we're really setting/using is the `file_id`. That seems to come directly from the FW gear toolkit so may be a discrepancy we need to resolve at some point. 