### PR TITLE
Support co-enrollment in affiliated studies

### DIFF
--- a/common/src/python/centers/center_group.py
+++ b/common/src/python/centers/center_group.py
@@ -14,7 +14,7 @@ from flywheel.models.role_output import RoleOutput
 from flywheel.models.user import User
 from flywheel_adaptor.flywheel_proxy import FlywheelProxy, GroupAdaptor, ProjectAdaptor
 from keys.keys import DefaultValues
-from projects.study import Study
+from projects.study import StudyModel
 from projects.template_project import TemplateProject
 from pydantic import AliasGenerator, BaseModel, ConfigDict, RootModel, ValidationError
 from redcap_api.redcap_project import REDCapRoles
@@ -898,7 +898,7 @@ class CenterProjectMetadata(BaseModel):
         """
         self.studies[study.study_id] = study
 
-    def get(self, study: Study) -> StudyMetadata:
+    def get(self, study: StudyModel) -> StudyMetadata:
         """Gets the study metadata for the study id.
 
         Creates a new StudyMetadata object if it does not exist.

--- a/common/src/python/centers/center_info.py
+++ b/common/src/python/centers/center_info.py
@@ -2,7 +2,7 @@
 
 from typing import Dict, List, Optional, Set
 
-from projects.study import StudyVisitor
+from projects.study import CenterStudyModel, StudyVisitor
 from pydantic import AliasChoices, BaseModel, Field
 
 
@@ -45,7 +45,7 @@ class CenterInfo(BaseModel):
 
     def apply(self, visitor: StudyVisitor):
         """Applies visitor to this Center."""
-        visitor.visit_center(self.group)
+        visitor.visit_center(CenterStudyModel(center_id=self.group))
 
 
 class CenterMapInfo(BaseModel):

--- a/common/src/python/projects/study.py
+++ b/common/src/python/projects/study.py
@@ -2,7 +2,17 @@
 
 import re
 from abc import ABC, abstractmethod
-from typing import Any, List, Literal, Mapping
+from typing import Any, Dict, List, Literal, Mapping
+
+from pydantic import (
+    AliasGenerator,
+    BaseModel,
+    ConfigDict,
+    Field,
+    ValidationError,
+    field_validator,
+)
+from serialization.case import kebab_case
 
 
 def convert_to_slug(name: str) -> str:
@@ -23,6 +33,23 @@ def convert_to_slug(name: str) -> str:
     return name.lower()
 
 
+class CenterStudyModel(BaseModel):
+    """Data model to represent study enrollment pattern."""
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        alias_generator=AliasGenerator(alias=kebab_case),
+        extra="forbid",
+    )
+
+    center_id: str
+    enrollment_pattern: Literal["co-enrollment", "separate"] = "co-enrollment"
+
+    def uses_coenrollment(self) -> bool:
+        """Indicates whether center uses co-enrollment."""
+        return self.enrollment_pattern == "co-enrollment"
+
+
 class StudyVisitor(ABC):
     """Abstract class for a visitor object for studies."""
 
@@ -35,7 +62,7 @@ class StudyVisitor(ABC):
         """
 
     @abstractmethod
-    def visit_center(self, center_id: str) -> None:
+    def visit_center(self, center: CenterStudyModel) -> None:
         """Method to visit the given center within a study.
 
         Args:
@@ -55,104 +82,58 @@ StudyMode = Literal["aggregation", "distribution"]
 StudyType = Literal["primary", "affiliated"]
 
 
-class StudyModel:
-    """Represents a study with data managed at NACC."""
+class StudyModel(BaseModel):
+    """Data model for studies based on the model used in the project-management
+    gear.
 
-    def __init__(
-        self,
-        *,
-        name: str,
-        study_id: str,
-        centers: List[str],
-        datatypes: List[str],
-        mode: StudyMode,
-        published: bool = False,
-        study_type: StudyType,
-    ) -> None:
-        """Initializes a study object.
+    The `mode` indicates whether the study is meant to aggregate or distribute data
+    relative to the centers:
+    * 'aggregation' should be used when data is gathered from the centers and
+      aggregated.
+    * 'distribution' should be used when data is distributed to the centers.
 
-        Args:
-          name: the name of the study
-          study_id: the symbolic ID of study
-          centers: the list of ids for centers in the study
-          mode: whether the study aggregates or distributes data
-          published: whether the data for the study is to be released
-          primary: whether this is the primary study of the coordinating center
-        """
-        self.__name = name
-        self.__centers = centers
-        self.__datatypes = datatypes
-        self.__mode: StudyMode = mode
-        self.__published = published
-        self.__type = study_type
-        self.__study_id = study_id
+    The `study_type` indicates whether the study is 'primary' or 'affiliated'.
+    Affiliated study participants may be co-enrolled in the primary study or
+    separately enrolled.
+    So, for an affiliated study the enrollment pattern of a center determines
+    how data is managed:
+    * for a co-enrollment pattern, participant data will be associated to the
+      primary study.
+    * for separate enrollment, participant data will be associated with the
+      affiliated study.
+    For the primary study, the center enrollment pattern is meaningless.
+    """
 
-    def __eq__(self, __o: object) -> bool:
-        if not isinstance(__o, StudyModel):
-            return False
-        return (
-            __o.name == self.__name
-            and __o.centers == self.centers
-            and __o.datatypes == self.datatypes
-            and __o.__mode == self.__mode
-            and __o.is_published() == self.is_published()
-            and __o.is_primary() == self.is_primary()
-        )
+    model_config = ConfigDict(
+        populate_by_name=True,
+        alias_generator=AliasGenerator(alias=kebab_case),
+        extra="forbid",
+    )
 
-    def __repr__(self) -> str:
-        return (
-            "Study("
-            f"name={self.__name},"
-            f"study_id={self.__study_id},"
-            f"centers={self.__centers},"
-            f"datatypes={self.__datatypes},"
-            f"mode={self.__mode},"
-            f"published={self.__published},"
-            f"study_type={self.__type}"
-            ")"
-        )
-
-    @property
-    def study_id(self) -> str:
-        """Study ID property."""
-        return self.__study_id
-
-    @property
-    def name(self) -> str:
-        """Study Name property."""
-        return self.__name
-
-    @property
-    def centers(self) -> List[str]:
-        """Study centers property."""
-        return self.__centers
-
-    @property
-    def datatypes(self) -> List[str]:
-        """Study datatypes property."""
-        return self.__datatypes
-
-    @property
-    def mode(self) -> StudyMode:
-        """Study mode property."""
-        return self.__mode
-
-    def is_published(self) -> bool:
-        """Study published predicate."""
-        return self.__published
-
-    def is_affiliated(self) -> bool:
-        """Predicate to indicate whether this is an affiliated study."""
-        return self.__type == "affiliated"
-
-    def is_primary(self) -> bool:
-        """Predicate to indicate whether is the main study of coordinating
-        center."""
-        return self.__type == "primary"
+    name: str = Field(alias="study")
+    study_id: str
+    centers: List[CenterStudyModel]
+    datatypes: List[str]
+    mode: Literal["aggregation", "distribution"]
+    study_type: Literal["primary", "affiliated"]
+    published: bool = Field(False)
 
     def apply(self, visitor: StudyVisitor) -> None:
         """Apply visitor to this Study."""
         visitor.visit_study(self)
+
+    def is_published(self) -> bool:
+        """Study published predicate."""
+        return self.published
+
+    def is_affiliated(self) -> bool:
+        """Predicate to indicate whether this is an affiliated study."""
+        return self.study_type == "affiliated"
+
+    def is_primary(self) -> bool:
+        """Predicate to indicate whether is the main study of coordinating
+        center."""
+        return self.study_type == "primary"
 
     def project_suffix(self) -> str:
         """Creates the suffix that should be added to study pipelines."""
