### PR TITLE
Map ADCID to pipeline

### DIFF
--- a/common/src/python/centers/center_group.py
+++ b/common/src/python/centers/center_group.py
@@ -772,7 +772,7 @@ class DistributionProjectMetadata(ProjectMetadata):
 class IngestProjectMetadata(ProjectMetadata):
     """Metadata for an ingest project of a center."""
 
-    study_adcid: int
+    pipeline_adcid: int
     datatype: str
 
 
@@ -819,7 +819,7 @@ class FormIngestProjectMetadata(IngestProjectMetadata):
         """
         return FormIngestProjectMetadata(
             study_id=ingest.study_id,
-            study_adcid=ingest.study_adcid,
+            pipeline_adcid=ingest.pipeline_adcid,
             project_id=ingest.project_id,
             project_label=ingest.project_label,
             datatype=ingest.datatype,
@@ -853,7 +853,7 @@ class CenterStudyMetadata(BaseModel):
 
     study_id: str
     study_name: str
-    study_adcid: int
+    pipeline_adcid: int
     ingest_projects: Dict[str, (IngestProjectMetadata | FormIngestProjectMetadata)] = {}
     accepted_project: Optional[ProjectMetadata] = None
     distribution_projects: Dict[str, DistributionProjectMetadata] = {}
@@ -927,7 +927,7 @@ class CenterProjectMetadata(BaseModel):
         self.studies[study.study_id] = study
 
     def get(
-        self, study: StudyModel, study_adcid: Optional[int] = None
+        self, study: StudyModel, pipeline_adcid: Optional[int] = None
     ) -> CenterStudyMetadata:
         """Gets the study metadata for the study id.
 
@@ -942,9 +942,9 @@ class CenterProjectMetadata(BaseModel):
         if study_info:
             return study_info
 
-        adcid = study_adcid if study_adcid is not None else self.adcid
+        adcid = pipeline_adcid if pipeline_adcid is not None else self.adcid
         study_info = CenterStudyMetadata(
-            study_id=study.study_id, study_name=study.name, study_adcid=adcid
+            study_id=study.study_id, study_name=study.name, pipeline_adcid=adcid
         )
         self.add(study_info)
         return study_info

--- a/common/src/python/centers/center_group.py
+++ b/common/src/python/centers/center_group.py
@@ -772,6 +772,7 @@ class DistributionProjectMetadata(ProjectMetadata):
 class IngestProjectMetadata(ProjectMetadata):
     """Metadata for an ingest project of a center."""
 
+    study_adcid: int
     datatype: str
 
 
@@ -818,6 +819,7 @@ class FormIngestProjectMetadata(IngestProjectMetadata):
         """
         return FormIngestProjectMetadata(
             study_id=ingest.study_id,
+            study_adcid=ingest.study_adcid,
             project_id=ingest.project_id,
             project_label=ingest.project_label,
             datatype=ingest.datatype,
@@ -924,7 +926,9 @@ class CenterProjectMetadata(BaseModel):
         """
         self.studies[study.study_id] = study
 
-    def get(self, study: StudyModel, study_adcid: Optional[int]) -> CenterStudyMetadata:
+    def get(
+        self, study: StudyModel, study_adcid: Optional[int] = None
+    ) -> CenterStudyMetadata:
         """Gets the study metadata for the study id.
 
         Creates a new StudyMetadata object if it does not exist.

--- a/common/src/python/centers/center_group.py
+++ b/common/src/python/centers/center_group.py
@@ -109,6 +109,9 @@ class CenterGroup(CenterAdaptor):
         Returns:
           the CenterGroup for the center
         """
+        if center.group is None:
+            raise CenterError(f"Center info is not a group: {center.name}")
+
         group = proxy.get_group(group_label=center.name, group_id=center.group)
         assert group, "No group for center"
 

--- a/common/src/python/centers/center_info.py
+++ b/common/src/python/centers/center_info.py
@@ -22,6 +22,7 @@ class CenterInfo(BaseModel):
     adcid: int
     name: str
     group: Optional[str] = Field(
+        None,
         validation_alias=AliasChoices("center_id", "center-id", "group"),
         serialization_alias="center-id",
     )

