### PR TITLE
CSV Subject Splitter: Parameterize required fields

### DIFF
--- a/docs/csv_subject_splitter/CHANGELOG.md
+++ b/docs/csv_subject_splitter/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this gear are documented in this file.
 
 * Adds `source_file` to file metadata to track provenance
 * Updates to read in files with `utf-8-sig` to handle BOM encoding
+* Parameterizes required fields
 
 ## 1.0.5
 

--- a/gear/csv_subject_splitter/src/docker/manifest.json
+++ b/gear/csv_subject_splitter/src/docker/manifest.json
@@ -51,6 +51,11 @@
             "description": "Whether or not to preserve the case of the header keys in the input file",
             "type": "boolean",
             "default": false
+        },
+        "required_fields": {
+            "description": "Comma-deliminated list of required fields",
+            "type": "string",
+            "default": ""
         }
     },
     "command": "/bin/run"

--- a/gear/csv_subject_splitter/src/python/csv_app/main.py
+++ b/gear/csv_subject_splitter/src/python/csv_app/main.py
@@ -62,15 +62,12 @@ class CSVSplitVisitor(CSVVisitor):
         Returns:
           True if the row was processed without error, False otherwise
         """
-
-        found_all = True
         empty_fields = set()
         for field in self.__req_fields:
             if field not in row or row[field] is None:
                 empty_fields.add(field)
-                found_all = False
 
-        if not found_all:
+        if empty_fields:
             self.__error_writer.write(empty_field_error(empty_fields, line_num))
             return False
 

--- a/gear/csv_subject_splitter/src/python/csv_app/main.py
+++ b/gear/csv_subject_splitter/src/python/csv_app/main.py
@@ -66,7 +66,7 @@ class CSVSplitVisitor(CSVVisitor):
         found_all = True
         empty_fields = set()
         for field in self.__req_fields:
-            if field not in row or not row[field]:
+            if field not in row or row[field] is None:
                 empty_fields.add(field)
                 found_all = False
 

--- a/gear/csv_subject_splitter/test/python/test_csv_split_visitor.py
+++ b/gear/csv_subject_splitter/test/python/test_csv_split_visitor.py
@@ -174,7 +174,7 @@ class TestCSVSplitVisitor:
 
         visitor = CSVSplitVisitor(
             provenance=provenance,
-            req_fields=["naccid"],
+            req_fields={"naccid"},
             uploader=MockUploader() if uploader is None else uploader,
             project=MockProject(),
             error_writer=error_writer,


### PR DESCRIPTION
Parameterizes required fields to allow enforcing specific fields to exist. 

For context this is being added because sometimes external files have missing expected data which causes issues in downstream analysis (e.g. curation). The logic for it was already there but just for NACCID.