### PR TITLE
Fix/tweak user mgmt logging

### DIFF
--- a/common/src/python/users/authorization_visitor.py
+++ b/common/src/python/users/authorization_visitor.py
@@ -140,7 +140,12 @@ class CenterAuthorizationVisitor(AbstractCenterMetadataVisitor):
 
         try:
             project.add_user_roles(user=self.__user, roles=role_set)
-            log.info("Added roles %s for user %s", role_set, self.__user.id)
+            log.info(
+                "Added roles for user %s to project %s/%s",
+                self.__user.id,
+                self.__center.id,
+                project.label,
+            )
         except ProjectError as error:
             raise AuthorizationError(error) from error
 

--- a/docs/user_management/CHANGELOG.md
+++ b/docs/user_management/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this gear are documented in this file.
 
-## 3.0.1
+## 3.0.2
 
 * Makes changes to reflect changes to the authorization scheme in the NACC directory. Adds handling of authorizations for particular studies, and expands the allowed datatypes.
   

--- a/gear/user_management/src/docker/BUILD
+++ b/gear/user_management/src/docker/BUILD
@@ -4,5 +4,5 @@ docker_image(
     name="user-management",
     source="Dockerfile",
     dependencies=[":manifest", "gear/user_management/src/python/user_app:bin"],
-    image_tags=["3.0.1", "latest"],
+    image_tags=["3.0.2", "latest"],
 )

--- a/gear/user_management/src/docker/manifest.json
+++ b/gear/user_management/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "user-management",
     "label": "User Management",
     "description": "Creates and updates user and user roles",
-    "version": "3.0.1",
+    "version": "3.0.2",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/user-management:3.0.1"
+            "image": "naccdata/user-management:3.0.2"
         },
         "flywheel": {
             "suite": "NACC Admin Gears",


### PR DESCRIPTION
Changes user management logging so that "added roles" case only logs user and project and not list of FW roles objects