--- a/common/src/python/centers/center_info.py
+++ b/common/src/python/centers/center_info.py
@@ -1,6 +1,6 @@
 """Models representing center information and center mappings."""
 
-from typing import Dict, Iterator, List, Optional, Set, Tuple, Union
+from typing import Dict, Iterator, List, Literal, Optional, Set, Tuple, Union
 
 from projects.study import CenterStudyModel, StudyVisitor
 from pydantic import AliasChoices, BaseModel, Field, RootModel, field_validator
@@ -16,11 +16,12 @@ class CenterInfo(BaseModel):
 
         active (bool): Optional, active or inactive status. Defaults to True.
         tags (Tuple[str]): Optional, list of tags for the center
+        type: "center" or "pipeline"
     """
 
     adcid: int
     name: str
-    group: str = Field(
+    group: Optional[str] = Field(
         validation_alias=AliasChoices("center_id", "center-id", "group"),
         serialization_alias="center-id",
     )
@@ -30,6 +31,11 @@ class CenterInfo(BaseModel):
         default=True,
     )
     tags: Optional[Tuple[str, ...]] = None
+    type: Literal["center", "pipeline"] = "center"
+
+    def is_pipeline(self) -> bool:
+        """Indicates whether this center info represents a pipeline."""
+        return self.type == "pipeline"
 
     def __repr__(self) -> str:
         return (
@@ -37,7 +43,9 @@ class CenterInfo(BaseModel):
             f"name={self.name}, "
             f"adcid={self.adcid}, "
             f"active={self.active}, "
-            f"tags={self.tags}"
+            f"tags={self.tags}, "
+            f"type={self.type}"
+            ")"
         )
 
     def __eq__(self, other: object) -> bool:
@@ -49,10 +57,15 @@ class CenterInfo(BaseModel):
             and self.group == other.group
             and self.name == other.name
             and self.active == other.active
+            and self.type == other.type
         )
 
     def apply(self, visitor: StudyVisitor):
         """Applies visitor to this Center."""
+        if self.is_pipeline():
+            return
+
+        assert self.group is not None
         visitor.visit_center(CenterStudyModel(center_id=self.group))
 
     @field_validator("tags", mode="before")

--- a/common/src/python/centers/nacc_group.py
+++ b/common/src/python/centers/nacc_group.py
@@ -66,30 +66,27 @@ class NACCGroup(CenterAdaptor):
         Args:
           center_group: the CenterGroup object for the center
         """
