### PR TITLE
Form Transformer: Do not upload empty strings to metadata

### DIFF
--- a/common/src/python/uploads/acquisition.py
+++ b/common/src/python/uploads/acquisition.py
@@ -66,7 +66,9 @@ def update_file_info_metadata(
     """
 
     # remove empty fields
-    non_empty_fields = {k: v for k, v in input_record.items() if v is not None and v != ""}
+    non_empty_fields = {
+        k: v for k, v in input_record.items() if v is not None and v != ""
+    }
     info = {"forms": {"json": non_empty_fields}}
 
     try:

--- a/common/src/python/uploads/acquisition.py
+++ b/common/src/python/uploads/acquisition.py
@@ -66,7 +66,7 @@ def update_file_info_metadata(
     """
 
     # remove empty fields
-    non_empty_fields = {k: v for k, v in input_record.items() if v is not None}
+    non_empty_fields = {k: v for k, v in input_record.items() if v is not None and v != ""}
     info = {"forms": {"json": non_empty_fields}}
 
     try:

--- a/docs/form_scheduler/index.md
+++ b/docs/form_scheduler/index.md
@@ -21,7 +21,7 @@ This gear takes the following optional input parameters:
 
 | Parameter | Required? | Default | Description |
 | --------- | --------- | ------- | ----------- |
-| `submission_pipeline` | No | `file-validator,identifier-lookup,form-transformer,form-qc-coordinator,form-qc-checker` | Comma-deliminated list of gears representing a submission pipeline. The first one must be `file-validator` |
+| `submission_pipeline` | No | `nacc-file-validator,identifier-lookup,form-transformer,form-qc-coordinator,form-qc-checker` | Comma-deliminated list of gears representing a submission pipeline |
 | `accepted_modules` | No | `"UDS,ENROLL,FTLD,LBD"` | Comma-deliminated list of accepted modules, listed in order of priority. There will be one queue for each. Cannot be empty. |
 | `queue_tags` | No | `"queued"` | Comma-deliminated list of tags to add to the prescreened file. Cannot be empty. |
 | `source_email` | No | `""` | Source email address to send emails from. If empty will not send emails. |

--- a/docs/form_transformer/CHANGELOG.md
+++ b/docs/form_transformer/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this gear are documented in this file.
 
+## 1.4.2
+* Update `update_file_info_metadata` to also ignore empty strings
+
 ## 1.4.1
 * Rebuild for handling multiple pipelines (submission, finalization)
 * Updates to read in files with `utf-8-sig` to handle BOM encoding

--- a/gear/form_scheduler/src/data/pipeline-configs.json
+++ b/gear/form_scheduler/src/data/pipeline-configs.json
@@ -1,6 +1,6 @@
 {
     "gears": [
-        "file-validator",
+        "nacc-file-validator",
         "identifier-lookup",
         "form-transformer",
         "form-qc-coordinator",
@@ -21,7 +21,7 @@
                 ".csv"
             ],
             "starting_gear": {
-                "gear_name": "file-validator",
+                "gear_name": "nacc-file-validator",
                 "inputs": [
                     {
                         "label": "input_file",

--- a/gear/form_transformer/src/docker/BUILD
+++ b/gear/form_transformer/src/docker/BUILD
@@ -4,5 +4,5 @@ docker_image(
     name="form-transformer",
     source="Dockerfile",
     dependencies=[":manifest", "gear/form_transformer/src/python/form_csv_app:bin"],
-    image_tags=["1.4.1", "latest"],
+    image_tags=["1.4.2", "latest"],
 )

--- a/gear/form_transformer/src/docker/manifest.json
+++ b/gear/form_transformer/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "form-transformer",
     "label": "Form CSV to JSON Transformer",
     "description": "Form specific transformation from CSV to JSON",
-    "version": "1.4.1",
+    "version": "1.4.2",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/form-transformer:1.4.1"
+            "image": "naccdata/form-transformer:1.4.2"
         },
         "flywheel": {
             "suite": "Curation",


### PR DESCRIPTION
Fixes bug/issue where empty string values were being pushed to the FW metadata. This causes some issues downstream since it "finds" a value but it's not valid. 