### PR TITLE
Fix/study authorization mapping

### DIFF
--- a/docs/user_management/CHANGELOG.md
+++ b/docs/user_management/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this gear are documented in this file.
 
+## 2.1.0
+
+* Changes authorization mapping lookup so that authorization rules will match a study qualified project if only general pipeline rules are defined.
+
 ## 2.0.0
 
 * Changes check for claimed record by relaxing requirement that record includes an OIDC asserted email address.

--- a/gear/gather_submission_status/src/python/gather_submission_status_app/main.py
+++ b/gear/gather_submission_status/src/python/gather_submission_status_app/main.py
@@ -265,8 +265,8 @@ class SubmissionStatusVisitor(CSVVisitor):
         if not center:
             self.__error_writer.write(
                 FileError(
-                    error_code="no-center",
-                    error_type="error",
+                    error_code="no-center", # pyright: ignore[reportCallIssue]
+                    error_type="error", # pyright: ignore[reportCallIssue]
                     location=CSVLocation(line=line_num, column_name="adcid"),
                     message=f"value {status_query.adcid} is not a valid ADCID",
                 )
@@ -277,8 +277,8 @@ class SubmissionStatusVisitor(CSVVisitor):
         if not projects:
             self.__error_writer.write(
                 FileError(
-                    error_code="no-projects",
-                    error_type="error",
+                    error_code="no-projects", # pyright: ignore[reportCallIssue]
+                    error_type="error", # pyright: ignore[reportCallIssue]
                     location=CSVLocation(line=line_num, column_name="adcid"),
                     message=(
                         f"center {status_query.adcid} has no matching projects "

--- a/gear/gather_submission_status/src/python/gather_submission_status_app/main.py
+++ b/gear/gather_submission_status/src/python/gather_submission_status_app/main.py
@@ -265,8 +265,8 @@ class SubmissionStatusVisitor(CSVVisitor):
         if not center:
             self.__error_writer.write(
                 FileError(
-                    error_code="no-center", # pyright: ignore[reportCallIssue]
-                    error_type="error", # pyright: ignore[reportCallIssue]
+                    error_code="no-center",  # pyright: ignore[reportCallIssue]
+                    error_type="error",  # pyright: ignore[reportCallIssue]
                     location=CSVLocation(line=line_num, column_name="adcid"),
                     message=f"value {status_query.adcid} is not a valid ADCID",
                 )
@@ -277,8 +277,8 @@ class SubmissionStatusVisitor(CSVVisitor):
         if not projects:
             self.__error_writer.write(
                 FileError(
-                    error_code="no-projects", # pyright: ignore[reportCallIssue]
-                    error_type="error", # pyright: ignore[reportCallIssue]
+                    error_code="no-projects",  # pyright: ignore[reportCallIssue]
+                    error_type="error",  # pyright: ignore[reportCallIssue]
                     location=CSVLocation(line=line_num, column_name="adcid"),
                     message=(
                         f"center {status_query.adcid} has no matching projects "

--- a/gear/user_management/src/docker/BUILD
+++ b/gear/user_management/src/docker/BUILD
@@ -4,5 +4,5 @@ docker_image(
     name="user-management",
     source="Dockerfile",
     dependencies=[":manifest", "gear/user_management/src/python/user_app:bin"],
-    image_tags=["2.0.0", "latest"],
+    image_tags=["2.1.0", "latest"],
 )

--- a/gear/user_management/src/docker/manifest.json
+++ b/gear/user_management/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "user-management",
     "label": "User Management",
     "description": "Creates and updates user and user roles",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/user-management:2.0.0"
+            "image": "naccdata/user-management:2.1.0"
         },
         "flywheel": {
             "suite": "NACC Admin Gears",


### PR DESCRIPTION
Changes authorization rule look up to allow study-specific rules or general pipeline rules to be used.
Specifically, changes `AuthMap.get()`, which looks up authorization rules by project label so that it behaves as follows:
1. Return rules for full label if there are any.
2. Return rules for label with "study" suffix removed if there are any.

For instance, if passed `"ingest-form-study"`, it will first look for rules for `"ingest-form-study"`, if it doesn't find any will look for rules for `"ingest-form"`.

