### PR TITLE
Identifier Lookup: Only make forms configs required for nacc direction

### DIFF
--- a/docs/identifier_lookup/CHANGELOG.md
+++ b/docs/identifier_lookup/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this gear are documented in this file.
 
+## 1.3.1
+* Make `form_configs_file` only required for `nacc` direction
+
 ## 1.3.0
 * Updates to use new identifier lambda functions with restructured identifiers database
 * Updates error metadata to include date and naccid

--- a/gear/identifier_lookup/src/docker/BUILD
+++ b/gear/identifier_lookup/src/docker/BUILD
@@ -4,5 +4,5 @@ docker_image(
     name="identifier-lookup",
     source="Dockerfile",
     dependencies=[":manifest", "gear/identifier_lookup/src/python/identifier_app:bin"],
-    image_tags=["1.3.0", "latest"],
+    image_tags=["1.3.1", "latest"],
 )

--- a/gear/identifier_lookup/src/docker/manifest.json
+++ b/gear/identifier_lookup/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "identifier-lookup",
     "label": "Identifier Lookup",
     "description": "Gear to look up participant identifiers for incoming data",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/identifier-lookup:1.3.0"
+            "image": "naccdata/identifier-lookup:1.3.1"
         },
         "flywheel": {
             "suite": "NACC Data Gears",
@@ -36,8 +36,9 @@
             }
         },
         "form_configs_file": {
-            "description": "A JSON file with forms module configurations",
+            "description": "A JSON file with forms module configurations; required for the nacc direction",
             "base": "file",
+            "optional": true,
             "type": {
                 "enum": [
                     "source code"

--- a/gear/identifier_lookup/src/python/identifier_app/run.py
+++ b/gear/identifier_lookup/src/python/identifier_app/run.py
@@ -70,20 +70,20 @@ class IdentifierLookupVisitor(GearExecutionEnvironment):
         client: ClientWrapper,
         admin_id: str,
         file_input: InputFileWrapper,
-        config_input: InputFileWrapper,
         identifiers_mode: IdentifiersMode,
         direction: Literal["nacc", "center"],
         gear_name: str,
         preserve_case: bool,
+        config_input: Optional[InputFileWrapper] = None,
     ):
         super().__init__(client=client)
         self.__admin_id = admin_id
         self.__file_input = file_input
-        self.__config_input = config_input
         self.__identifiers_mode: IdentifiersMode = identifiers_mode
         self.__direction: Literal["nacc", "center"] = direction
         self.__gear_name = gear_name
         self.__preserve_case = preserve_case
+        self.__config_input = config_input
 
     @classmethod
     def create(
@@ -106,7 +106,6 @@ class IdentifierLookupVisitor(GearExecutionEnvironment):
         config_input = InputFileWrapper.create(
             input_name="form_configs_file", context=context
         )
-        assert config_input, "create raises exception if missing configuration file"
 
         admin_id = context.config.get("admin_group", DefaultValues.NACC_GROUP_ID)
         mode = context.config.get("database_mode", "prod")
@@ -114,15 +113,18 @@ class IdentifierLookupVisitor(GearExecutionEnvironment):
         preserve_case = context.config.get("preserve_case", False)
         gear_name = context.manifest.get("name", "identifier-lookup")
 
+        if config_input is None and direction == "nacc":
+            raise GearExecutionError("form_configs_file required for 'nacc' direction")
+
         return IdentifierLookupVisitor(
             client=client,
             gear_name=gear_name,
             admin_id=admin_id,
             file_input=file_input,
-            config_input=config_input,
             identifiers_mode=mode,
             direction=direction,
             preserve_case=preserve_case,
+            config_input=config_input,
         )
 
     def __build_naccid_lookup(
@@ -134,6 +136,8 @@ class IdentifierLookupVisitor(GearExecutionEnvironment):
         error_writer: ListErrorWriter,
         misc_errors: List[FileError],
     ) -> CSVVisitor:
+        assert self.__config_input, "form_configs_file required for NACCID lookup"
+
         module = self.__file_input.get_module_name_from_file_suffix()
         if not module:
             raise GearExecutionError(


### PR DESCRIPTION
Currently the gear requires the form configs file, but we have several pipelines that use the `center` direction in which this file is unnecessary. This change updates to only require it for the `naccid` direction.