### PR TITLE
Update nacc-form-validator

### DIFF
--- a/docs/form_qc_checker/CHANGELOG.md
+++ b/docs/form_qc_checker/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this gear are documented in this file.
 
+## 1.5.1
+* Updates `nacc-form-validator` to 1.5.2
 
 ## 1.5.0
 * Adds support for handling multiple pipelines (submission, finalization)

--- a/gear/form_qc_checker/src/docker/BUILD
+++ b/gear/form_qc_checker/src/docker/BUILD
@@ -4,5 +4,5 @@ docker_image(
     name="form-qc-checker",
     source="Dockerfile",
     dependencies=[":manifest", "gear/form_qc_checker/src/python/form_qc_app:bin"],
-    image_tags=["1.5.0", "latest"],
+    image_tags=["1.5.1", "latest"],
 )

--- a/gear/form_qc_checker/src/docker/manifest.json
+++ b/gear/form_qc_checker/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "form-qc-checker",
     "label": "Form QC Checker",
     "description": "Gear to check form data as JSON with QC rule set",
-    "version": "1.5.0",
+    "version": "1.5.1",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/form-qc-checker:1.5.0"
+            "image": "naccdata/form-qc-checker:1.5.1"
         },
         "flywheel": {
             "suite": "Curation",

--- a/python-default.lock
+++ b/python-default.lock
@@ -18,7 +18,7 @@
 //     "fw-utils>=3",
 //     "moto[s3,ses,ssm]>=5.0.15",
 //     "nacc_attribute_deriver@ https://github.com/naccdata/nacc-attribute-deriver/releases/download/v1.4.0/nacc_attribute_deriver-1.4.0-py3-none-any.whl",
-//     "nacc_form_validator@ https://github.com/naccdata/nacc-form-validator/releases/download/v0.5.1/nacc_form_validator-0.5.1-py3-none-any.whl",
+//     "nacc_form_validator@ https://github.com/naccdata/nacc-form-validator/releases/download/v0.5.2/nacc_form_validator-0.5.2-py3-none-any.whl",
 //     "natsort",
 //     "pandas-stubs>=2.0.3",
 //     "pandas>=2.1.1",
@@ -197,42 +197,42 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "2e3411bb43285caad1c8e1a3186d025ba65a6342e26bad493f6b8feb3d1a1680",
-              "url": "https://files.pythonhosted.org/packages/de/67/42355b452a5aa622205c321217cba61a85746f0d93984788116a43120821/boto3-1.38.43-py3-none-any.whl"
+              "hash": "9c8e88a32a6465e5905308708cff5b17547117f06982908bdfdb0108b4a65079",
+              "url": "https://files.pythonhosted.org/packages/b6/13/0eb850c821a976346a905370bb30c86da7edc2bbc3977c445fffc6306032/boto3-1.38.46-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "9b0ff0b34c9cf7328546c532c20b081f09055ff485f4d57c19146c36877048c5",
-              "url": "https://files.pythonhosted.org/packages/90/96/c99c9dac902faae3896558809d130b1bf02df8abb6e4553ad87d018910f9/boto3-1.38.43.tar.gz"
+              "hash": "d1ca2b53138afd0341e1962bd52be6071ab7a63c5b4f89228c5ef8942c40c852",
+              "url": "https://files.pythonhosted.org/packages/cc/56/ca67d22364ce8f23b1885d9a1bae50d8005fa9b32ec0deddba0b19079b99/boto3-1.38.46.tar.gz"
             }
           ],
           "project_name": "boto3",
           "requires_dists": [
-            "botocore<1.39.0,>=1.38.43",
+            "botocore<1.39.0,>=1.38.46",
             "botocore[crt]<2.0a0,>=1.21.0; extra == \"crt\"",
             "jmespath<2.0.0,>=0.7.1",
             "s3transfer<0.14.0,>=0.13.0"
           ],
           "requires_python": ">=3.9",
-          "version": "1.38.43"
+          "version": "1.38.46"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "2dc863a0bae3a9f31de6cdaff083be0f5f8850d4a846a017ef6079b620294f12",
-              "url": "https://files.pythonhosted.org/packages/df/8f/cd4445e5ce721a27121634bd25f40ee975d28d93cd1e660635aed9158108/boto3_stubs-1.38.43-py3-none-any.whl"
+              "hash": "e60f1bee8fed90213725de68bdcfc1bf8765030596962656e06c131bb779972d",
+              "url": "https://files.pythonhosted.org/packages/46/1d/2bc653af4a19170024bb54802fc68c781af64a3aef6d10ac072717593f7e/boto3_stubs-1.38.46-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6fe495830b63ffe3bbc8082e96890eee1e9a93ec5c3c1bd9b9b531ec4d90c1a7",
-              "url": "https://files.pythonhosted.org/packages/41/b5/054002183f9e6987da47e57c62f1bcd8d153a1b301fdfb4b919fc2fd149f/boto3_stubs-1.38.43.tar.gz"
+              "hash": "526789fc1f4a6f89f372424dc9a4109296f6bd18afab1abf5d281a94f5cfb770",
+              "url": "https://files.pythonhosted.org/packages/0e/c6/b042b91c40e6e70760d6b63fe391e198bd939b7630e1c5b809b635a601ae/boto3_stubs-1.38.46.tar.gz"
             }
           ],
           "project_name": "boto3-stubs",
           "requires_dists": [
             "boto3-stubs-full<1.39.0,>=1.38.0; extra == \"full\"",
-            "boto3==1.38.43; extra == \"boto3\"",
+            "boto3==1.38.46; extra == \"boto3\"",
             "botocore-stubs",
             "mypy-boto3-accessanalyzer<1.39.0,>=1.38.0; extra == \"accessanalyzer\"",
             "mypy-boto3-accessanalyzer<1.39.0,>=1.38.0; extra == \"all\"",
@@ -643,6 +643,8 @@
             "mypy-boto3-kendra<1.39.0,>=1.38.0; extra == \"kendra\"",
             "mypy-boto3-keyspaces<1.39.0,>=1.38.0; extra == \"all\"",
             "mypy-boto3-keyspaces<1.39.0,>=1.38.0; extra == \"keyspaces\"",
+            "mypy-boto3-keyspacesstreams<1.39.0,>=1.38.0; extra == \"all\"",
+            "mypy-boto3-keyspacesstreams<1.39.0,>=1.38.0; extra == \"keyspacesstreams\"",
             "mypy-boto3-kinesis-video-archived-media<1.39.0,>=1.38.0; extra == \"all\"",
             "mypy-boto3-kinesis-video-archived-media<1.39.0,>=1.38.0; extra == \"kinesis-video-archived-media\"",
             "mypy-boto3-kinesis-video-media<1.39.0,>=1.38.0; extra == \"all\"",
@@ -1059,19 +1061,19 @@
             "typing-extensions>=4.1.0; python_version < \"3.12\""
           ],
           "requires_python": ">=3.8",