-        self.add_adcid(
+        self.update_center_map(
             adcid=center_group.adcid,
-            group_label=center_group.label,
-            group_id=center_group.id,
-            active=center_group.is_active(),
+            info=CenterInfo(
+                adcid=center_group.adcid,
+                name=center_group.label,
+                group=center_group.id,
+                active=center_group.is_active(),
+            ),
         )
 
-    def add_adcid(
-        self, adcid: int, group_label: str, group_id: str, active: bool
-    ) -> None:
-        """Adds the adcid-group correspondence.
+    def update_center_map(self, adcid: int, info: CenterInfo) -> None:
+        """Updates the center map in the metadata project to map the adcid to
+        the center info.
 
         Args:
-          adcid: the ADC ID
-          group_label: the label for the center group
-          group_id: the ID for the center group
-          active: active or inactive status for the center.
+          adcid: the center ID
+          info: the center info object
         """
         metadata = self.get_metadata()
         center_map = self.get_center_map()
-        center_map.add(
-            adcid,
-            CenterInfo(adcid=adcid, name=group_label, group=group_id, active=active),
-        )
+        center_map.add(adcid, info)
         metadata.update_info(center_map.model_dump())
 
     def get_center_map(

--- a/common/src/python/centers/nacc_group.py
+++ b/common/src/python/centers/nacc_group.py
@@ -182,8 +182,12 @@ class NACCGroup(CenterAdaptor):
         centers = []
         center_map = self.get_center_map()
         for center_info in center_map.centers.values():
+            if center_info.is_pipeline():
+                continue
+
             group_id = center_info.group
-            group = self._fw.find_group(group_id=(group_id))
+            assert group_id is not None
+            group = self._fw.find_group(group_id=group_id)
             if group:
                 center = CenterGroup.create_from_group_adaptor(adaptor=group)
                 centers.append(center)

--- a/common/src/python/keys/types.py
+++ b/common/src/python/keys/types.py
@@ -1,3 +1,4 @@
 from typing import Literal
 
 ModuleName = Literal["UDS", "FTLD", "LBD", "MDS"]
+PipelineStage = Literal["ingest", "retrospective", "sandbox", "distribution"]

--- a/common/src/python/projects/project_mapper.py
+++ b/common/src/python/projects/project_mapper.py
@@ -37,6 +37,9 @@ def build_project_map(
     project_map = {}
     try:
         for adcid, center_info in center_map.centers.items():
+            if center_info.is_pipeline():
+                continue
+
             group = CenterGroup.create_from_center(center=center_info, proxy=proxy)
             project = group.find_project(destination_label)
             if not project:

--- a/common/src/python/projects/study.py
+++ b/common/src/python/projects/study.py
@@ -44,7 +44,7 @@ class CenterStudyModel(BaseModel):
     )
 
     center_id: str
-    study_adcid: Optional[int] = None
+    pipeline_adcid: Optional[int] = None
     enrollment_pattern: Literal["co-enrollment", "separate"] = "co-enrollment"
 
 

--- a/common/src/python/projects/study.py
+++ b/common/src/python/projects/study.py
@@ -2,7 +2,7 @@
 
 import re
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Literal, Mapping, Self
+from typing import Any, Dict, List, Literal, Mapping, Optional, Self
 
 from pydantic import (
     AliasGenerator,
@@ -44,6 +44,7 @@ class CenterStudyModel(BaseModel):
     )
 
     center_id: str
+    study_adcid: Optional[int] = None
     enrollment_pattern: Literal["co-enrollment", "separate"] = "co-enrollment"
 
 

--- a/common/src/python/projects/study_mapping.py
+++ b/common/src/python/projects/study_mapping.py
@@ -210,6 +210,7 @@ class AggregationMapper(StudyMapper):
             study_info.add_ingest(
                 IngestProjectMetadata(
                     study_id=self.study.study_id,
+                    study_adcid=study_info.study_adcid,
                     project_id=project.id,
                     project_label=project.label,
                     datatype=datatype,

--- a/common/src/python/projects/study_mapping.py
+++ b/common/src/python/projects/study_mapping.py
@@ -32,10 +32,10 @@ from typing import Callable, List, Optional
 from centers.center_group import (
     CenterError,
     CenterGroup,
+    CenterStudyMetadata,
     DistributionProjectMetadata,
     IngestProjectMetadata,
     ProjectMetadata,
-    StudyMetadata,
 )
 from flywheel.models.access_permission import AccessPermission
 from flywheel_adaptor.flywheel_proxy import (
@@ -68,7 +68,7 @@ class StudyMapper(ABC):
 
     @abstractmethod
     def map_center_pipelines(
-        self, center: CenterGroup, study_info: StudyMetadata
+        self, center: CenterGroup, study_info: CenterStudyMetadata
     ) -> None:
         """Maps the study to pipelines within a center.
 
@@ -132,7 +132,7 @@ class AggregationMapper(StudyMapper):
         self.__release_group: Optional[GroupAdaptor] = None
 
     def map_center_pipelines(
-        self, center: CenterGroup, study_info: StudyMetadata
+        self, center: CenterGroup, study_info: CenterStudyMetadata
     ) -> None:
         """Creates accepted, ingest and retrospective projects in the group.
         Updates the study metadata.
@@ -163,7 +163,9 @@ class AggregationMapper(StudyMapper):
         self.__get_release_group()
         self.__get_master_project()
 
-    def __add_accepted(self, *, center: CenterGroup, study_info: StudyMetadata) -> None:
+    def __add_accepted(
+        self, *, center: CenterGroup, study_info: CenterStudyMetadata
+    ) -> None:
         """Creates an accepted project in the center group, and updates the
         study metadata.
 
@@ -193,7 +195,7 @@ class AggregationMapper(StudyMapper):
         center: CenterGroup,
         pipeline: str,
         datatype: str,
-        study_info: StudyMetadata,
+        study_info: CenterStudyMetadata,
     ) -> None:
         """Adds an ingest projects for the study datatype to the center.
 
@@ -290,7 +292,7 @@ class DistributionMapper(StudyMapper):
         super().__init__(study=study, proxy=proxy)
 
     def map_center_pipelines(
-        self, center: CenterGroup, study_info: StudyMetadata
+        self, center: CenterGroup, study_info: CenterStudyMetadata
     ) -> None:
         """Adds distribution projects for the study to the group.
 
