### PR TITLE
Turn off mypy vscode extension

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,7 +29,7 @@
             "extensions": [
                 "ms-python.python",
                 "ms-azuretools.vscode-docker",
-                "ms-python.mypy-type-checker",
+                // "ms-python.mypy-type-checker",
                 "streetsidesoftware.code-spell-checker",                
                 "yzhang.markdown-all-in-one",
                 "charliermarsh.ruff"


### PR DESCRIPTION
The mypy vscode extension is painful to use with the mypy configured in pants, so removing it.