-          "version": "1.38.43"
+          "version": "1.38.46"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "2ee60ac0b08e80e9be2aa2841d42e438d5bc4f82549560a682837655097a3db7",
-              "url": "https://files.pythonhosted.org/packages/15/12/0ebcfb91738d0cf9560220ee4e0db351acab14026fac74bbce9ab3881fd9/botocore-1.38.43-py3-none-any.whl"
+              "hash": "89ca782ffbf2e8769ca9c89234cfa5ca577f1987d07d913ee3c68c4776b1eb5b",
+              "url": "https://files.pythonhosted.org/packages/a4/00/dd90b7a0255587ba1c9754d32a221adb4a9022f181df3eef401b0b9fadfc/botocore-1.38.46-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "c453c5c16c157c5427058bb3cc2c5ad35ee2e43336f0ccbfcc6092c5635505c6",
-              "url": "https://files.pythonhosted.org/packages/1d/ff/8ace3f46fa1a32c09ee994b5401c7853613a283e134449fdc136bb753b40/botocore-1.38.43.tar.gz"
+              "hash": "8798e5a418c27cf93195b077153644aea44cb171fcd56edc1ecebaa1e49e226e",
+              "url": "https://files.pythonhosted.org/packages/cf/5f/d76870e4399fbfc12aa5c3bb36029edfc1a434392afc70a343c9d7d96e90/botocore-1.38.46.tar.gz"
             }
           ],
           "project_name": "botocore",
@@ -1083,7 +1085,7 @@
             "urllib3<1.27,>=1.25.4; python_version < \"3.10\""
           ],
           "requires_python": ">=3.9",
-          "version": "1.38.43"
+          "version": "1.38.46"
         },
         {
           "artifacts": [
@@ -2035,8 +2037,8 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "88e6eed8ee7e315affcb1b51e8f69ba5ce85cdf8f5eb8bce7bf839559f06e2be",
-              "url": "https://github.com/naccdata/nacc-form-validator/releases/download/v0.5.1/nacc_form_validator-0.5.1-py3-none-any.whl"
+              "hash": "cb60a9c11df9e12cea3cddef060422b877047315dc8f81c71e728959c0397d26",
+              "url": "https://github.com/naccdata/nacc-form-validator/releases/download/v0.5.2/nacc_form_validator-0.5.2-py3-none-any.whl"
             }
           ],
           "project_name": "nacc-form-validator",
@@ -2046,7 +2048,7 @@
             "types-python-dateutil>=2.9.0.20240316"
           ],
           "requires_python": "==3.11.*",
-          "version": "0.5.1"
+          "version": "0.5.2"
         },
         {
           "artifacts": [

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,5 +26,5 @@ urllib3 >= 2.2.1
 ratelimit>=2.2.1
 ratelimit-types>=0.0.1
 redcap_api@ https://github.com/naccdata/redcap-api/releases/download/v0.1.1/redcap_api-0.1.1-py3-none-any.whl
-nacc_form_validator@ https://github.com/naccdata/nacc-form-validator/releases/download/v0.5.1/nacc_form_validator-0.5.1-py3-none-any.whl
+nacc_form_validator@ https://github.com/naccdata/nacc-form-validator/releases/download/v0.5.2/nacc_form_validator-0.5.2-py3-none-any.whl
 nacc_attribute_deriver@ https://github.com/naccdata/nacc-attribute-deriver/releases/download/v1.4.0/nacc_attribute_deriver-1.4.0-py3-none-any.whl


### PR DESCRIPTION
Updates `nacc-form-validator` to fix bug where comparing ages crashes if the birth day/month/year is explicitly set to None.

Lockfile diff: python-default.lock [python-default]
                                                                  
==                    Upgraded dependencies                     ==

  boto3                          1.38.43      -->   1.38.46
  boto3-stubs                    1.38.43      -->   1.38.46
  botocore                       1.38.43      -->   1.38.46
  nacc-form-validator            0.5.1        -->   0.5.2