@@ -313,7 +315,7 @@ class DistributionMapper(StudyMapper):
             self.__add_ingest(study_group=study_group, datatype=datatype)
 
     def __add_distribution(
-        self, *, center: CenterGroup, study_info: "StudyMetadata", datatype: str
+        self, *, center: CenterGroup, study_info: "CenterStudyMetadata", datatype: str
     ) -> None:
         """Adds a distribution project to this center for the study.
 
@@ -421,7 +423,9 @@ class StudyMappingVisitor(StudyVisitor):
             return
 
         portal_info = center.get_project_info()
-        study_info = portal_info.get(self.__study)
+        study_info = portal_info.get(
+            study=self.__study, study_adcid=center_model.study_adcid
+        )
 
         self.__mapper.map_center_pipelines(center=center, study_info=study_info)
 

--- a/common/src/python/projects/study_mapping.py
+++ b/common/src/python/projects/study_mapping.py
@@ -210,13 +210,13 @@ class AggregationMapper(StudyMapper):
             study_info.add_ingest(
                 IngestProjectMetadata(
                     study_id=self.study.study_id,
-                    study_adcid=study_info.study_adcid,
+                    pipeline_adcid=study_info.pipeline_adcid,
                     project_id=project.id,
                     project_label=project.label,
                     datatype=datatype,
                 )
             )
-            project.update_info({"study_adcid": study_info.study_adcid})
+            project.update_info({"pipeline_adcid": study_info.pipeline_adcid})
 
         self.add_pipeline(
             center=center,
@@ -426,7 +426,7 @@ class StudyMappingVisitor(StudyVisitor):
 
         portal_info = center.get_project_info()
         study_info = portal_info.get(
-            study=self.__study, study_adcid=center_model.study_adcid
+            study=self.__study, pipeline_adcid=center_model.pipeline_adcid
         )
 
         self.__mapper.map_center_pipelines(center=center, study_info=study_info)

--- a/common/src/python/projects/study_mapping.py
+++ b/common/src/python/projects/study_mapping.py
@@ -216,6 +216,7 @@ class AggregationMapper(StudyMapper):
                     datatype=datatype,
                 )
             )
+            project.update_info({"study_adcid": study_info.study_adcid})
 
         self.add_pipeline(
             center=center,

--- a/common/test/python/centers/test_center_info.py
+++ b/common/test/python/centers/test_center_info.py
@@ -88,7 +88,8 @@ class TestCenterInfo:
     def test_repr(self, dummy_center):
         """Test representation."""
         assert repr(dummy_center) == (
-            "Center(group=alpha-adrc, name=Alpha ADRC, adcid=7, active=True, tags=None, type=center)"
+            "Center(group=alpha-adrc, name=Alpha ADRC, adcid=7, active=True, "
+            "tags=None, type=center)"
         )
 
 

--- a/common/test/python/centers/test_center_info.py
+++ b/common/test/python/centers/test_center_info.py
@@ -68,7 +68,7 @@ class TestCenterInfo:
             CenterInfo()  # type: ignore
 
         with pytest.raises(ValidationError):
-            CenterInfo(name="Alpha ADRC", adcid=7)  # type: ignore
+            CenterInfo(name="Alpha ADRC")  # type: ignore
 
     def test_apply(self, dummy_center):
         """Test that visitor applied."""
@@ -112,3 +112,21 @@ class TestCenterMapInfo:
         """Test getting."""
         assert dummy_center_map.get(7) == dummy_center
         assert not dummy_center_map.get(1)
+
+
+class TestCenterInfoSerialization:
+    def test_center(self):
+        center = CenterInfo(
+            adcid=0, name="dummy", group="dummy", active=True, tags=("one", "two")
+        )
+        center_dump = center.model_dump(by_alias=True)
+        center_load = CenterInfo.model_validate(center_dump, by_alias=True)
+        assert center == center_load
+
+    def test_pipeline(self):
+        pipeline = CenterInfo(
+            adcid=0, name="dummy", group=None, type="pipeline", active=True
+        )
+        pipeline_dump = pipeline.model_dump(by_alias=True, exclude_none=True)
+        pipeline_load = CenterInfo.model_validate(pipeline_dump, by_alias=True)
+        assert pipeline_load == pipeline

--- a/common/test/python/centers/test_center_info.py
+++ b/common/test/python/centers/test_center_info.py
@@ -88,7 +88,7 @@ class TestCenterInfo:
     def test_repr(self, dummy_center):
         """Test representation."""
         assert repr(dummy_center) == (
-            "Center(group=alpha-adrc, name=Alpha ADRC, adcid=7, active=True, tags=None"
+            "Center(group=alpha-adrc, name=Alpha ADRC, adcid=7, active=True, tags=None, type=center)"
         )
 
 

--- a/common/test/python/centers/test_portal_metadata.py
+++ b/common/test/python/centers/test_portal_metadata.py
@@ -3,12 +3,12 @@
 import pytest
 from centers.center_group import (
     CenterProjectMetadata,
+    CenterStudyMetadata,
     FormIngestProjectMetadata,
     IngestProjectMetadata,
     ProjectMetadata,
     REDCapFormProjectMetadata,
     REDCapProjectInput,
-    StudyMetadata,
 )
 from keys.keys import DefaultValues
 from pydantic import ValidationError
@@ -142,9 +142,10 @@ def study_object(
     projects = {}
     projects[project_with_datatype.project_label] = project_with_datatype
     projects[ingest_project_with_redcap.project_label] = ingest_project_with_redcap
-    yield StudyMetadata(
+    yield CenterStudyMetadata(
         study_id="test",
         study_name="Test",
+        study_adcid=0,
         ingest_projects=projects,
         accepted_project=project_without_datatype,
     )
@@ -162,10 +163,10 @@ class TestStudyMetadataSerialization:
         assert "study-name" in study_dump
         assert "ingest-projects" in study_dump
         assert "accepted-project" in study_dump
-        assert len(study_dump.keys()) == 5
+        assert len(study_dump.keys()) == 6
 
         try:
-            model_object = StudyMetadata.model_validate(study_dump)
+            model_object = CenterStudyMetadata.model_validate(study_dump)
             assert model_object == study_object
         except ValidationError as error:
             assert False, error  # noqa: B011
@@ -177,7 +178,7 @@ def portal_metadata(study_object):
     """Creates portal info object."""
     studies = {}
     studies[study_object.study_id] = study_object
-    yield CenterProjectMetadata(studies=studies)
+    yield CenterProjectMetadata(adcid=0, active=True, studies=studies)
 
 
 class TestCenterPortalMetadataSerialization:
@@ -187,7 +188,7 @@ class TestCenterPortalMetadataSerialization:
         """Test serialization of portal info."""
         portal_dump = portal_metadata.model_dump(by_alias=True, exclude_none=True)
         assert portal_dump
-        assert len(portal_dump.keys()) == 1
+        assert len(portal_dump.keys()) == 3
         assert "studies" in portal_dump
 
         try:

--- a/common/test/python/centers/test_portal_metadata.py
+++ b/common/test/python/centers/test_portal_metadata.py
@@ -20,7 +20,7 @@ def project_with_datatype():
     """Returns a ProjectMetadata object with datatype."""
     yield IngestProjectMetadata(
         study_id="test",
-        study_adcid=0,
+        pipeline_adcid=0,
         project_id="9999999999",
         project_label="ingest-blah-test",
         datatype="blah",
@@ -33,7 +33,7 @@ def form_ingest_without_redcap():
     """Returns a form ingest project without redcap info."""
     yield IngestProjectMetadata(
         study_id="alpha",
-        study_adcid=0,
+        pipeline_adcid=0,
         project_id="11111111",
         project_label="ingest-form-alpha",
         datatype="form",
@@ -46,7 +46,7 @@ def ingest_project_with_redcap():
     """Returns a form ingest project."""
     yield FormIngestProjectMetadata(
         study_id="test",
-        study_adcid=0,
+        pipeline_adcid=0,
         project_id="88888888",
         project_label="ingest-form-test",
         datatype="form",
@@ -148,7 +148,7 @@ def study_object(
     yield CenterStudyMetadata(
         study_id="test",
         study_name="Test",
-        study_adcid=0,
+        pipeline_adcid=0,
         ingest_projects=projects,
         accepted_project=project_without_datatype,
     )

--- a/common/test/python/centers/test_portal_metadata.py
+++ b/common/test/python/centers/test_portal_metadata.py
@@ -20,6 +20,7 @@ def project_with_datatype():
     """Returns a ProjectMetadata object with datatype."""
     yield IngestProjectMetadata(
         study_id="test",
+        study_adcid=0,
         project_id="9999999999",
         project_label="ingest-blah-test",
         datatype="blah",
@@ -32,6 +33,7 @@ def form_ingest_without_redcap():
     """Returns a form ingest project without redcap info."""
     yield IngestProjectMetadata(
         study_id="alpha",
+        study_adcid=0,
         project_id="11111111",
         project_label="ingest-form-alpha",
         datatype="form",
@@ -44,6 +46,7 @@ def ingest_project_with_redcap():
     """Returns a form ingest project."""
     yield FormIngestProjectMetadata(
         study_id="test",
+        study_adcid=0,
         project_id="88888888",
         project_label="ingest-form-test",
         datatype="form",
@@ -75,7 +78,7 @@ class TestProjectMetadataSerialization:
             by_alias=True, exclude_none=True
         )
         assert project_dump
-        assert len(project_dump.keys()) == 4
+        assert len(project_dump.keys()) == 5
         assert "project-label" in project_dump
         assert "study-id" in project_dump
 

--- a/gear/center_management/src/python/center_app/main.py
+++ b/gear/center_management/src/python/center_app/main.py
@@ -53,6 +53,9 @@ def run(
     center_roles = get_project_roles(proxy, role_names)
 
     for center in center_list:
+        if center.is_pipeline():
+            continue
+
         if new_only and center.tags and "new-center" not in center.tags:
             log.info(
                 f"new_only set to True and {center.name} does not "

--- a/gear/center_management/src/python/center_app/main.py
+++ b/gear/center_management/src/python/center_app/main.py
@@ -54,6 +54,7 @@ def run(
 
     for center in center_list:
         if center.is_pipeline():
+            admin_group.update_center_map(adcid=center.adcid, info=center)
             continue
 
         if new_only and center.tags and "new-center" not in center.tags:

--- a/gear/redcap_project_creation/src/python/redcap_project_creation_app/run.py
+++ b/gear/redcap_project_creation/src/python/redcap_project_creation_app/run.py
@@ -149,9 +149,12 @@ class REDCapProjectCreation(GearExecutionEnvironment):
         study_redcap_metadata = StudyREDCapProjectsList([])
         # collect updated REDCap project mapping metadata for the study
         for center in centers.values():
+            if center.is_pipeline():
+                continue
             if not center.active:
                 continue
 
+            assert center.group is not None
             group_adaptor = self.proxy.find_group(center.group)
             if not group_adaptor:
                 log.warning("Cannot find Flywheel group for Center ID %s", center.group)


### PR DESCRIPTION
In the legacy system, an ADCID had to be assigned to create a separate submission pipeline.
So, we have a small number of ADCIDs that are not centers, but designators for pipelines.
Making a group for each ADCID has implications all the way through the system to the directory that we don't want to perpetuate.

So, these changes allow an ADCID to be set for a particular ingest pipeline, which allows for the legacy "pipeline" ADCIDs to be assigned to pipelines within a center group with a different ADCID.

> The use of `adcid` is not changed, and refers to a center.
> The use of `pipeline_adcid` refers to the ADCID of a pipeline pipeline.