### PR TITLE
Batch Scheduler: Optionally disable retries

### DIFF
--- a/docs/batch_scheduler/CHANGELOG.md
+++ b/docs/batch_scheduler/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this gear are documented in this file.
 
+## 1.1.3
+* Adds option to NOT retry jobs on failure
+
 ## 1.1.2
 * Adds include_centers config
   

--- a/gear/batch_scheduler/src/docker/BUILD
+++ b/gear/batch_scheduler/src/docker/BUILD
@@ -7,5 +7,5 @@ docker_image(
         ":manifest",
         "gear/batch_scheduler/src/python/batch_scheduler_app:bin",
     ],
-    image_tags=["1.1.2", "latest"],
+    image_tags=["1.1.3", "latest"],
 )

--- a/gear/batch_scheduler/src/docker/manifest.json
+++ b/gear/batch_scheduler/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "batch-scheduler",
     "label": "Batch Scheduler",
     "description": "A gear to schedule batch runs of another gear",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/batch-scheduler:1.1.2"
+            "image": "naccdata/batch-scheduler:1.1.3"
         },
         "flywheel": {
             "suite": "Utility",
@@ -81,6 +81,11 @@
             "description": "Comma-delimited list of emails to send error reports to",
             "type": "string",
             "default": "nacc_dev@uw.edu"
+        },
+        "retry_jobs": {
+            "description": "Whether or not to retry failed jobs",
+            "type": "boolean",
+            "default": true
         }
     },
     "command": "/bin/run"

--- a/gear/batch_scheduler/src/python/batch_scheduler_app/run.py
+++ b/gear/batch_scheduler/src/python/batch_scheduler_app/run.py
@@ -35,6 +35,7 @@ class BatchSchedulerVisitor(GearExecutionEnvironment):
         exclude_centers: List[str],
         exclude_studies: List[str],
         time_interval: int,
+        retry_jobs: bool,
     ):
         """
         Args:
@@ -45,6 +46,7 @@ class BatchSchedulerVisitor(GearExecutionEnvironment):
             exclude_centers: list of centers to exclude from batch run
             exclude_studies: list of study suffixes to exclude from batch run
             time_interval: time interval in days between the runs (input -1 to ignore)
+            retry_jobs: whether or not to retry jobs
         """
         super().__init__(client=client)
         self.__admin_id = admin_id
@@ -53,6 +55,7 @@ class BatchSchedulerVisitor(GearExecutionEnvironment):
         self.__exclude_centers = exclude_centers
         self.__exclude_studies = exclude_studies
         self.__time_interval = time_interval
+        self.__retry_jobs = retry_jobs
 
     @classmethod
     def create(
@@ -112,6 +115,7 @@ class BatchSchedulerVisitor(GearExecutionEnvironment):
             exclude_centers=exclude_centers_list,
             exclude_studies=exclude_studies_list,
             time_interval=context.config.get("time_interval", 7),
+            retry_jobs=context.config.get("retry_jobs", True),
         )
 
     def __get_center_ids(self) -> Optional[List[str]]:
@@ -175,6 +179,7 @@ class BatchSchedulerVisitor(GearExecutionEnvironment):
             batch_configs=batch_configs,
             sender_email=sender_email,
             target_emails=target_emails,
+            retry_jobs=self.__retry_jobs,
             dry_run=context.config.get("dry_run", False),
         )
 


### PR DESCRIPTION
Adds option to not retry failed jobs. This is useful for things like the attribute curator which often fails for data issues that would not be resolved by a retry (and would waste a lot of time and resources). 