@@ -163,15 +144,45 @@ class StudyModel:
 
     @classmethod
     def create(cls, study: Mapping[str, Any]) -> "StudyModel":
-        """Create study from given mapping."""
+        try:
+            return StudyModel.model_validate(study)
+        except ValidationError as error:
+            raise StudyError(error) from error
 
-        study_mode: StudyMode = study.get("mode", "aggregation")
-        return StudyModel(
-            name=study["study"],
-            study_id=study["study-id"],
-            centers=study["centers"],
-            datatypes=study["datatypes"],
-            mode=study_mode,
-            published=study["published"],
-            study_type="primary" if "primary" in study else "affiliated",
-        )
+    @field_validator("centers", mode="before")
+    @classmethod
+    def center_list(cls, centers: List[str | Dict[str, str]]) -> List[CenterStudyModel]:
+        """Allows validation of an object where centers are given as strings.
+
+        Converts center-ids to CenterStudyModel with co-enrollment enrollment pattern.
+
+        Args:
+          centers: list of string or CenterStudyModel
+        Returns:
+          List with center-ids converted to CenterStudyModel
+        """
+
+        def center_model(
+            value: str | Dict[str, str] | CenterStudyModel,
+        ) -> CenterStudyModel:
+            """Converts value to a CenterStudyModel if required.
+
+            Creates a CenterStudyModel from a center-id by adding the
+            co-enrollment enrollment pattern.
+
+            Args:
+              value: the center-id or a CenterStudyModel
+            Returns:
+              the CenterStudyModel for the value
+            """
+            if isinstance(value, CenterStudyModel):
+                return value
+            if isinstance(value, Dict):
+                return CenterStudyModel.model_validate(value)
+            return CenterStudyModel(center_id=value, enrollment_pattern="co-enrollment")
+
+        return [center_model(value) for value in centers]
+
+
+class StudyError(Exception):
+    """Exception for loading a study."""

--- a/common/src/python/projects/study_group.py
+++ b/common/src/python/projects/study_group.py
@@ -1,18 +1,18 @@
 from flywheel.models.group import Group
 from flywheel_adaptor.flywheel_proxy import FlywheelProxy, GroupAdaptor, ProjectAdaptor
 
-from projects.study import Study
+from projects.study import StudyModel
 
 
 class StudyGroup(GroupAdaptor):
     """Defines a group adaptor to represent a study in Flywheel."""
 
-    def __init__(self, *, group: Group, proxy: FlywheelProxy, study: Study) -> None:
+    def __init__(self, *, group: Group, proxy: FlywheelProxy, study: StudyModel) -> None:
         super().__init__(group=group, proxy=proxy)
         self.__study = study
 
     @classmethod
-    def create(cls, study: Study, proxy: FlywheelProxy) -> "StudyGroup":
+    def create(cls, study: StudyModel, proxy: FlywheelProxy) -> "StudyGroup":
         """Creates a study group for the study object.
 
         Args:

--- a/common/src/python/projects/study_group.py
+++ b/common/src/python/projects/study_group.py
@@ -7,7 +7,9 @@ from projects.study import StudyModel
 class StudyGroup(GroupAdaptor):
     """Defines a group adaptor to represent a study in Flywheel."""
 
-    def __init__(self, *, group: Group, proxy: FlywheelProxy, study: StudyModel) -> None:
+    def __init__(
+        self, *, group: Group, proxy: FlywheelProxy, study: StudyModel
+    ) -> None:
         super().__init__(group=group, proxy=proxy)
         self.__study = study
 

--- a/common/src/python/projects/study_mapping.py
+++ b/common/src/python/projects/study_mapping.py
@@ -44,7 +44,7 @@ from flywheel_adaptor.flywheel_proxy import (
     ProjectAdaptor,
 )
 
-from projects.study import Study, StudyVisitor
+from projects.study import StudyModel, StudyVisitor
 from projects.study_group import StudyGroup
 
 log = logging.getLogger(__name__)
@@ -80,7 +80,7 @@ class AggregationMapper(StudyMapper):
     def __init__(
         self,
         *,
-        study: Study,
+        study: StudyModel,
         pipelines: List[str],
         proxy: FlywheelProxy,
         admin_access: List[AccessPermission],
@@ -222,7 +222,7 @@ class AggregationMapper(StudyMapper):
 class DistributionMapper(StudyMapper):
     """Defines a mapping from a distribution study to FW containers."""
 
-    def __init__(self, study: Study, proxy: FlywheelProxy) -> None:
+    def __init__(self, study: StudyModel, proxy: FlywheelProxy) -> None:
         self.__study = study
         self.__fw = proxy
 
@@ -289,10 +289,10 @@ class StudyMappingVisitor(StudyVisitor):
     ) -> None:
         self.__admin_access = admin_access
         self.__fw = flywheel_proxy
-        self.__study: Optional[Study] = None
+        self.__study: Optional[StudyModel] = None
         self.__mapper: Optional[StudyMapper] = None
 
-    def visit_study(self, study: Study) -> None:
+    def visit_study(self, study: StudyModel) -> None:
         """Creates FW containers for the study.
 
         Args:

--- a/common/test/python/centers/test_center_info.py
+++ b/common/test/python/centers/test_center_info.py
@@ -5,7 +5,7 @@ from typing import Optional
 import pytest
 import yaml
 from centers.center_info import CenterInfo, CenterMapInfo
-from projects.study import Study, StudyVisitor
+from projects.study import StudyModel, StudyVisitor
 from pydantic import ValidationError
 
 
@@ -23,7 +23,7 @@ class DummyVisitor(StudyVisitor):
     def visit_datatype(self, datatype: str):
         self.datatype_name = datatype
 
-    def visit_study(self, study: Study) -> None:
+    def visit_study(self, study: StudyModel) -> None:
         self.project_name = study.name
 
 

--- a/common/test/python/centers/test_center_info.py
+++ b/common/test/python/centers/test_center_info.py
@@ -5,7 +5,7 @@ from typing import Optional
 import pytest
 import yaml
 from centers.center_info import CenterInfo, CenterMapInfo
-from projects.study import StudyModel, StudyVisitor
+from projects.study import CenterStudyModel, StudyModel, StudyVisitor
 from pydantic import ValidationError
 
 
@@ -17,8 +17,8 @@ class DummyVisitor(StudyVisitor):
         self.project_name: Optional[str] = None
         self.datatype_name: Optional[str] = None
 
-    def visit_center(self, center_id: str) -> None:
-        self.center_id = center_id
+    def visit_center(self, center: CenterStudyModel) -> None:
+        self.center_id = center.center_id
 
     def visit_datatype(self, datatype: str):
         self.datatype_name = datatype

--- a/common/test/python/projects/test_study.py
+++ b/common/test/python/projects/test_study.py
@@ -3,7 +3,7 @@
 from typing import Optional
 
 import pytest
-from projects.study import Study, StudyVisitor
+from projects.study import StudyModel, StudyVisitor
 
 
 class DummyVisitor(StudyVisitor):
@@ -20,7 +20,7 @@ class DummyVisitor(StudyVisitor):
     def visit_datatype(self, datatype: str):
         self.datatype_name = datatype
 
-    def visit_study(self, study: Study) -> None:
+    def visit_study(self, study: StudyModel) -> None:
         self.project_name = study.name
 
 
@@ -29,14 +29,14 @@ class TestStudy:
 
     def test_object(self):
         """Tests for object creation."""
-        project = Study(
+        project = StudyModel(
             name="Project Alpha",
             study_id="project-alpha",
             centers=["ac"],
             datatypes=["dicom"],
             mode="aggregation",
             published=True,
-            primary=True,
+            study_type="primary",
         )
         assert project.study_id == "project-alpha"
         assert project.centers == ["ac"]
@@ -45,7 +45,7 @@ class TestStudy:
         assert project.is_published()
         assert project.is_primary()
 
-        project2 = Study.create(
+        project2 = StudyModel.create(
             {
                 "study": "Project Alpha",
                 "study-id": "project-alpha",
@@ -59,18 +59,19 @@ class TestStudy:
         assert project == project2
 
         with pytest.raises(KeyError):
-            Study.create({})
+            StudyModel.create({})
 
     def test_apply(self):
         """Test project apply method."""
         visitor = DummyVisitor()
-        project = Study(
+        project = StudyModel(
             name="Project Beta",
             study_id="beta",
             centers=[],
             datatypes=[],
             mode="aggregation",
             published=True,
+            study_type="affiliated"
         )
         project.apply(visitor)
         assert visitor.project_name == "Project Beta"

--- a/common/test/python/projects/test_study.py
+++ b/common/test/python/projects/test_study.py
@@ -3,7 +3,7 @@
 from typing import Optional
 
 import pytest
-from projects.study import StudyModel, StudyVisitor
+from projects.study import CenterStudyModel, StudyError, StudyModel, StudyVisitor
 
 
 class DummyVisitor(StudyVisitor):
@@ -14,8 +14,8 @@ class DummyVisitor(StudyVisitor):
         self.project_name: Optional[str] = None
         self.datatype_name: Optional[str] = None
 
-    def visit_center(self, center_id: str) -> None:
-        self.center_id = center_id
+    def visit_center(self, center: CenterStudyModel) -> None:
+        self.center_id = center.center_id
 
     def visit_datatype(self, datatype: str):
         self.datatype_name = datatype
@@ -30,16 +30,22 @@ class TestStudy:
     def test_object(self):
         """Tests for object creation."""
         project = StudyModel(
-            name="Project Alpha",
+            study="Project Alpha",
             study_id="project-alpha",
-            centers=["ac"],
+            centers=[
+                CenterStudyModel(center_id="ac"),
+                CenterStudyModel(center_id="bc"),
+            ],
             datatypes=["dicom"],
             mode="aggregation",
             published=True,
             study_type="primary",
         )
         assert project.study_id == "project-alpha"
-        assert project.centers == ["ac"]
+        assert project.centers == [
+            CenterStudyModel(center_id="ac"),
+            CenterStudyModel(center_id="bc"),
+        ]
         assert project.datatypes == ["dicom"]
         assert project.mode == "aggregation"
         assert project.is_published()
@@ -49,29 +55,32 @@ class TestStudy:
             {
                 "study": "Project Alpha",
                 "study-id": "project-alpha",
-                "centers": ["ac"],
+                "centers": [
+                    "ac",
+                    {"center-id": "bc", "enrollment-pattern": "co-enrollment"},
+                ],
                 "datatypes": ["dicom"],
                 "mode": "aggregation",
                 "published": True,
-                "primary": True,
+                "study-type": "primary",
             }
         )
         assert project == project2
 
-        with pytest.raises(KeyError):
+        with pytest.raises(StudyError):
             StudyModel.create({})
 
     def test_apply(self):
         """Test project apply method."""
         visitor = DummyVisitor()
         project = StudyModel(
-            name="Project Beta",
+            study="Project Beta",
             study_id="beta",
             centers=[],
             datatypes=[],
             mode="aggregation",
             published=True,
-            study_type="affiliated"
+            study_type="affiliated",
         )
         project.apply(visitor)
         assert visitor.project_name == "Project Beta"

--- a/docs/project_management/CHANGELOG.md
+++ b/docs/project_management/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 All notable changes to this gear are documented in this file.
 
-## Unreleased
+## 2.0.0
 
+* Changes study to capture enrollment-pattern for centers within an affiliated study.
+* Only creates pipelines for an affiliated study in a center where separate enrollment is designated.
 * Moves permission management for study into project and group creation.
 
 ## 1.1.1

--- a/docs/project_management/index.md
+++ b/docs/project_management/index.md
@@ -34,19 +34,27 @@ The file format is
 ---
 study: <study-name>
 study-id: <string-identifier>
-primary: <whether is primary study>
-centers: <list of center identifiers>
+study_type: <'primary' or 'affiliated'>
+centers: <list of center details>
 datatypes: <list of datatype identifiers>
 mode: <whether data should be aggregated or distributed>
 published: <whether the data is published>
 ```
 
+"Center details" may either be a center identifier or a center-study object.
 Center identifiers are Flywheel group IDs created by the [center management](../center_management/index.md) gear.
+A center-study object has a center identifier labeled as `center-id` and an `enrollment-pattern` that may be `co-enrollment`, or `separate`.
+In the `centers` list, a center identifier is assumed to represent a center-study object with the co-enrollment pattern.
 
 The mode is a string that is either `aggregation` or `distribution`.
 The mode may be omitted for aggregating studies to support older project formats.
 
-Running on the file will create a group for each center that does not already exist, and add new projects:
+Running on the file will create a group for each center that does not already exist, which includes
+
+* a `metadata` project where center-specific metadata can be stored using the project info object.
+* a `center-portal` project where center-level UI extensions for the ADRC portal can be attached.
+  
+Additional projects will be added if the study is either primary or it is affiliated and the center has separate enrollments:
 
 1. pipeline projects for each datatype.
    For aggregating studies, a project will have a name of the form `<pipeline>-<datatype>-<study-id>` where `<pipeline>` is `ingest`, `sandbox` or `retrospective`.
@@ -54,8 +62,7 @@ Running on the file will create a group for each center that does not already ex
    For instance, `ingest-form-leads`.
    For the primary study, the study-id is dropped like `ingest-form`.
 2. An `accepted` pipeline project for an aggregating study, where data that has passed QC is accessible.
-3. a `metadata` project where center-specific metadata can be stored using the project info object.
-4. a `center-portal` project where center-level UI extensions for the ADRC portal can be attached.
+
 
 Notes:
 1. Only one study should have `primary` set to `True`.
@@ -77,6 +84,7 @@ Notes:
 ---
 study: "Project Tau"
 study-id: tau
+study-type: affiliated
 centers:
   - alpha
   - beta-inactive
@@ -88,9 +96,11 @@ published: True
 ---
 study: "Project Zeta"
 study-id: zeta
+study-type: affiliated
 centers:
   - alpha
-  - gamma-adrc
+  - center-id: gamma-adrc
+    enrollment-pattern: separate
 datatypes:
   - form
 mode: aggregation

--- a/gear/project_management/src/docker/BUILD
+++ b/gear/project_management/src/docker/BUILD
@@ -4,5 +4,5 @@ docker_image(
     name="project-management",
     source="Dockerfile",
     dependencies=[":manifest", "gear/project_management/src/python/project_app:bin"],
-    image_tags=["1.1.1", "latest"],
+    image_tags=["2.0.0", "latest"],
 )

--- a/gear/project_management/src/docker/manifest.json
+++ b/gear/project_management/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "project-management",
     "label": "Project management",
     "description": "Creates and updates projects from project YAML file",
-    "version": "1.1.1",
+    "version": "2.0.0",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/project-management:1.1.1"
+            "image": "naccdata/project-management:2.0.0"
         },
         "flywheel": {
             "suite": "NACC Admin Gears",

--- a/gear/project_management/src/python/project_app/main.py
+++ b/gear/project_management/src/python/project_app/main.py
@@ -6,7 +6,7 @@ from typing import List
 from centers.nacc_group import NACCGroup
 from flywheel.models.group_role import GroupRole
 from flywheel_adaptor.flywheel_proxy import FlywheelProxy
-from projects.study import Study
+from projects.study import StudyModel
 from projects.study_mapping import StudyMappingVisitor
 
 log = logging.getLogger(__name__)
@@ -33,7 +33,7 @@ def get_project_roles(flywheel_proxy, role_names: List[str]) -> List[GroupRole]:
     return role_list
 
 
-def run(*, proxy: FlywheelProxy, admin_group: NACCGroup, study_list: List[Study]):
+def run(*, proxy: FlywheelProxy, admin_group: NACCGroup, study_list: List[StudyModel]):
     """Runs project pipeline creation/management.
 
     Args:

--- a/gear/project_management/src/python/project_app/run.py
+++ b/gear/project_management/src/python/project_app/run.py
@@ -24,7 +24,7 @@ from gear_execution.gear_execution import (
 )
 from inputs.parameter_store import ParameterStore
 from inputs.yaml import YAMLReadError, load_all_from_stream
-from projects.study import Study
+from projects.study import StudyModel
 
 from project_app.main import run
 
@@ -65,7 +65,7 @@ class ProjectCreationVisitor(GearExecutionEnvironment):
             admin_id=admin_id, client=client, project_filepath=project_filepath
         )
 
-    def __get_study_list(self, project_filepath: str) -> List[Study]:
+    def __get_study_list(self, project_filepath: str) -> List[StudyModel]:
         try:
             with open(project_filepath, "r", encoding="utf-8-sig") as stream:
                 project_list = load_all_from_stream(stream)
@@ -76,7 +76,7 @@ class ProjectCreationVisitor(GearExecutionEnvironment):
         if not project_list:
             raise GearExecutionError("Failed to read project file")
 
-        return [Study.create(study_doc) for study_doc in project_list]
+        return [StudyModel.create(study_doc) for study_doc in project_list]
 
     def run(self, context: GearToolkitContext) -> None:
         """Executes the gear.

--- a/python-default.lock
+++ b/python-default.lock
@@ -198,42 +198,42 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "056cfa2440fe1a157a7c2be897c749c83e1a322144aa4dad889f2fca66571019",
-              "url": "https://files.pythonhosted.org/packages/15/70/723d2ab259aeaed6c96e5c1857ebe7d474ed9aa8f487dea352c60f33798f/boto3-1.39.3-py3-none-any.whl"
+              "hash": "8e62c5724dc06a1934fde155a2eb48cb851cc17ad0b5142da9eb9e46fe0355d3",
+              "url": "https://files.pythonhosted.org/packages/08/bf/a6a73de65e3347305fc0aed129c63897e047042f55152414295a930700d6/boto3-1.39.13-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0a367106497649ae3d8a7b571b8c3be01b7b935a0fe303d4cc2574ed03aecbb4",
-              "url": "https://files.pythonhosted.org/packages/02/42/712a74bb86d06538c55067a35b8a82c57aa303eba95b2b1ee91c829288f4/boto3-1.39.3.tar.gz"
+              "hash": "ace50ccfc4caba235b020e7d36f0191aa399771cb6fe6e34b4359b671aab1a4b",
+              "url": "https://files.pythonhosted.org/packages/b1/cc/5ebce7eeba468c0bf5092c94684039e8484ca00329e62f0627662c930959/boto3-1.39.13.tar.gz"
             }
           ],
           "project_name": "boto3",
           "requires_dists": [
-            "botocore<1.40.0,>=1.39.3",
+            "botocore<1.40.0,>=1.39.13",
             "botocore[crt]<2.0a0,>=1.21.0; extra == \"crt\"",
             "jmespath<2.0.0,>=0.7.1",
             "s3transfer<0.14.0,>=0.13.0"
           ],
           "requires_python": ">=3.9",
-          "version": "1.39.3"
+          "version": "1.39.13"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "4daddb19374efa6d1bef7aded9cede0075f380722a9e60ab129ebba14ae66b69",
-              "url": "https://files.pythonhosted.org/packages/be/b8/0c56297e5f290de17e838c7e4ff338f5b94351c6566aed70ee197a671dc5/boto3_stubs-1.39.3-py3-none-any.whl"
+              "hash": "3e98d23da8cb87a97b91ead03c9034f3f48ded9fb49bb35411c2fc74e32c331f",
+              "url": "https://files.pythonhosted.org/packages/c9/d2/c6b2512d4fb99091fc314cceed9fefced50dd6bcfa5a4978a0317f416209/boto3_stubs-1.39.13-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "9aad443b1d690951fd9ccb6fa20ad387bd0b1054c704566ff65dd0043a63fc26",
-              "url": "https://files.pythonhosted.org/packages/f0/ea/85b9940d6eedc04d0c6febf24d27311b6ee54f85ccc37192eb4db0dff5d6/boto3_stubs-1.39.3.tar.gz"
+              "hash": "60a3057c3831ea31b9dc432f79a4ce219bce5712a58c43e59a558065fa164a07",
+              "url": "https://files.pythonhosted.org/packages/83/74/9274d7d1870337cbf1b4c8542ac8dce0957e2621bd9e480bec0a0e5b695d/boto3_stubs-1.39.13.tar.gz"
             }
           ],
           "project_name": "boto3-stubs",
           "requires_dists": [
             "boto3-stubs-full<1.40.0,>=1.39.0; extra == \"full\"",
-            "boto3==1.39.3; extra == \"boto3\"",
+            "boto3==1.39.13; extra == \"boto3\"",
             "botocore-stubs",
             "mypy-boto3-accessanalyzer<1.40.0,>=1.39.0; extra == \"accessanalyzer\"",
             "mypy-boto3-accessanalyzer<1.40.0,>=1.39.0; extra == \"all\"",
@@ -317,6 +317,10 @@
             "mypy-boto3-bedrock-agent-runtime<1.40.0,>=1.39.0; extra == \"bedrock-agent-runtime\"",
             "mypy-boto3-bedrock-agent<1.40.0,>=1.39.0; extra == \"all\"",
             "mypy-boto3-bedrock-agent<1.40.0,>=1.39.0; extra == \"bedrock-agent\"",
+            "mypy-boto3-bedrock-agentcore-control<1.40.0,>=1.39.0; extra == \"all\"",
+            "mypy-boto3-bedrock-agentcore-control<1.40.0,>=1.39.0; extra == \"bedrock-agentcore-control\"",
+            "mypy-boto3-bedrock-agentcore<1.40.0,>=1.39.0; extra == \"all\"",
+            "mypy-boto3-bedrock-agentcore<1.40.0,>=1.39.0; extra == \"bedrock-agentcore\"",
             "mypy-boto3-bedrock-data-automation-runtime<1.40.0,>=1.39.0; extra == \"all\"",
             "mypy-boto3-bedrock-data-automation-runtime<1.40.0,>=1.39.0; extra == \"bedrock-data-automation-runtime\"",
             "mypy-boto3-bedrock-data-automation<1.40.0,>=1.39.0; extra == \"all\"",
@@ -911,6 +915,8 @@
             "mypy-boto3-s3outposts<1.40.0,>=1.39.0; extra == \"s3outposts\"",
             "mypy-boto3-s3tables<1.40.0,>=1.39.0; extra == \"all\"",
             "mypy-boto3-s3tables<1.40.0,>=1.39.0; extra == \"s3tables\"",
+            "mypy-boto3-s3vectors<1.40.0,>=1.39.0; extra == \"all\"",
+            "mypy-boto3-s3vectors<1.40.0,>=1.39.0; extra == \"s3vectors\"",
             "mypy-boto3-sagemaker-a2i-runtime<1.40.0,>=1.39.0; extra == \"all\"",
             "mypy-boto3-sagemaker-a2i-runtime<1.40.0,>=1.39.0; extra == \"sagemaker-a2i-runtime\"",
             "mypy-boto3-sagemaker-edge<1.40.0,>=1.39.0; extra == \"all\"",
@@ -1064,19 +1070,19 @@
             "typing-extensions>=4.1.0; python_version < \"3.12\""
           ],
           "requires_python": ">=3.8",
-          "version": "1.39.3"
+          "version": "1.39.13"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "66a81cfac18ad5e9f47696c73fdf44cdbd8f8ca51ab3fca1effca0aabf61f02f",
-              "url": "https://files.pythonhosted.org/packages/53/e4/3698dbb037a44d82a501577c6e3824c19f4289f4afbcadb06793866250d8/botocore-1.39.3-py3-none-any.whl"
+              "hash": "6318ae28984d05aaabe92160446d37a2c498951b34a4d5431bc1ec7eb0376417",
+              "url": "https://files.pythonhosted.org/packages/ac/ce/8bb5626b0313c3f203215124f432d04ef46de611a9377b0791386e7355b2/botocore-1.39.13-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "da8f477e119f9f8a3aaa8b3c99d9c6856ed0a243680aa3a3fbbfc15a8d4093fb",
-              "url": "https://files.pythonhosted.org/packages/60/66/96e89cc261d75f0b8125436272c335c74d2a39df84504a0c3956adcd1301/botocore-1.39.3.tar.gz"
+              "hash": "ee8053f34e425a40843daccfa78820d6891f0d4f85fc647ab98f9ba28c36f9e7",
+              "url": "https://files.pythonhosted.org/packages/dd/39/eb875fff1c1d3299da660ed6cb00dd9b313e831ef7d18cb3c0f346a39578/botocore-1.39.13.tar.gz"
             }
           ],
           "project_name": "botocore",
@@ -1088,7 +1094,7 @@
             "urllib3<1.27,>=1.25.4; python_version < \"3.10\""
           ],
           "requires_python": ">=3.9",
-          "version": "1.39.3"
+          "version": "1.39.13"
         },
         {
           "artifacts": [
@@ -1135,19 +1141,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "2e0c7ce7cb5d8f8634ca55d2ba7e6ec2689a2fd6537d8dec1296a477a4910057",
-              "url": "https://files.pythonhosted.org/packages/84/ae/320161bd181fc06471eed047ecce67b693fd7515b16d495d8932db763426/certifi-2025.6.15-py3-none-any.whl"
+              "hash": "6b31f564a415d79ee77df69d757bb49a5bb53bd9f756cbbe24394ffd6fc1f4b2",
+              "url": "https://files.pythonhosted.org/packages/4f/52/34c6cf5bb9285074dc3531c437b3919e825d976fde097a7a73f79e726d03/certifi-2025.7.14-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d747aa5a8b9bbbb1bb8c22bb13e22bd1f18e9796defa16bab421f7f7a317323b",
-              "url": "https://files.pythonhosted.org/packages/73/f7/f14b46d4bcd21092d7d3ccef689615220d8a08fb25e564b65d20738e672e/certifi-2025.6.15.tar.gz"
+              "hash": "8ea99dbdfaaf2ba2f9bac77b9249ef62ec5218e7c2b2e903378ed5fccf765995",
+              "url": "https://files.pythonhosted.org/packages/b3/76/52c535bcebe74590f296d6c77c86dabf761c41980e1347a2422e4aa2ae41/certifi-2025.7.14.tar.gz"
             }
           ],
           "project_name": "certifi",
           "requires_dists": [],
           "requires_python": ">=3.7",
-          "version": "2025.6.15"
+          "version": "2025.7.14"
         },
         {
           "artifacts": [
@@ -1512,8 +1518,8 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "d3839c9ce0d67ec67897714651bfff15eb6ed6629ff185917035f20647ea00dd",
-              "url": "https://files.pythonhosted.org/packages/44/c9/c0e3e00d8ee755d67d8414439bd23017646060bf24724501a7453c879373/flywheel_sdk-20.4.4-py2.py3-none-any.whl"
+              "hash": "1a3bcdcc1f4255c962b0a919ee585fe9d4297b70bc481e9bab9e12fe0c152673",
+              "url": "https://files.pythonhosted.org/packages/d2/93/ee616dc2016aaed966b5306f809b0a3e6b3bc1346db854c1757e45910301/flywheel_sdk-20.5.0-py2.py3-none-any.whl"
             }
           ],
           "project_name": "flywheel-sdk",
@@ -1527,7 +1533,7 @@
             "urllib3>=2.2.1"
           ],
           "requires_python": null,
-          "version": "20.4.4"
+          "version": "20.5.0"
         },
         {
           "artifacts": [
@@ -1798,13 +1804,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "a462455f19f5faf404a7902952b6f0e3ce868f3ee09a359b05eca6673bd8412d",
-              "url": "https://files.pythonhosted.org/packages/a2/3d/023389198f69c722d039351050738d6755376c8fd343e91dc493ea485905/jsonschema-4.24.0-py3-none-any.whl"
+              "hash": "24c2e8da302de79c8b9382fee3e76b355e44d2a4364bb207159ce10b517bd716",
+              "url": "https://files.pythonhosted.org/packages/fe/54/c86cd8e011fe98803d7e382fd67c0df5ceab8d2b7ad8c5a81524f791551c/jsonschema-4.25.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0b4e8069eb12aedfa881333004bccaec24ecef5a8a6a4b6df142b2cc9599d196",
-              "url": "https://files.pythonhosted.org/packages/bf/d3/1cf5326b923a53515d8f3a2cd442e6d7e94fcc444716e879ea70a0ce3177/jsonschema-4.24.0.tar.gz"
+              "hash": "e63acf5c11762c0e6672ffb61482bdf57f0876684d8d249c0fe2d730d48bc55f",
+              "url": "https://files.pythonhosted.org/packages/d5/00/a297a868e9d0784450faa7365c2172a7d6110c763e30ba861867c32ae6a9/jsonschema-4.25.0.tar.gz"
             }
           ],
           "project_name": "jsonschema",
@@ -1814,17 +1820,16 @@
             "fqdn; extra == \"format-nongpl\"",
             "idna; extra == \"format\"",
             "idna; extra == \"format-nongpl\"",
-            "importlib-resources>=1.4.0; python_version < \"3.9\"",
             "isoduration; extra == \"format\"",
             "isoduration; extra == \"format-nongpl\"",
             "jsonpointer>1.13; extra == \"format\"",
             "jsonpointer>1.13; extra == \"format-nongpl\"",
             "jsonschema-specifications>=2023.03.6",
-            "pkgutil-resolve-name>=1.3.10; python_version < \"3.9\"",
             "referencing>=0.28.4",
             "rfc3339-validator; extra == \"format\"",
             "rfc3339-validator; extra == \"format-nongpl\"",
             "rfc3986-validator>0.1.0; extra == \"format-nongpl\"",
+            "rfc3987-syntax>=1.1.0; extra == \"format-nongpl\"",
             "rfc3987; extra == \"format\"",
             "rpds-py>=0.7.1",
             "uri-template; extra == \"format\"",
@@ -1833,7 +1838,7 @@
             "webcolors>=24.6.0; extra == \"format-nongpl\""
           ],
           "requires_python": ">=3.9",
-          "version": "4.24.0"
+          "version": "4.25.0"
         },
         {
           "artifacts": [
@@ -1912,13 +1917,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "e4a3092bc8fe9139caa77cd34cdcbad804de4d9671e2270ea3b4d53f5c645047",
-              "url": "https://files.pythonhosted.org/packages/f9/2f/62f959b7412dc87c545b8139249f0cb97cd133777e56405d54581114507f/moto-5.1.6-py3-none-any.whl"
+              "hash": "12f3a15100da7de019c671a516dbba33b14072faba103f16ca79a39b8c803b7d",
+              "url": "https://files.pythonhosted.org/packages/f1/a9/7dc06460777b2c1e7a91bb485e9dd600a88331aeac73ca88a8a6d437900f/moto-5.1.8-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "baf7afa9d4a92f07277b29cf466d0738f25db2ed2ee12afcb1dc3f2c540beebd",
-              "url": "https://files.pythonhosted.org/packages/39/c0/eb2c997ffb22af6878a5d369284ad0bf2356d6b22686b5350f749d7a7db7/moto-5.1.6.tar.gz"
+              "hash": "5c2f63c051b7c13224cb1483917c85a796468d7e37dcd5d1a5b8de66729de3f4",
+              "url": "https://files.pythonhosted.org/packages/19/e8/986b38d3459124168e21b8ea3311a9a26e930bc84b1e9ede16e5bccd574c/moto-5.1.8.tar.gz"
             }
           ],
           "project_name": "moto",
@@ -2019,7 +2024,7 @@
             "xmltodict"
           ],
           "requires_python": ">=3.9",
-          "version": "5.1.6"
+          "version": "5.1.8"
         },
         {
           "artifacts": [
@@ -2078,79 +2083,84 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "eabd7e8740d494ce2b4ea0ff05afa1b7b291e978c0ae075487c51e8bd93c0c68",
-              "url": "https://files.pythonhosted.org/packages/15/08/e00e7070ede29b2b176165eba18d6f9784d5349be3c0c1218338e79c27fd/numpy-2.3.1-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl"
+              "hash": "aa098a5ab53fa407fded5870865c6275a5cd4101cfdef8d6fafc48286a96e981",
+              "url": "https://files.pythonhosted.org/packages/8b/95/8023e87cbea31a750a6c00ff9427d65ebc5fef104a136bfa69f76266d614/numpy-2.3.2-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1ec9ae20a4226da374362cca3c62cd753faf2f951440b0e3b98e93c235441d2b",
-              "url": "https://files.pythonhosted.org/packages/2e/19/d7c972dfe90a353dbd3efbbe1d14a5951de80c99c9dc1b93cd998d51dc0f/numpy-2.3.1.tar.gz"
+              "hash": "f75018be4980a7324edc5930fe39aa391d5734531b1926968605416ff58c332d",
+              "url": "https://files.pythonhosted.org/packages/17/f2/e4d72e6bc5ff01e2ab613dc198d560714971900c03674b41947e38606502/numpy-2.3.2-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5ccb7336eaf0e77c1635b232c141846493a588ec9ea777a7c24d7166bb8533ae",
-              "url": "https://files.pythonhosted.org/packages/58/0e/0966c2f44beeac12af8d836e5b5f826a407cf34c45cb73ddcdfce9f5960b/numpy-2.3.1-cp311-cp311-macosx_11_0_arm64.whl"
+              "hash": "e0486a11ec30cdecb53f184d496d1c6a20786c81e55e41640270130056f8ee48",
+              "url": "https://files.pythonhosted.org/packages/37/7d/3fec4199c5ffb892bed55cff901e4f39a58c81df9c44c280499e92cad264/numpy-2.3.2.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "ebb8603d45bc86bbd5edb0d63e52c5fd9e7945d3a503b77e486bd88dde67a19b",
-              "url": "https://files.pythonhosted.org/packages/65/b6/41b705d9dbae04649b529fc9bd3387664c3281c7cd78b404a4efe73dcc45/numpy-2.3.1-pp311-pypy311_pp73-macosx_14_0_arm64.whl"
+              "hash": "2c3271cc4097beb5a60f010bcc1cc204b300bb3eafb4399376418a83a1c6373c",
+              "url": "https://files.pythonhosted.org/packages/48/b4/6500b24d278e15dd796f43824e69939d00981d37d9779e32499e823aa0aa/numpy-2.3.2-pp311-pypy311_pp73-macosx_14_0_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0025048b3c1557a20bc80d06fdeb8cc7fc193721484cca82b2cfa072fec71a93",
-              "url": "https://files.pythonhosted.org/packages/6a/e2/5756a00cabcf50a3f527a0c968b2b4881c62b1379223931853114fa04cda/numpy-2.3.1-cp311-cp311-musllinux_1_2_aarch64.whl"
+              "hash": "cbc95b3813920145032412f7e33d12080f11dc776262df1712e1638207dde9e8",
+              "url": "https://files.pythonhosted.org/packages/49/ce/055274fcba4107c022b2113a213c7287346563f48d62e8d2a5176ad93217/numpy-2.3.2-cp311-cp311-macosx_14_0_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "afed2ce4a84f6b0fc6c1ce734ff368cbf5a5e24e8954a338f3bdffa0718adffb",
-              "url": "https://files.pythonhosted.org/packages/75/c9/9bec03675192077467a9c7c2bdd1f2e922bd01d3a69b15c3a0fdcd8548f6/numpy-2.3.1-cp311-cp311-manylinux_2_28_x86_64.whl"
+              "hash": "69779198d9caee6e547adb933941ed7520f896fd9656834c300bdf4dd8642712",
+              "url": "https://files.pythonhosted.org/packages/83/85/27280c7f34fcd305c2209c0cdca4d70775e4859a9eaa92f850087f8dea50/numpy-2.3.2-pp311-pypy311_pp73-macosx_14_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "15aa4c392ac396e2ad3d0a2680c0f0dee420f9fed14eef09bdb9450ee6dcb7b7",
-              "url": "https://files.pythonhosted.org/packages/7a/b4/fe3ac1902bff7a4934a22d49e1c9d71a623204d654d4cc43c6e8fe337fcb/numpy-2.3.1-pp311-pypy311_pp73-macosx_14_0_x86_64.whl"
+              "hash": "852ae5bed3478b92f093e30f785c98e0cb62fa0a939ed057c31716e18a7a22b9",
+              "url": "https://files.pythonhosted.org/packages/96/26/1320083986108998bd487e2931eed2aeedf914b6e8905431487543ec911d/numpy-2.3.2-cp311-cp311-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0bb3a4a61e1d327e035275d2a993c96fa786e4913aa089843e6a2d9dd205c66a",
-              "url": "https://files.pythonhosted.org/packages/7d/31/6e35a247acb1bfc19226791dfc7d4c30002cd4e620e11e58b0ddf836fe52/numpy-2.3.1-cp311-cp311-macosx_14_0_arm64.whl"
+              "hash": "8446acd11fe3dc1830568c941d44449fd5cb83068e5c70bd5a470d323d448296",
+              "url": "https://files.pythonhosted.org/packages/9b/c9/142c1e03f199d202da8e980c2496213509291b6024fd2735ad28ae7065c7/numpy-2.3.2-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "c6e0bf9d1a2f50d2b65a7cf56db37c095af17b59f6c132396f7c6d5dd76484df",
-              "url": "https://files.pythonhosted.org/packages/ae/ee/89bedf69c36ace1ac8f59e97811c1f5031e179a37e4821c3a230bf750142/numpy-2.3.1-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl"
+              "hash": "71669b5daae692189540cffc4c439468d35a3f84f0c88b078ecd94337f6cb0ec",
+              "url": "https://files.pythonhosted.org/packages/9f/57/cdd5eac00dd5f137277355c318a955c0d8fb8aa486020c22afd305f8b88f/numpy-2.3.2-pp311-pypy311_pp73-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e344eb79dab01f1e838ebb67aab09965fb271d6da6b00adda26328ac27d4a66e",
-              "url": "https://files.pythonhosted.org/packages/b0/25/93b621219bb6f5a2d4e713a824522c69ab1f06a57cd571cda70e2e31af44/numpy-2.3.1-cp311-cp311-macosx_14_0_x86_64.whl"
+              "hash": "1f91e5c028504660d606340a084db4b216567ded1056ea2b4be4f9d10b67197f",
+              "url": "https://files.pythonhosted.org/packages/a9/ec/2f6c45c3484cc159621ea8fc000ac5a86f1575f090cac78ac27193ce82cd/numpy-2.3.2-cp311-cp311-musllinux_1_2_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6ea9e48336a402551f52cd8f593343699003d2353daa4b72ce8d34f66b722070",
-              "url": "https://files.pythonhosted.org/packages/b0/c7/87c64d7ab426156530676000c94784ef55676df2f13b2796f97722464124/numpy-2.3.1-cp311-cp311-macosx_10_9_x86_64.whl"
+              "hash": "fb1752a3bb9a3ad2d6b090b88a9a0ae1cd6f004ef95f75825e2f382c183b2097",
+              "url": "https://files.pythonhosted.org/packages/b5/01/dd67cf511850bd7aefd6347aaae0956ed415abea741ae107834aae7d6d4e/numpy-2.3.2-cp311-cp311-musllinux_1_2_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ad506d4b09e684394c42c966ec1527f6ebc25da7f4da4b1b056606ffe446b8a3",
-              "url": "https://files.pythonhosted.org/packages/e8/34/facc13b9b42ddca30498fc51f7f73c3d0f2be179943a4b4da8686e259740/numpy-2.3.1-pp311-pypy311_pp73-macosx_10_15_x86_64.whl"
+              "hash": "f0a1a8476ad77a228e41619af2fa9505cf69df928e9aaa165746584ea17fed2b",
+              "url": "https://files.pythonhosted.org/packages/b7/13/e792d7209261afb0c9f4759ffef6135b35c77c6349a151f488f531d13595/numpy-2.3.2-cp311-cp311-macosx_14_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "467db865b392168ceb1ef1ffa6f5a86e62468c43e0cfb4ab6da667ede10e58db",
-              "url": "https://files.pythonhosted.org/packages/ef/60/6b06ed98d11fb32e27fb59468b42383f3877146d3ee639f733776b6ac596/numpy-2.3.1-cp311-cp311-manylinux_2_28_aarch64.whl"
+              "hash": "7a0e27186e781a69959d0230dd9909b5e26024f8da10683bd6344baea1885168",
+              "url": "https://files.pythonhosted.org/packages/c4/2b/792b341463fa93fc7e55abbdbe87dac316c5b8cb5e94fb7a59fb6fa0cda5/numpy-2.3.2-cp311-cp311-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a5ee121b60aa509679b682819c602579e1df14a5b07fe95671c8849aad8f2115",
-              "url": "https://files.pythonhosted.org/packages/ff/86/a471f65f0a86f1ca62dcc90b9fa46174dd48f50214e5446bc16a775646c5/numpy-2.3.1-cp311-cp311-musllinux_1_2_x86_64.whl"
+              "hash": "20b8200721840f5621b7bd03f8dcd78de33ec522fc40dc2641aa09537df010c3",
+              "url": "https://files.pythonhosted.org/packages/c8/b0/fbeee3000a51ebf7222016e2939b5c5ecf8000a19555d04a18f1e02521b8/numpy-2.3.2-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "14a91ebac98813a49bc6aa1a0dfc09513dcec1d97eaf31ca21a87221a1cdcb15",
+              "url": "https://files.pythonhosted.org/packages/cf/ea/50ebc91d28b275b23b7128ef25c3d08152bc4068f42742867e07a870a42a/numpy-2.3.2-pp311-pypy311_pp73-macosx_10_15_x86_64.whl"
             }
           ],
           "project_name": "numpy",
           "requires_dists": [],
           "requires_python": ">=3.11",
-          "version": "2.3.1"
+          "version": "2.3.2"
         },
         {
           "artifacts": [
@@ -2197,38 +2207,38 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "ed16339bc354a73e0a609df36d256672c7d296f3f767ac07257801aa064ff73c",
-              "url": "https://files.pythonhosted.org/packages/95/81/b310e60d033ab64b08e66c635b94076488f0b6ce6a674379dd5b224fc51c/pandas-2.3.0-cp311-cp311-musllinux_1_2_x86_64.whl"
+              "hash": "4d544806b485ddf29e52d75b1f559142514e60ef58a832f74fb38e48d757b299",
+              "url": "https://files.pythonhosted.org/packages/e0/94/6fce6bf85b5056d065e0a7933cba2616dcb48596f7ba3c6341ec4bcc529d/pandas-2.3.1-cp311-cp311-musllinux_1_2_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "14a0cc77b0f089d2d2ffe3007db58f170dae9b9f54e569b299db871a3ab5bf46",
-              "url": "https://files.pythonhosted.org/packages/14/22/b493ec614582307faf3f94989be0f7f0a71932ed6f56c9a80c0bb4a3b51e/pandas-2.3.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "3462c3735fe19f2638f2c3a40bd94ec2dc5ba13abbb032dd2fa1f540a075509d",
+              "url": "https://files.pythonhosted.org/packages/07/5f/63760ff107bcf5146eee41b38b3985f9055e710a72fdd637b791dea3495c/pandas-2.3.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e5f08eb9a445d07720776df6e641975665c9ea12c9d8a331e0f6890f2dcd76ef",
-              "url": "https://files.pythonhosted.org/packages/1b/cc/0af9c07f8d714ea563b12383a7e5bde9479cf32413ee2f346a9c5a801f22/pandas-2.3.0-cp311-cp311-macosx_11_0_arm64.whl"
+              "hash": "98bcc8b5bf7afed22cc753a28bc4d9e26e078e777066bc53fac7904ddef9a678",
+              "url": "https://files.pythonhosted.org/packages/15/53/f31a9b4dfe73fe4711c3a609bd8e60238022f48eacedc257cd13ae9327a7/pandas-2.3.1-cp311-cp311-musllinux_1_2_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "34600ab34ebf1131a7613a260a61dbe8b62c188ec0ea4c296da7c9a06b004133",
-              "url": "https://files.pythonhosted.org/packages/72/51/48f713c4c728d7c55ef7444ba5ea027c26998d96d1a40953b346438602fc/pandas-2.3.0.tar.gz"
+              "hash": "2b0540963d83431f5ce8870ea02a7430adca100cec8a050f0811f8e31035541b",
+              "url": "https://files.pythonhosted.org/packages/76/1c/ccf70029e927e473a4476c00e0d5b32e623bff27f0402d0a92b7fc29bb9f/pandas-2.3.1-cp311-cp311-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8adff9f138fc614347ff33812046787f7d43b3cef7c0f0171b3340cae333f6ca",
-              "url": "https://files.pythonhosted.org/packages/96/1e/ba313812a699fe37bf62e6194265a4621be11833f5fce46d9eae22acb5d7/pandas-2.3.0-cp311-cp311-macosx_10_9_x86_64.whl"
+              "hash": "e6723a27ad7b244c0c79d8e7007092d7c8f0f11305770e2f4cd778b3ad5f9f85",
+              "url": "https://files.pythonhosted.org/packages/8a/4c/367c98854a1251940edf54a4df0826dcacfb987f9068abf3e3064081a382/pandas-2.3.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "c06f6f144ad0a1bf84699aeea7eff6068ca5c63ceb404798198af7eb86082e33",
-              "url": "https://files.pythonhosted.org/packages/9f/74/b012addb34cda5ce855218a37b258c4e056a0b9b334d116e518d72638737/pandas-2.3.0-cp311-cp311-musllinux_1_2_aarch64.whl"
+              "hash": "0a95b9ac964fe83ce317827f80304d37388ea77616b1425f0ae41c9d2d0d7bb2",
+              "url": "https://files.pythonhosted.org/packages/d1/6f/75aa71f8a14267117adeeed5d21b204770189c0a0025acbdc03c337b28fc/pandas-2.3.1.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "fa35c266c8cd1a67d75971a1912b185b492d257092bdd2709bbdebe574ed228d",
-              "url": "https://files.pythonhosted.org/packages/ee/3e/8c0fb7e2cf4a55198466ced1ca6a9054ae3b7e7630df7757031df10001fd/pandas-2.3.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "fe7317f578c6a153912bd2292f02e40c1d8f253e93c599e82620c7f69755c74f",
+              "url": "https://files.pythonhosted.org/packages/ec/d3/3c37cb724d76a841f14b8f5fe57e5e3645207cc67370e4f84717e8bb7657/pandas-2.3.1-cp311-cp311-macosx_11_0_arm64.whl"
             }
           ],
           "project_name": "pandas",
@@ -2320,7 +2330,7 @@
             "zstandard>=0.19.0; extra == \"compression\""
           ],
           "requires_python": ">=3.9",
-          "version": "2.3.0"
+          "version": "2.3.1"
         },
         {
           "artifacts": [
@@ -3013,13 +3023,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "0148ef34d6dd964d0d8cf4311b2b21c474693e57c2e069ec708ce043d2b527be",
-              "url": "https://files.pythonhosted.org/packages/18/17/22bf8155aa0ea2305eefa3a6402e040df7ebe512d1310165eda1e233c3f8/s3transfer-0.13.0-py3-none-any.whl"
+              "hash": "a981aa7429be23fe6dfc13e80e4020057cbab622b08c0315288758d67cabc724",
+              "url": "https://files.pythonhosted.org/packages/6d/4f/d073e09df851cfa251ef7840007d04db3293a0482ce607d2b993926089be/s3transfer-0.13.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f5e6db74eb7776a37208001113ea7aa97695368242b364d73e91c981ac522177",
-              "url": "https://files.pythonhosted.org/packages/ed/5d/9dcc100abc6711e8247af5aa561fc07c4a046f72f659c3adea9a449e191a/s3transfer-0.13.0.tar.gz"
+              "hash": "c3fdba22ba1bd367922f27ec8032d6a1cf5f10c934fb5d68cf60fd5a23d936cf",
+              "url": "https://files.pythonhosted.org/packages/6d/05/d52bf1e65044b4e5e27d4e63e8d1579dbdec54fce685908ae09bc3720030/s3transfer-0.13.1.tar.gz"
             }
           ],
           "project_name": "s3transfer",
@@ -3028,7 +3038,7 @@
             "botocore[crt]<2.0a.0,>=1.37.4; extra == \"crt\""
           ],
           "requires_python": ">=3.9",
-          "version": "0.13.0"
+          "version": "0.13.1"
         },
         {
           "artifacts": [
@@ -3216,19 +3226,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "2b2b3f57f9c6a61fba26a9c0ffb9ea5681c9b83e69cd897c6b5f668d9c0cab93",
-              "url": "https://files.pythonhosted.org/packages/c5/3f/b0e8db149896005adc938a1e7f371d6d7e9eca4053a29b108978ed15e0c2/types_python_dateutil-2.9.0.20250516-py3-none-any.whl"
+              "hash": "4d6d0cc1cc4d24a2dc3816024e502564094497b713f7befda4d5bc7a8e3fd21f",
+              "url": "https://files.pythonhosted.org/packages/72/52/43e70a8e57fefb172c22a21000b03ebcc15e47e97f5cb8495b9c2832efb4/types_python_dateutil-2.9.0.20250708-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "13e80d6c9c47df23ad773d54b2826bd52dbbb41be87c3f339381c1700ad21ee5",
-              "url": "https://files.pythonhosted.org/packages/ef/88/d65ed807393285204ab6e2801e5d11fbbea811adcaa979a2ed3b67a5ef41/types_python_dateutil-2.9.0.20250516.tar.gz"
+              "hash": "ccdbd75dab2d6c9696c350579f34cffe2c281e4c5f27a585b2a2438dd1d5c8ab",
+              "url": "https://files.pythonhosted.org/packages/c9/95/6bdde7607da2e1e99ec1c1672a759d42f26644bbacf939916e086db34870/types_python_dateutil-2.9.0.20250708.tar.gz"
             }
           ],
           "project_name": "types-python-dateutil",
           "requires_dists": [],
           "requires_python": ">=3.9",
-          "version": "2.9.0.20250516"
+          "version": "2.9.0.20250708"
         },
         {
           "artifacts": [
@@ -3308,19 +3318,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "a1514509136dd0b477638fc68d6a91497af5076466ad0fa6c338e44e359944af",
-              "url": "https://files.pythonhosted.org/packages/69/e0/552843e0d356fbb5256d21449fa957fa4eff3bbc135a74a691ee70c7c5da/typing_extensions-4.14.0-py3-none-any.whl"
+              "hash": "d1e1e3b58374dc93031d6eda2420a48ea44a36c2b4766a4fdeb3710755731d76",
+              "url": "https://files.pythonhosted.org/packages/b5/00/d631e67a838026495268c2f6884f3711a15a9a2a96cd244fdaea53b823fb/typing_extensions-4.14.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8676b788e32f02ab42d9e7c61324048ae4c6d844a399eebace3d4979d75ceef4",
-              "url": "https://files.pythonhosted.org/packages/d1/bc/51647cd02527e87d05cb083ccc402f93e441606ff1f01739a62c8ad09ba5/typing_extensions-4.14.0.tar.gz"
+              "hash": "38b39f4aeeab64884ce9f74c94263ef78f3c22467c8724005483154c26648d36",
+              "url": "https://files.pythonhosted.org/packages/98/5a/da40306b885cc8c09109dc2e1abd358d5684b1425678151cdaed4731c822/typing_extensions-4.14.1.tar.gz"
             }
           ],
           "project_name": "typing-extensions",
           "requires_dists": [],
           "requires_python": ">=3.9",
-          "version": "4.14.0"
+          "version": "4.14.1"
         },
         {
           "artifacts": [


### PR DESCRIPTION
* Adds ability to designate the enrollment strategy a center uses in an affiliated study: whether all participants are co-enrolled, or whether (some) participants are enrolled separately.
* Changes pipeline project creation so that they are not created for an affiliated studies in a center where the participants are all co-enrolled
* Also, includes refactoring of permission management. 