### PR TITLE
Refactor/extend nacc common

### DIFF
--- a/.kiro/specs/nacc-common-data-access/.config.kiro
+++ b/.kiro/specs/nacc-common-data-access/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "f7b1c87b-0989-4f46-b533-2fd44fe08dde", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/nacc-common-data-access/design.md
+++ b/.kiro/specs/nacc-common-data-access/design.md
@@ -1,0 +1,407 @@
+# Design Document
+
+## Overview
+
+This feature extends the `nacc-common` public API in `error_data.py` with submission-oriented data access functions that expose existing internal capabilities through simple, dict-returning interfaces. The goal is to let Alzheimer's Disease Research Centers query per-submission QC summaries, error details, visit metadata, and submission listings without touching Flywheel SDK objects or internal QC model classes.
+
+Centers think in terms of **submissions** — identified by PTID, date, and module — not implementation-specific storage details. The public API uses an opaque `Submission_Identifier` (a `str`) that centers receive from `list_submissions` and pass to detail functions. Internally, this identifier currently maps to a QC status log filename, but this mapping is an implementation detail hidden behind a private helper.
+
+The changes fall into two categories:
+
+1. **Backward-compatible parameter additions**: Adding an optional `ptids` parameter to `get_error_data` and `get_status_data`, passing it through to `ProjectReportVisitor` as `ptid_set`.
+2. **New functions**: Four new public functions (`get_submission_qc_summary`, `get_submission_errors`, `get_submission_visit_metadata`, `list_submissions`) that wrap existing internals and return plain dicts using the submission abstraction.
+
+All functions live in `error_data.py` to keep the public API in one module. A shared private helper `_find_submission` resolves an opaque identifier to the underlying storage object.
+
+## Architecture
+
+```mermaid
+graph TD
+    subgraph "Public API (error_data.py)"
+        A[get_error_data]
+        B[get_status_data]
+        C[get_submission_qc_summary]
+        D[get_submission_errors]
+        E[get_submission_visit_metadata]
+        F[list_submissions]
+        H["_find_submission (private)"]
+        I["_should_include_file (private)"]
+    end
+
+    subgraph "Internal Models"
+        FQC[FileQCModel]
+        GQC[GearQCModel]
+        DI[DataIdentification]
+    end
+
+    subgraph "Internal Infrastructure"
+        PRV[ProjectReportVisitor]
+        EVK[extract_visit_keys]
+        QCP[QC_FILENAME_PATTERN]
+    end
+
+    subgraph "Flywheel SDK"
+        P[Project]
+        FE[FileEntry]
+    end
+
+    A -->|ptids param added| PRV
+    B -->|ptids param added| PRV
+    C --> H
+    C --> FQC
+    D --> H
+    D --> FQC
+    D --> GQC
+    E --> H
+    E --> DI
+    F --> QCP
+    F --> EVK
+    F --> FQC
+    F --> I
+    H --> P
+    H --> FE
+    I --> QCP
+```
+
+### Design Decisions
+
+1. **Submission abstraction over file-based API**: The public interface uses `identifier` (an opaque string) rather than `filename`. Centers don't need to know that submissions are stored as QC status log files. This allows the underlying storage to change without breaking center scripts.
+
+2. **`_find_submission` helper**: Resolves an opaque identifier to the underlying `FileEntry`. Currently this does a filename lookup in `project.files`, but the abstraction allows future changes (e.g., database-backed storage). Returns `Optional[FileEntry]` — callers handle `None` per their return type contract. Calls `file.reload()` to ensure `.info` is populated.
+
+3. **All functions in `error_data.py`**: Keeps the public API surface in one module. Centers import from one place.
+
+4. **Standalone `_should_include_file` for filtering**: `list_submissions` needs the same PTID/module filtering logic as `ProjectReportVisitor.__should_process_file`, but doesn't need the full visitor machinery. A standalone private function reuses `QC_FILENAME_PATTERN` and applies the same filter logic.
+
+5. **`FileQCModel.create()` handles reload**: The factory method calls `file_entry.reload()` internally, so the new functions don't need to reload before calling it. However, `_find_submission` calls `file.reload()` once to ensure `.info` is populated for functions that read `file.info.visit` directly.
+
+6. **Plain dict returns**: All functions return `dict`, `list[dict]`, or `Optional[dict]` — never Pydantic models or Flywheel objects. This matches the existing pattern and keeps the interface serialization-friendly.
+
+7. **Return `"identifier"` not `"filename"`**: Public-facing dicts use the key `"identifier"` to refer to the submission identifier. The value happens to be the QC log filename today, but centers should treat it as opaque.
+
+## Components and Interfaces
+
+### Modified Functions
+
+#### `get_error_data(project, modules=None, ptids=None)`
+
+```python
+def get_error_data(
+    project: Project,
+    modules: Optional[set[str]] = None,
+    ptids: Optional[set[str]] = None,
+) -> list[dict[str, Any]]:
+```
+
+- Adds optional `ptids` parameter
+- Passes `ptids` to `ProjectReportVisitor` as `ptid_set`
+- Backward compatible: existing calls without `ptids` behave identically
+
+#### `get_status_data(project, modules=None, ptids=None)`
+
+```python
+def get_status_data(
+    project: Project,
+    modules: Optional[set[str]] = None,
+    ptids: Optional[set[str]] = None,
+) -> list[dict[str, Any]]:
+```
+
+- Same change as `get_error_data`
+
+### New Private Helpers
+
+#### `_find_submission(project, identifier)`
+
+```python
+def _find_submission(project: Project, identifier: str) -> Optional[FileEntry]:
+```
+
+- Resolves an opaque submission identifier to the underlying storage object
+- Currently: iterates `project.files` looking for a file with matching `.name`
+- Returns the `FileEntry` (reloaded) if found, `None` otherwise
+- Calls `file.reload()` to ensure `.info` is populated
+- Implementation detail: the identifier is currently the QC log filename
+
+#### `_should_include_file(filename, modules=None, ptids=None)`
+
+```python
+def _should_include_file(
+    filename: str,
+    modules: Optional[set[str]] = None,
+    ptids: Optional[set[str]] = None,
+) -> bool:
+```
+
+- Matches `filename` against `QC_FILENAME_PATTERN`
+- If `ptids` is provided, checks that the extracted PTID is in the set
+- If `modules` is provided, checks that the extracted module (upper-cased) is in the set
+- Returns `False` if the filename doesn't match the pattern at all
+
+### New Public Functions
+
+#### `get_submission_qc_summary(project, identifier)`
+
+```python
+def get_submission_qc_summary(
+    project: Project, identifier: str
+) -> Optional[dict[str, Any]]:
+```
+
+- Uses `_find_submission` to resolve the identifier to a `FileEntry`
+- Builds `FileQCModel.create(file_entry)`
+- Returns `None` if identifier doesn't resolve or QC model has empty `qc` dict
+- Returns:
+
+  ```python
+  {
+      "identifier": "PTID_2024-01-15_UDS_qc-status.log",
+      "overall_status": "FAIL",
+      "stages": {
+          "form_qc_checker": {"status": "FAIL", "error_count": 3},
+          "form_validator": {"status": "PASS", "error_count": 0}
+      }
+  }
+  ```
+
+#### `get_submission_errors(project, identifier)`
+
+```python
+def get_submission_errors(
+    project: Project, identifier: str
+) -> list[dict[str, Any]]:
+```
+
+- Uses `_find_submission` to resolve the identifier
+- Builds `FileQCModel.create(file_entry)`
+- Iterates all gears, collects errors via `gear_model.get_errors()`
+- Returns flat list of dicts, each with `"stage"` key plus all `FileError` fields (serialized with `by_alias=True`)
+- Returns empty list if identifier doesn't resolve or no errors
+
+#### `get_submission_visit_metadata(project, identifier)`
+
+```python
+def get_submission_visit_metadata(
+    project: Project, identifier: str
+) -> Optional[dict[str, Any]]:
+```
+
+- Uses `_find_submission` to resolve the identifier
+- Calls `DataIdentification.from_visit_info(file_entry)`
+- Returns `data_id.model_dump()` (flattened dict) if successful
+- Returns `None` if identifier doesn't resolve or no visit metadata
+
+#### `list_submissions(project, modules=None, ptids=None)`
+
+```python
+def list_submissions(
+    project: Project,
+    modules: Optional[set[str]] = None,
+    ptids: Optional[set[str]] = None,
+) -> list[dict[str, Any]]:
+```
+
+- Iterates `project.files`, filters with `_should_include_file`
+- For each matching file, extracts PTID, date, module from the filename via `extract_visit_keys`
+- Attempts to build `FileQCModel` for `overall_status`; sets to `None` on failure
+- Returns list of dicts:
+
+  ```python
+  {
+      "identifier": "PTID_2024-01-15_UDS_qc-status.log",
+      "ptid": "PTID",
+      "date": "2024-01-15",
+      "module": "UDS",
+      "overall_status": "PASS"  # or None if no QC data
+  }
+  ```
+
+## Data Models
+
+No new Pydantic models are introduced. All functions return plain Python dicts and lists.
+
+### Return Type Summary
+
+| Function | Return Type | On Missing/Error |
+| --- | --- | --- |
+| `get_error_data` | `list[dict[str, Any]]` | `ReportError` if no ADCID |
+| `get_status_data` | `list[dict[str, Any]]` | `ReportError` if no ADCID |
+| `get_submission_qc_summary` | `Optional[dict[str, Any]]` | `None` |
+| `get_submission_errors` | `list[dict[str, Any]]` | `[]` |
+| `get_submission_visit_metadata` | `Optional[dict[str, Any]]` | `None` |
+| `list_submissions` | `list[dict[str, Any]]` | `[]` |
+
+### Dict Schemas
+
+**QC Summary dict** (`get_submission_qc_summary`):
+
+- `identifier: str` — the opaque submission identifier
+- `overall_status: str` — one of `"PASS"`, `"FAIL"`, `"IN REVIEW"`
+- `stages: dict[str, dict]` — maps stage name to `{"status": Optional[str], "error_count": int}`
+
+**Error detail dict** (`get_submission_errors`):
+
+- `stage: str` — stage (gear) name
+- `type: str` — error type (alias of `error_type`)
+- `code: str` — error code (alias of `error_code`)
+- `message: str`
+- `location: Optional[dict]` — CSV or JSON location
+- `container_id: Optional[str]`
+- `flywheel_path: Optional[str]`
+- `value: Optional[str]`
+- `expected: Optional[str]`
+- `timestamp: Optional[str]`
+- `ptid: Optional[str]`
+- `visitnum: Optional[str]`
+- `date: Optional[str]`
+- `naccid: Optional[str]`
+
+**Visit metadata dict** (`get_submission_visit_metadata`):
+
+- Flattened output from `DataIdentification.model_dump()`:
+  - `adcid: Optional[int]`
+  - `ptid: str`
+  - `naccid: Optional[str]`
+  - `date: str`
+  - `visitnum: Optional[str]`
+  - `module: str` (for form data) or `modality: str` (for image data)
+  - `packet: Optional[str]` (for form data)
+
+**Submission listing dict** (`list_submissions`):
+
+- `identifier: str` — the opaque submission identifier
+- `ptid: str`
+- `date: str`
+- `module: str`
+- `overall_status: Optional[str]` — one of `"PASS"`, `"FAIL"`, `"IN REVIEW"`, or `None`
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: QC summary faithfully represents FileQCModel
+
+*For any* valid `FileQCModel` with at least one gear, `get_submission_qc_summary` SHALL return a dict where:
+
+- `"identifier"` equals the input identifier
+- `"overall_status"` equals `FileQCModel.get_file_status()`
+- `"stages"` contains an entry for every gear in the model, where each entry's `"status"` matches `gear_model.get_status()` and `"error_count"` equals `len(gear_model.get_errors())`
+
+**Validates: Requirements 3.1, 3.2, 3.3**
+
+### Property 2: Error details faithfully represent FileQCModel errors
+
+*For any* `FileQCModel` with errors across one or more gears, each dict returned by `get_submission_errors` SHALL contain a `"stage"` key matching the gear name and SHALL be a superset of the corresponding `FileError.model_dump(by_alias=True)` output. The total number of dicts returned SHALL equal the sum of `len(gear_model.get_errors())` across all gears.
+
+**Validates: Requirements 4.1, 4.2, 4.5**
+
+### Property 3: Visit metadata round trip
+
+*For any* file with valid visit metadata in `file.info.visit`, `get_submission_visit_metadata` SHALL return a dict equal to `DataIdentification.from_visit_info(file_entry).model_dump()`.
+
+**Validates: Requirements 5.1**
+
+### Property 4: Submission listing filter correctness
+
+*For any* set of QC log files and any combination of `modules` and `ptids` filters, every dict in the list returned by `list_submissions` SHALL have a `"ptid"` value in the `ptids` set (when provided) AND a `"module"` value (compared case-insensitively) in the `modules` set (when provided). When neither filter is provided, the result SHALL include all QC log files.
+
+**Validates: Requirements 6.1, 6.2, 6.3, 6.4**
+
+### Property 5: Submission listing output structure matches identifier
+
+*For any* QC log file included in the `list_submissions` result, the dict SHALL contain `"identifier"`, `"ptid"`, `"date"`, and `"module"` values where the ptid, date, and module match the regex capture groups from `QC_FILENAME_PATTERN`, and `"overall_status"` SHALL equal `FileQCModel.get_file_status()` when QC data exists or `None` otherwise.
+
+**Validates: Requirements 6.5, 6.6**
+
+### Property 6: All return values are JSON-serializable plain dicts
+
+*For any* valid input to any public data access function, the return value SHALL be directly serializable via `json.dumps()` without custom encoders, and SHALL not contain any Pydantic `BaseModel` instances or Flywheel SDK objects.
+
+**Validates: Requirements 8.1, 8.2, 8.3**
+
+## Error Handling
+
+### Existing Error Behavior (Preserved)
+
+- `get_error_data` and `get_status_data` raise `ReportError` if the project has no `pipeline_adcid` in `project.info`. This behavior is unchanged.
+- `FileQCModel.create()` raises `pydantic.ValidationError` if the QC data structure is malformed. The new functions handle this gracefully.
+
+### New Function Error Handling
+
+| Scenario | Function | Behavior |
+| --- | --- | --- |
+| Identifier doesn't resolve | `get_submission_qc_summary` | Returns `None` |
+| Identifier doesn't resolve | `get_submission_errors` | Returns `[]` |
+| Identifier doesn't resolve | `get_submission_visit_metadata` | Returns `None` |
+| Submission has no QC data (empty `qc` dict) | `get_submission_qc_summary` | Returns `None` |
+| Submission has no QC data | `get_submission_errors` | Returns `[]` |
+| Submission has no visit metadata | `get_submission_visit_metadata` | Returns `None` |
+| `FileQCModel.create()` raises `ValidationError` | `get_submission_qc_summary` | Returns `None` |
+| `FileQCModel.create()` raises `ValidationError` | `get_submission_errors` | Returns `[]` |
+| `FileQCModel.create()` raises `ValidationError` | `list_submissions` | Sets `overall_status` to `None` for that entry |
+| `DataIdentification.from_visit_info()` returns `None` | `get_submission_visit_metadata` | Returns `None` |
+| Filename doesn't match QC pattern | `list_submissions` | File is skipped (not included in results) |
+
+### Design Rationale
+
+- Per-submission functions return `None` or `[]` rather than raising exceptions because "submission not found" and "no data" are expected conditions in center workflows, not exceptional errors.
+- `list_submissions` gracefully handles individual submission failures (malformed QC data) by setting `overall_status` to `None` rather than failing the entire listing.
+- The existing `ReportError` for missing ADCID is preserved because it indicates a misconfigured project, which is a genuine error condition.
+
+## Testing Strategy
+
+### Testing Approach
+
+This feature is well-suited for a dual testing approach:
+
+- **Property-based tests** (using [Hypothesis](https://hypothesis.readthedocs.io/)): Verify the 6 correctness properties above across randomly generated `FileQCModel` configurations, identifiers, and filter combinations. These test the pure logic of dict construction, filtering, and data transformation.
+- **Example-based unit tests**: Verify edge cases (identifier not found, no QC data, no visit metadata, `ValidationError` handling), backward compatibility, and specific wiring (ptids parameter pass-through).
+
+### Property-Based Testing Configuration
+
+- **Library**: Hypothesis (already available in the Python ecosystem; add to test dependencies)
+- **Minimum iterations**: 100 per property test
+- **Tag format**: `Feature: nacc-common-data-access, Property {number}: {property_text}`
+- Each correctness property is implemented as a single property-based test
+
+### What to Mock
+
+All tests mock Flywheel objects since the functions under test wrap Flywheel SDK calls:
+
+- **`Project`**: Mock with a `.files` list of mock `FileEntry` objects and `.info` dict with `pipeline_adcid`
+- **`FileEntry`**: Mock with `.name`, `.info` (containing `qc` and/or `visit` dicts), and `.reload()` returning self
+- **`FileQCModel`**: For property tests, construct directly from generated data (no mock needed — it's a Pydantic model). For integration-style tests, mock the `FileEntry` that `FileQCModel.create()` reads from.
+
+Follow the existing pattern in `test_file_qc_model.py` which constructs `FileQCModel`, `GearQCModel`, and `ValidationModel` directly without mocks.
+
+### Test Organization
+
+Tests go in `nacc-common/test/python/`:
+
+- `test_error_data_ptid_filter.py` — Example tests for ptids parameter on `get_error_data` and `get_status_data`
+- `test_submission_qc_summary.py` — Property + example tests for `get_submission_qc_summary`
+- `test_submission_errors.py` — Property + example tests for `get_submission_errors`
+- `test_submission_visit_metadata.py` — Property + example tests for `get_submission_visit_metadata`
+- `test_list_submissions.py` — Property + example tests for `list_submissions`
+- `test_json_serializable.py` — Property test for JSON serialization contract (Property 6)
+
+### Property Test to Correctness Property Mapping
+
+| Test File | Properties Covered |
+| --- | --- |
+| `test_submission_qc_summary.py` | Property 1 |
+| `test_submission_errors.py` | Property 2 |
+| `test_submission_visit_metadata.py` | Property 3 |
+| `test_list_submissions.py` | Property 4, Property 5 |
+| `test_json_serializable.py` | Property 6 |
+
+### Example Test Coverage
+
+| Requirement | Test Type | What's Verified |
+| --- | --- | --- |
+| 1.1–1.4 (PTID filter for errors) | Example | ptids passed through, filtering works |
+| 2.1–2.4 (PTID filter for status) | Example | ptids passed through, filtering works |
+| 3.4–3.5 (QC summary edge cases) | Example | None returned for missing identifier / no QC data |
+| 4.3–4.4 (Error detail edge cases) | Example | Empty list for missing identifier / no errors |
+| 5.2–5.3 (Visit metadata edge cases) | Example | None returned for missing identifier / no metadata |
+| 7.1–7.4 (Backward compatibility) | Example | Old signatures still work, same output structure |

--- a/.kiro/specs/nacc-common-data-access/nacc-common-v4-prompt.md
+++ b/.kiro/specs/nacc-common-data-access/nacc-common-v4-prompt.md
@@ -1,0 +1,162 @@
+# nacc-common: High-Level Data Access Functions
+
+## Context
+
+The `nacc-common` package (currently v3.0.0) is used by the [NACC Data Platform demo scripts](https://github.com/naccdata/data-platform-demos) to help Alzheimer's Disease Research Centers interact with the NACC Data Platform, which is built on Flywheel.
+
+Centers use these demos as templates for their own automation scripts. We want to **minimize direct Flywheel SDK coupling** in center-facing code so that a future platform migration doesn't break every center's scripts. `nacc-common` is the abstraction layer — centers should depend on it, not on `flywheel-sdk` directly.
+
+### What works well today
+
+The existing high-level functions in `error_data.py` establish the right pattern:
+
+```python
+def get_error_data(project: Project, modules: Optional[set[str]] = None) -> list[dict[str, Any]]
+def get_status_data(project: Project, modules: Optional[set[str]] = None) -> list[dict[str, Any]]
+```
+
+These take a Flywheel `Project`, hide all the visitor/QC-model machinery internally, and return plain dicts. Centers never touch `FileQCModel`, `GearQCModel`, `ValidationModel`, or `FileEntry` directly. This is the pattern we want to extend.
+
+### What's missing
+
+There are several capabilities already implemented in `nacc-common` internals that are not exposed through similarly simple functions. Centers either can't access them at all, or would have to work directly with Flywheel objects and the visitor hierarchy to use them.
+
+## Requested Changes
+
+### 1. Add PTID filtering to `get_error_data` and `get_status_data`
+
+`ProjectReportVisitor` already accepts a `ptid_set` parameter, but the public functions in `error_data.py` don't expose it.
+
+**Current signatures:**
+```python
+def get_error_data(project: Project, modules: Optional[set[str]] = None) -> list[dict[str, Any]]
+def get_status_data(project: Project, modules: Optional[set[str]] = None) -> list[dict[str, Any]]
+```
+
+**Requested signatures:**
+```python
+def get_error_data(
+    project: Project,
+    modules: Optional[set[str]] = None,
+    ptids: Optional[set[str]] = None,
+) -> list[dict[str, Any]]
+
+def get_status_data(
+    project: Project,
+    modules: Optional[set[str]] = None,
+    ptids: Optional[set[str]] = None,
+) -> list[dict[str, Any]]
+```
+
+The `ptids` parameter should be passed through to `ProjectReportVisitor` as `ptid_set`. This is a backward-compatible addition.
+
+### 2. Add per-file QC summary function
+
+`FileQCModel.create(file_entry)` and the gear/validation model hierarchy are powerful but require centers to work with Flywheel `FileEntry` objects and understand the internal QC model structure.
+
+**Requested function** (in `error_data.py` or a new module):
+
+```python
+def get_file_qc_summary(project: Project, filename: str) -> Optional[dict[str, Any]]
+```
+
+**Behavior:**
+- Find the named file in `project.files`
+- Build a `FileQCModel` from it
+- Return a plain dict with:
+  - `"filename"`: the filename
+  - `"overall_status"`: the result of `FileQCModel.get_file_status()` (PASS/FAIL/IN REVIEW)
+  - `"stages"`: a dict mapping gear name → `{"status": QCStatus, "error_count": int}`
+- Return `None` if the file is not found or has no QC data
+
+This gives centers a simple way to check "what happened to my file?" without touching any Flywheel or QC model objects.
+
+### 3. Add per-file error detail function
+
+**Requested function:**
+
+```python
+def get_file_errors(project: Project, filename: str) -> list[dict[str, Any]]
+```
+
+**Behavior:**
+- Find the named file in `project.files`
+- Build a `FileQCModel` from it
+- For each gear, collect errors from `gear_model.get_errors()`
+- Return a flat list of dicts, each containing:
+  - `"stage"`: the gear name
+  - All fields from `FileError.model_dump(by_alias=True)` (type, code, message, location, etc.)
+- Return an empty list if the file is not found or has no errors
+
+### 4. Add per-file visit metadata function
+
+`DataIdentification.from_visit_info(file_entry)` reads visit metadata from a file's `.info.visit` dict, but requires a `FileEntry` object.
+
+**Requested function:**
+
+```python
+def get_file_visit_metadata(project: Project, filename: str) -> Optional[dict[str, Any]]
+```
+
+**Behavior:**
+- Find the named file in `project.files`
+- Call `DataIdentification.from_visit_info(file_entry)`
+- If successful, return `data_id.model_dump()` (the flattened serialization that `DataIdentification` already provides)
+- Return `None` if the file is not found or has no visit metadata
+
+### 5. Add project file listing function
+
+Centers currently have to iterate `project.files` directly and parse filenames to understand what's in a project. A convenience function would help.
+
+**Requested function:**
+
+```python
+def list_project_files(
+    project: Project,
+    modules: Optional[set[str]] = None,
+    ptids: Optional[set[str]] = None,
+) -> list[dict[str, Any]]
+```
+
+**Behavior:**
+- Iterate QC status log files in the project (files matching the `QC_FILENAME_PATTERN` from `qc_report.py`)
+- Apply module and ptid filters (same logic as `ProjectReportVisitor.__should_process_file`)
+- For each matching file, extract visit keys via `extract_visit_keys()` and include `FileQCModel.get_file_status()`
+- Return a list of dicts, each containing:
+  - `"filename"`: the filename
+  - `"ptid"`, `"date"`, `"module"`: extracted from the filename
+  - `"overall_status"`: the file's aggregate QC status (PASS/FAIL/IN REVIEW), or `None` if no QC data
+
+## Design Notes
+
+### Return types
+
+All functions should return plain `dict`/`list[dict]` — not Pydantic models, not Flywheel objects. This keeps the interface serialization-friendly and avoids leaking internal types to centers.
+
+### The `Project` parameter
+
+All functions currently take a Flywheel `Project`. This is acceptable for now since `get_project()` in `pipeline.py` already creates it. Long-term, if the platform changes, these functions are the seam where a protocol or adapter pattern could be introduced — the call sites in center scripts wouldn't change.
+
+### Backward compatibility
+
+- Changes to `get_error_data` and `get_status_data` add optional parameters only — fully backward compatible.
+- New functions are purely additive.
+- No existing behavior should change.
+
+### Testing considerations
+
+The new functions wrap existing tested internals (`FileQCModel.create`, `extract_visit_keys`, `ProjectReportVisitor`). Unit tests should mock the Flywheel `Project` and `FileEntry` objects to verify:
+- Correct filtering by module and ptid
+- Correct dict structure in return values
+- `None`/empty-list returns for missing files or absent QC data
+
+## Usage in Demos
+
+Once these functions are available in `nacc-common`, the demo repo will:
+
+1. Add `--module` and `--ptid` CLI flags to `pull_errors.py` and `pull_status.py`
+2. Create a new `demo/file_status/` demo that calls `get_file_qc_summary` and `get_file_errors` to inspect individual submissions
+3. Create a new `demo/list_files/` demo that calls `list_project_files` to show what's in a project
+4. Potentially create enrollment-specific demos using `datatype="enrollment"`
+
+All of these would use only `nacc-common` public functions + `flywheel.Client` for auth — no direct Flywheel object manipulation.

--- a/.kiro/specs/nacc-common-data-access/requirements.md
+++ b/.kiro/specs/nacc-common-data-access/requirements.md
@@ -1,0 +1,119 @@
+# Requirements Document
+
+## Introduction
+
+The `nacc-common` package (v3.0.0) serves as the abstraction layer between Alzheimer's Disease Research Centers and the NACC Data Platform (built on Flywheel). Centers use `nacc-common` through the [data-platform-demos](https://github.com/naccdata/data-platform-demos) as templates for their own automation scripts. The goal is to minimize direct Flywheel SDK coupling so that a future platform migration does not break center scripts.
+
+The existing public API in `error_data.py` (`get_error_data`, `get_status_data`) establishes the right pattern: accept a Flywheel `Project`, hide internal visitor/QC-model machinery, and return plain dicts. This feature extends that pattern by exposing additional capabilities already implemented in `nacc-common` internals through similarly simple, dict-returning functions. It also adds PTID filtering to the existing functions.
+
+Centers should think in terms of "submissions" — identified by PTID, date, and module — rather than implementation-specific storage details. The underlying storage mechanism (currently file-based) is an internal detail that may be refactored in the future.
+
+## Glossary
+
+- **Project**: A Flywheel `Project` object representing a center's pipeline project, obtained via `get_project()` in `pipeline.py`
+- **Submission**: A logical unit of data submitted by a center, uniquely identified by the combination of PTID, date, and module. The underlying storage representation is an internal implementation detail
+- **QCStatus**: A string literal type with values `"PASS"`, `"FAIL"`, or `"IN REVIEW"`, representing the validation state of a pipeline stage or submission
+- **PTID**: A participant identifier (center-assigned), matching the pattern `[!-~]{1,10}` (printable non-whitespace characters, 1-10 chars)
+- **Module**: A data module identifier (e.g., UDS, LBD, FTLD, NP), always stored and compared in uppercase
+- **Stage**: The name of a processing step in the pipeline (e.g., `"form_qc_checker"`)
+- **Submission_Identifier**: An opaque identifier for a specific submission within a project, used to look up per-submission details. Centers receive these identifiers from listing functions and pass them to detail functions without needing to understand the identifier format
+- **FileQCModel**: Internal Pydantic model (`error_models.py`) representing the QC data structure, containing per-stage validation results (internal, not exposed to centers)
+- **DataIdentification**: Internal Pydantic model (`data_identification.py`) representing composed visit metadata (participant, date, visit, form/image data) with a flattened serialization (internal, not exposed to centers)
+- **FileError**: Internal Pydantic model representing a single error found during pipeline processing, with fields for type, code, message, location, and context (internal, not exposed to centers)
+- **ProjectReportVisitor**: Internal visitor class (`qc_report.py`) that traverses submissions in a project, already supporting `ptid_set` and `modules` filtering (internal, not exposed to centers)
+
+## Requirements
+
+### Requirement 1: PTID Filtering for Error Data
+
+**User Story:** As a center developer, I want to filter error data by participant ID, so that I can retrieve errors for specific participants without downloading the entire project's error set.
+
+#### Acceptance Criteria
+
+1. WHEN `get_error_data` is called with a `ptids` parameter containing a set of PTID strings, THE Error_Data_Module SHALL return only error records for submissions whose PTID is in the provided set
+2. WHEN `get_error_data` is called without a `ptids` parameter, THE Error_Data_Module SHALL return error records for all submissions, preserving the existing behavior
+3. WHEN `get_error_data` is called with both `modules` and `ptids` parameters, THE Error_Data_Module SHALL return only error records matching both filters
+4. THE Error_Data_Module SHALL pass the `ptids` parameter through to the internal filtering mechanism
+
+### Requirement 2: PTID Filtering for Status Data
+
+**User Story:** As a center developer, I want to filter status data by participant ID, so that I can retrieve QC status for specific participants without downloading the entire project's status set.
+
+#### Acceptance Criteria
+
+1. WHEN `get_status_data` is called with a `ptids` parameter containing a set of PTID strings, THE Status_Data_Module SHALL return only status records for submissions whose PTID is in the provided set
+2. WHEN `get_status_data` is called without a `ptids` parameter, THE Status_Data_Module SHALL return status records for all submissions, preserving the existing behavior
+3. WHEN `get_status_data` is called with both `modules` and `ptids` parameters, THE Status_Data_Module SHALL return only status records matching both filters
+4. THE Status_Data_Module SHALL pass the `ptids` parameter through to the internal filtering mechanism
+
+### Requirement 3: Per-Submission QC Summary
+
+**User Story:** As a center developer, I want to get a plain-dict QC summary for a specific submission, so that I can check "what happened to my submission?" without working with Flywheel or QC model objects directly.
+
+#### Acceptance Criteria
+
+1. WHEN `get_submission_qc_summary` is called with a project and a Submission_Identifier that resolves to an existing submission, THE QC_Summary_Function SHALL return a dict containing the key `"identifier"` with the Submission_Identifier value
+2. WHEN `get_submission_qc_summary` is called with a valid Submission_Identifier, THE QC_Summary_Function SHALL return a dict containing the key `"overall_status"` with the aggregate QC status (one of `"PASS"`, `"FAIL"`, or `"IN REVIEW"`)
+3. WHEN `get_submission_qc_summary` is called with a valid Submission_Identifier, THE QC_Summary_Function SHALL return a dict containing the key `"stages"` with a dict mapping each stage name to a dict with keys `"status"` (the stage's QCStatus) and `"error_count"` (the number of errors for that stage)
+4. WHEN `get_submission_qc_summary` is called with a Submission_Identifier that does not resolve to an existing submission, THE QC_Summary_Function SHALL return `None`
+5. WHEN `get_submission_qc_summary` is called with a Submission_Identifier that resolves to a submission with no QC data, THE QC_Summary_Function SHALL return `None`
+6. THE QC_Summary_Function SHALL return a plain `dict`, not a Pydantic model or Flywheel object
+
+### Requirement 4: Per-Submission Error Details
+
+**User Story:** As a center developer, I want to get a flat list of all errors for a specific submission, so that I can inspect individual submission errors without working with Flywheel or QC model objects directly.
+
+#### Acceptance Criteria
+
+1. WHEN `get_submission_errors` is called with a project and a Submission_Identifier that resolves to an existing submission with errors, THE Submission_Error_Function SHALL return a list of dicts, each containing the key `"stage"` with the stage name
+2. WHEN `get_submission_errors` is called with a valid Submission_Identifier, THE Submission_Error_Function SHALL include error detail fields (type, code, message, location, and context) in each error dict
+3. WHEN `get_submission_errors` is called with a Submission_Identifier that does not resolve to an existing submission, THE Submission_Error_Function SHALL return an empty list
+4. WHEN `get_submission_errors` is called with a Submission_Identifier that resolves to a submission with no errors, THE Submission_Error_Function SHALL return an empty list
+5. THE Submission_Error_Function SHALL collect errors from all stages, producing a flat list across all stages
+6. THE Submission_Error_Function SHALL return a list of plain `dict` objects, not Pydantic models or Flywheel objects
+
+### Requirement 5: Per-Submission Visit Metadata
+
+**User Story:** As a center developer, I want to retrieve visit metadata for a specific submission, so that I can inspect participant and visit information without working with Flywheel objects or internal data models directly.
+
+#### Acceptance Criteria
+
+1. WHEN `get_submission_visit_metadata` is called with a project and a Submission_Identifier that resolves to an existing submission with visit metadata, THE Visit_Metadata_Function SHALL return a plain dict containing the visit metadata fields (participant identifiers, date, visit number, module, and packet as applicable)
+2. WHEN `get_submission_visit_metadata` is called with a Submission_Identifier that does not resolve to an existing submission, THE Visit_Metadata_Function SHALL return `None`
+3. WHEN `get_submission_visit_metadata` is called with a Submission_Identifier that resolves to a submission with no visit metadata, THE Visit_Metadata_Function SHALL return `None`
+4. THE Visit_Metadata_Function SHALL return a plain `dict`, not a Pydantic model or Flywheel object
+
+### Requirement 6: Submission Listing
+
+**User Story:** As a center developer, I want to list all submissions in a project with optional filtering, so that I can understand what submissions exist without working with Flywheel objects or understanding the underlying storage format.
+
+#### Acceptance Criteria
+
+1. WHEN `list_submissions` is called with a `modules` parameter, THE Submission_Listing_Function SHALL include only submissions whose module (compared case-insensitively) is in the provided set
+2. WHEN `list_submissions` is called with a `ptids` parameter, THE Submission_Listing_Function SHALL include only submissions whose PTID is in the provided set
+3. WHEN `list_submissions` is called with both `modules` and `ptids` parameters, THE Submission_Listing_Function SHALL include only submissions matching both filters
+4. WHEN `list_submissions` is called without `modules` or `ptids` parameters, THE Submission_Listing_Function SHALL include all submissions in the project
+5. THE Submission_Listing_Function SHALL return a list of dicts, each containing `"identifier"` (the Submission_Identifier), `"ptid"`, `"date"`, and `"module"`
+6. THE Submission_Listing_Function SHALL include `"overall_status"` in each dict, set to the aggregate QC status or `None` if the submission has no QC data
+7. THE Submission_Listing_Function SHALL return a list of plain `dict` objects, not Pydantic models or Flywheel objects
+
+### Requirement 7: Backward Compatibility
+
+**User Story:** As a center developer with existing scripts, I want the new version of `nacc-common` to be fully backward compatible, so that my existing code continues to work without modification.
+
+#### Acceptance Criteria
+
+1. THE Error_Data_Module SHALL accept calls to `get_error_data` with only `project` and optional `modules` parameters, producing identical results to the current v3.0.0 behavior
+2. THE Status_Data_Module SHALL accept calls to `get_status_data` with only `project` and optional `modules` parameters, producing identical results to the current v3.0.0 behavior
+3. THE nacc_common Package SHALL not remove, rename, or change the return type of any existing public function
+4. THE nacc_common Package SHALL not change the structure of dicts returned by existing functions
+
+### Requirement 8: Plain Dict Return Type Contract
+
+**User Story:** As a center developer, I want all public data access functions to return plain Python dicts and lists, so that I can serialize results to JSON or CSV without depending on nacc-common internal types.
+
+#### Acceptance Criteria
+
+1. THE nacc_common Public_API SHALL return `list[dict[str, Any]]` or `Optional[dict[str, Any]]` from all data access functions
+2. THE nacc_common Public_API SHALL not expose Pydantic model instances, Flywheel SDK objects, or internal types in return values
+3. THE nacc_common Public_API SHALL produce return values that are directly serializable via `json.dumps()` without custom encoders

--- a/.kiro/specs/nacc-common-data-access/tasks.md
+++ b/.kiro/specs/nacc-common-data-access/tasks.md
@@ -1,0 +1,128 @@
+# Implementation Plan: NACC Common Data Access
+
+## Overview
+
+Extend `nacc-common`'s public API in `error_data.py` with submission-oriented data access functions. The implementation adds an optional `ptids` parameter to existing functions, introduces two private helpers (`_find_submission`, `_should_include_file`), and four new public functions (`get_submission_qc_summary`, `get_submission_errors`, `get_submission_visit_metadata`, `list_submissions`). All new functions return plain dicts and follow the established patterns in the module.
+
+## Tasks
+
+- [x] 1. Add private helpers and PTID filtering to existing functions
+  - [x] 1.1 Add new imports and implement `_find_submission` and `_should_include_file` in `error_data.py`
+    - Add imports: `re`, `logging`, `FileEntry` from flywheel, `FileQCModel` from `error_models`, `DataIdentification` from `data_identification`, `QC_FILENAME_PATTERN` and `extract_visit_keys` from `qc_report`, `ValidationError` from pydantic
+    - Implement `_find_submission(project, identifier) -> Optional[FileEntry]` — iterates `project.files`, matches by `.name`, calls `file.reload()`, returns `FileEntry` or `None`
+    - Implement `_should_include_file(filename, modules=None, ptids=None) -> bool` — matches filename against `QC_FILENAME_PATTERN`, applies PTID and module filters
+    - _Requirements: 3.4, 4.3, 5.2, 6.1, 6.2_
+  - [x] 1.2 Add optional `ptids` parameter to `get_error_data` and `get_status_data`
+    - Add `ptids: Optional[set[str]] = None` parameter to both function signatures
+    - Pass `ptids` as `ptid_set` to `ProjectReportVisitor` constructor in both functions
+    - Existing calls without `ptids` must continue working identically
+    - _Requirements: 1.1, 1.2, 1.3, 1.4, 2.1, 2.2, 2.3, 2.4, 7.1, 7.2_
+  - [x] 1.3 Write example tests for PTID filtering on `get_error_data` and `get_status_data`
+    - Create `nacc-common/test/python/test_error_data_ptid_filter.py`
+    - Test: calling with `ptids` filters results to matching PTIDs only
+    - Test: calling without `ptids` returns all results (backward compatibility)
+    - Test: calling with both `modules` and `ptids` applies both filters
+    - Mock `Project` with `.files` list of mock `FileEntry` objects, `.info` with `pipeline_adcid`
+    - _Requirements: 1.1, 1.2, 1.3, 2.1, 2.2, 2.3, 7.1, 7.2_
+
+- [x] 2. Implement per-submission QC summary function
+  - [x] 2.1 Implement `get_submission_qc_summary` in `error_data.py`
+    - Signature: `get_submission_qc_summary(project: Project, identifier: str) -> Optional[dict[str, Any]]`
+    - Use `_find_submission` to resolve identifier to `FileEntry`
+    - Build `FileQCModel.create(file_entry)`; return `None` if `qc` dict is empty or `ValidationError` is raised
+    - Return dict with `"identifier"`, `"overall_status"` (from `get_file_status()`), and `"stages"` mapping each gear name to `{"status": gear_model.get_status(), "error_count": len(gear_model.get_errors())}`
+    - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5, 3.6_
+  - [x] 2.2 Write property test for QC summary (Property 1)
+    - Create `nacc-common/test/python/test_submission_qc_summary.py`
+    - **Property 1: QC summary faithfully represents FileQCModel**
+    - **Validates: Requirements 3.1, 3.2, 3.3**
+    - Use Hypothesis to generate `FileQCModel` instances with random gear names, statuses, and error lists
+    - Assert: `"identifier"` matches input, `"overall_status"` matches `get_file_status()`, `"stages"` has entry for every gear with correct status and error count
+  - [ ]* 2.3 Write example tests for QC summary edge cases
+    - Test: returns `None` when identifier doesn't resolve (file not found)
+    - Test: returns `None` when submission has empty `qc` dict
+    - Test: returns `None` when `FileQCModel.create()` raises `ValidationError`
+    - _Requirements: 3.4, 3.5, 3.6_
+
+- [x] 3. Implement per-submission error details function
+  - [x] 3.1 Implement `get_submission_errors` in `error_data.py`
+    - Signature: `get_submission_errors(project: Project, identifier: str) -> list[dict[str, Any]]`
+    - Use `_find_submission` to resolve identifier; return `[]` if not found
+    - Build `FileQCModel.create(file_entry)`; return `[]` on `ValidationError`
+    - Iterate all gears, collect errors via `gear_model.get_errors()`, serialize each `FileError` with `model_dump(by_alias=True)` and add `"stage"` key
+    - _Requirements: 4.1, 4.2, 4.3, 4.4, 4.5, 4.6_
+  - [ ]* 3.2 Write property test for error details (Property 2)
+    - Add to `nacc-common/test/python/test_submission_errors.py`
+    - **Property 2: Error details faithfully represent FileQCModel errors**
+    - **Validates: Requirements 4.1, 4.2, 4.5**
+    - Use Hypothesis to generate `FileQCModel` instances with errors across multiple gears
+    - Assert: total dicts equals sum of `len(gear_model.get_errors())`, each dict has `"stage"` matching gear name and is a superset of `FileError.model_dump(by_alias=True)`
+  - [ ]* 3.3 Write example tests for error details edge cases
+    - Test: returns `[]` when identifier doesn't resolve
+    - Test: returns `[]` when submission has no errors
+    - Test: error dicts include `"stage"` key plus all `FileError` fields serialized with `by_alias=True`
+    - _Requirements: 4.3, 4.4, 4.6_
+
+- [x] 4. Implement per-submission visit metadata function
+  - [x] 4.1 Implement `get_submission_visit_metadata` in `error_data.py`
+    - Signature: `get_submission_visit_metadata(project: Project, identifier: str) -> Optional[dict[str, Any]]`
+    - Use `_find_submission` to resolve identifier; return `None` if not found
+    - Call `DataIdentification.from_visit_info(file_entry)`; return `None` if result is `None`
+    - Return `data_id.model_dump()`
+    - _Requirements: 5.1, 5.2, 5.3, 5.4_
+  - [ ]* 4.2 Write property test for visit metadata (Property 3)
+    - Create `nacc-common/test/python/test_submission_visit_metadata.py`
+    - **Property 3: Visit metadata round trip**
+    - **Validates: Requirements 5.1**
+    - Use Hypothesis to generate visit metadata dicts, mock `FileEntry` with matching `.info.visit` data
+    - Assert: returned dict equals `DataIdentification.from_visit_info(file_entry).model_dump()`
+  - [ ]* 4.3 Write example tests for visit metadata edge cases
+    - Test: returns `None` when identifier doesn't resolve
+    - Test: returns `None` when submission has no visit metadata
+    - Test: returned dict is a plain dict, not a Pydantic model
+    - _Requirements: 5.2, 5.3, 5.4_
+
+- [x] 5. Implement submission listing function
+  - [x] 5.1 Implement `list_submissions` in `error_data.py`
+    - Signature: `list_submissions(project: Project, modules=None, ptids=None) -> list[dict[str, Any]]`
+    - Iterate `project.files`, filter with `_should_include_file`
+    - For each matching file, extract PTID, date, module from filename via `extract_visit_keys`
+    - Attempt `FileQCModel.create()` for `overall_status`; set to `None` on failure
+    - Return list of dicts with `"identifier"`, `"ptid"`, `"date"`, `"module"`, `"overall_status"`
+    - _Requirements: 6.1, 6.2, 6.3, 6.4, 6.5, 6.6, 6.7_
+  - [x] 5.2 Write property test for submission listing filters (Property 4)
+    - Create `nacc-common/test/python/test_list_submissions.py`
+    - **Property 4: Submission listing filter correctness**
+    - **Validates: Requirements 6.1, 6.2, 6.3, 6.4**
+    - Use Hypothesis to generate sets of QC log filenames and filter combinations
+    - Assert: every result dict has `"ptid"` in `ptids` set (when provided) and `"module"` in `modules` set (case-insensitive, when provided)
+  - [ ]* 5.3 Write property test for submission listing output structure (Property 5)
+    - Add to `nacc-common/test/python/test_list_submissions.py`
+    - **Property 5: Submission listing output structure matches identifier**
+    - **Validates: Requirements 6.5, 6.6**
+    - Assert: each dict has `"identifier"`, `"ptid"`, `"date"`, `"module"` matching regex capture groups, and `"overall_status"` matching `FileQCModel.get_file_status()` or `None`
+  - [ ]* 5.4 Write example tests for submission listing edge cases
+    - Test: returns `[]` when project has no QC log files
+    - Test: filters by modules only, ptids only, and both together
+    - Test: gracefully handles individual `ValidationError` by setting `overall_status` to `None`
+    - _Requirements: 6.1, 6.2, 6.3, 6.4, 6.7_
+
+- [x] 6. JSON serialization property test and BUILD configuration
+  - [ ]* 6.1 Write property test for JSON serialization contract (Property 6)
+    - Create `nacc-common/test/python/test_json_serializable.py`
+    - **Property 6: All return values are JSON-serializable plain dicts**
+    - **Validates: Requirements 8.1, 8.2, 8.3**
+    - Use Hypothesis to generate inputs for each public function, assert `json.dumps()` succeeds without custom encoders, assert no `BaseModel` instances or Flywheel objects in results
+  - [x] 6.2 Update `nacc-common/test/python/BUILD` to add `hypothesis` as a test dependency
+    - Add `dependencies=["3rdparty/python#hypothesis"]` to the `python_tests` target (or add to `requirements.txt` if needed)
+    - Verify the existing Hypothesis-based test (`test_property_visit_metadata.py`) pattern for dependency resolution
+    - _Requirements: all property tests depend on this_
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for faster MVP
+- Each task references specific requirements for traceability
+- Property tests validate universal correctness properties from the design document
+- Unit tests validate specific examples and edge cases
+- All functions are implemented in the single file `error_data.py` to keep the public API in one module
+- No checkpoint tasks are included — project hooks enforce quality checks automatically

--- a/docs/nacc_common/CHANGELOG.md
+++ b/docs/nacc_common/CHANGELOG.md
@@ -4,6 +4,16 @@ Documentation of release versions of the `nacc-common` package.
 
 ## Unreleased
 
+## v3.1.0
+
+### New Features
+
+* Adds optional `ptids` parameter to `get_error_data` and `get_status_data` for participant-level filtering (backward compatible).
+* Adds `get_submission_qc_summary` for per-submission QC status and error counts.
+* Adds `get_submission_errors` for a flat list of all errors across pipeline stages for a submission.
+* Adds `get_submission_visit_metadata` for visit metadata lookup by submission identifier.
+* Adds `list_submissions` for listing all submissions in a project with optional module and PTID filtering.
+
 ## v3.0.0
 
 ### Breaking Changes

--- a/nacc-common/BUILD
+++ b/nacc-common/BUILD
@@ -15,7 +15,7 @@ python_distribution(
     sdist=True,
     provides=python_artifact(
         name="nacc-common",
-        version="3.0.0",
+        version="3.1.0",
     ),
     # Don't generate setup.py
     generate_setup=False,

--- a/nacc-common/pyproject.toml
+++ b/nacc-common/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nacc-common"
-version = "3.0.0"
+version = "3.1.0"
 description = "NACC Data Platform utilities"
 license-files = ["LICENSE"]
 authors = [{ name = "NACC", email = "nacchelp@uw.edu" }]

--- a/nacc-common/src/python/nacc_common/error_data.py
+++ b/nacc-common/src/python/nacc_common/error_data.py
@@ -1,11 +1,19 @@
+import logging
+import re
 from typing import Any, Optional
 
+from flywheel.models.file_entry import FileEntry
 from flywheel.models.project import Project
+from pydantic import ValidationError
 
+from nacc_common.data_identification import DataIdentification
+from nacc_common.error_models import FileQCModel
 from nacc_common.qc_report import (
+    QC_FILENAME_PATTERN,
     ListReportWriter,
     ProjectReportVisitor,
     WriterTableVisitor,
+    extract_visit_keys,
 )
 from nacc_common.visit_submission_error import (
     ErrorReportModel,
@@ -15,6 +23,8 @@ from nacc_common.visit_submission_status import (
     StatusReportModel,
     status_report_visitor_builder,
 )
+
+log = logging.getLogger(__name__)
 
 ModuleName = str
 
@@ -41,14 +51,66 @@ def get_pipeline_adcid(project: Project) -> Optional[int]:
     return int(adcid)
 
 
+def _find_submission(project: Project, identifier: str) -> Optional[FileEntry]:
+    """Resolves an opaque submission identifier to the underlying FileEntry.
+
+    Currently the identifier maps to a QC status log filename, but this is an
+    implementation detail hidden behind this helper.
+
+    Args:
+      project: the flywheel project object
+      identifier: the opaque submission identifier
+    Returns:
+      the FileEntry if found, None otherwise
+    """
+    for file in project.files:
+        if file.name == identifier:
+            file = file.reload()
+            return file
+    return None
+
+
+def _should_include_file(
+    filename: str,
+    modules: Optional[set[str]] = None,
+    ptids: Optional[set[str]] = None,
+) -> bool:
+    """Determines whether a QC log file should be included based on filters.
+
+    Matches the filename against QC_FILENAME_PATTERN and applies optional PTID
+    and module filters.
+
+    Args:
+      filename: the filename to check
+      modules: optional set of module names to filter by (compared upper-cased)
+      ptids: optional set of PTIDs to filter by
+    Returns:
+      True if the file matches the pattern and passes all filters
+    """
+    match = re.match(QC_FILENAME_PATTERN, filename)
+    if not match:
+        return False
+
+    ptid = match.group(1)
+    if ptids is not None and ptid not in ptids:
+        return False
+
+    module = match.group(3).upper()
+    return modules is None or module in modules
+
+
 def get_status_data(
-    project: Project, modules: Optional[set[str]] = None
+    project: Project,
+    modules: Optional[set[str]] = None,
+    ptids: Optional[set[str]] = None,
 ) -> list[dict[str, Any]]:
     """Returns a list of dictionaries containing QC status data for files in
     the project.
 
     Args:
       project: the project
+      modules: optional set of module names to filter by
+      ptids: optional set of PTIDs to filter by
     Returns:
       a list containing status info objects for files in the project
     Raises:
@@ -64,6 +126,7 @@ def get_status_data(
     project_visitor = ProjectReportVisitor(
         adcid=adcid,
         modules=modules,
+        ptid_set=ptids,
         file_visitor_factory=status_report_visitor_builder,
         table_visitor=WriterTableVisitor(ListReportWriter(result)),
     )
@@ -73,13 +136,17 @@ def get_status_data(
 
 
 def get_error_data(
-    project: Project, modules: Optional[set[str]] = None
+    project: Project,
+    modules: Optional[set[str]] = None,
+    ptids: Optional[set[str]] = None,
 ) -> list[dict[str, Any]]:
     """Creates a list of dictionaries, each corresponding to an error in a file
     in the project.
 
     Args:
       project: the flywheel project object
+      modules: optional set of module names to filter by
+      ptids: optional set of PTIDs to filter by
     Returns:
       a list contain error info objects for files in the project
     Raises:
@@ -95,9 +162,158 @@ def get_error_data(
     project_visitor = ProjectReportVisitor(
         adcid=adcid,
         modules=modules,
+        ptid_set=ptids,
         file_visitor_factory=error_report_visitor_builder,
         table_visitor=WriterTableVisitor(list_writer),
     )
     project_visitor.visit_project(project)
+
+    return result
+
+
+def get_submission_qc_summary(
+    project: Project, identifier: str
+) -> Optional[dict[str, Any]]:
+    """Returns a plain-dict QC summary for a specific submission.
+
+    Resolves the identifier to a submission, builds a FileQCModel, and returns
+    a dict with the overall status and per-stage status/error counts.
+
+    Args:
+      project: the flywheel project object
+      identifier: the opaque submission identifier
+    Returns:
+      a dict with "identifier", "overall_status", and "stages", or None if the
+      submission is not found, has no QC data, or QC data is malformed
+    """
+    file_entry = _find_submission(project, identifier)
+    if file_entry is None:
+        return None
+
+    try:
+        qc_model = FileQCModel.create(file_entry)
+    except ValidationError:
+        return None
+
+    if not qc_model.qc:
+        return None
+
+    stages: dict[str, dict[str, Any]] = {}
+    for gear_name, gear_model in qc_model.qc.items():
+        stages[gear_name] = {
+            "status": gear_model.get_status(),
+            "error_count": len(gear_model.get_errors()),
+        }
+
+    return {
+        "identifier": identifier,
+        "overall_status": qc_model.get_file_status(),
+        "stages": stages,
+    }
+
+
+def get_submission_errors(project: Project, identifier: str) -> list[dict[str, Any]]:
+    """Returns a flat list of error dicts for a specific submission.
+
+    Resolves the identifier to a submission, builds a FileQCModel, and
+    collects all errors across all stages. Each error dict includes all
+    FileError fields (serialized with aliases) plus a "stage" key.
+
+    Args:
+      project: the flywheel project object
+      identifier: the opaque submission identifier
+    Returns:
+      a list of error dicts, or an empty list if the submission is not
+      found, has no errors, or QC data is malformed
+    """
+    file_entry = _find_submission(project, identifier)
+    if file_entry is None:
+        return []
+
+    try:
+        qc_model = FileQCModel.create(file_entry)
+    except ValidationError:
+        return []
+
+    errors: list[dict[str, Any]] = []
+    for gear_name, gear_model in qc_model.qc.items():
+        for file_error in gear_model.get_errors():
+            error_dict = file_error.model_dump(by_alias=True)
+            error_dict["stage"] = gear_name
+            errors.append(error_dict)
+
+    return errors
+
+
+def get_submission_visit_metadata(
+    project: Project, identifier: str
+) -> Optional[dict[str, Any]]:
+    """Returns visit metadata for a specific submission as a plain dict.
+
+    Resolves the identifier to a submission and extracts visit metadata
+    using DataIdentification.from_visit_info().
+
+    Args:
+      project: the flywheel project object
+      identifier: the opaque submission identifier
+    Returns:
+      a dict with visit metadata fields (participant identifiers, date,
+      visit number, module/modality, packet), or None if the submission
+      is not found or has no visit metadata
+    """
+    file_entry = _find_submission(project, identifier)
+    if file_entry is None:
+        return None
+
+    data_id = DataIdentification.from_visit_info(file_entry)
+    if data_id is None:
+        return None
+
+    return data_id.model_dump()
+
+
+def list_submissions(
+    project: Project,
+    modules: Optional[set[str]] = None,
+    ptids: Optional[set[str]] = None,
+) -> list[dict[str, Any]]:
+    """Returns a list of submission summary dicts for QC log files in the
+    project, with optional filtering by module and/or PTID.
+
+    For each matching file, extracts visit keys from the filename and
+    attempts to determine the overall QC status. If the QC data is
+    missing or malformed, overall_status is set to None.
+
+    Args:
+      project: the flywheel project object
+      modules: optional set of module names to filter by (compared upper-cased)
+      ptids: optional set of PTIDs to filter by
+    Returns:
+      a list of dicts, each with "identifier", "ptid", "date", "module",
+      and "overall_status"
+    """
+    result: list[dict[str, Any]] = []
+
+    for file in project.files:
+        if not _should_include_file(file.name, modules=modules, ptids=ptids):
+            continue
+
+        visit_keys = extract_visit_keys(file)
+
+        try:
+            qc_model = FileQCModel.create(file)
+            overall_status: Optional[str] = qc_model.get_file_status()
+        except ValidationError:
+            overall_status = None
+
+        result.append(
+            {
+                "identifier": file.name,
+                "ptid": visit_keys.ptid,
+                "date": visit_keys.date,
+                "module": visit_keys.module,
+                "overall_status": overall_status,
+            }
+        )
 
     return result

--- a/nacc-common/test/python/test_error_data_ptid_filter.py
+++ b/nacc-common/test/python/test_error_data_ptid_filter.py
@@ -1,0 +1,267 @@
+"""Tests for PTID filtering on get_error_data and get_status_data.
+
+Verifies that the optional `ptids` parameter correctly filters results
+by participant ID, maintains backward compatibility when omitted, and
+works in combination with `modules` filtering.
+
+Requirements: 1.1, 1.2, 1.3, 2.1, 2.2, 2.3, 7.1, 7.2
+"""
+
+from unittest.mock import MagicMock, patch
+
+from nacc_common.error_data import get_error_data, get_status_data
+
+
+def _make_file_entry(ptid: str, date: str, module: str, qc_data: dict) -> MagicMock:
+    """Create a mock FileEntry with a QC log filename and info.
+
+    The file.info dict contains both the QC data and visit metadata matching
+    the filename, which mirrors how real Flywheel files are structured.
+
+    Args:
+        ptid: participant identifier
+        date: visit date (YYYY-MM-DD)
+        module: module name (e.g. UDS, LBD)
+        qc_data: dict representing QC data to place in file.info.qc
+
+    Returns:
+        MagicMock that behaves like a FileEntry for ProjectReportVisitor
+    """
+    filename = f"{ptid}_{date}_{module}_qc-status.log"
+    file_entry = MagicMock()
+    file_entry.name = filename
+    file_entry.info = {"qc": qc_data}
+    file_entry.reload.return_value = file_entry
+    return file_entry
+
+
+def _make_project(files: list, adcid: int = 42) -> MagicMock:
+    """Create a mock Project with file entries and pipeline ADCID.
+
+    Args:
+        files: list of mock FileEntry objects
+        adcid: pipeline ADCID value
+
+    Returns:
+        MagicMock that behaves like a flywheel Project
+    """
+    project = MagicMock()
+    project.files = files
+    project.info = {"pipeline_adcid": adcid}
+    project.label = "test-project"
+    project.reload.return_value = project
+    return project
+
+
+def _qc_with_errors(ptid: str) -> dict:
+    """Return a QC data structure with one gear that has one error.
+
+    The error includes the ptid so that the serialized error record
+    identifies which participant the error belongs to.
+
+    Args:
+        ptid: participant identifier to embed in the error
+    """
+    return {
+        "form_qc_checker": {
+            "validation": {
+                "state": "FAIL",
+                "data": [
+                    {
+                        "type": "error",
+                        "code": "VAL001",
+                        "message": "validation failed",
+                        "ptid": ptid,
+                    }
+                ],
+                "cleared": [],
+            }
+        }
+    }
+
+
+def _qc_passing() -> dict:
+    """Return a QC data structure with one gear that passes."""
+    return {
+        "form_qc_checker": {
+            "validation": {
+                "state": "PASS",
+                "data": [],
+                "cleared": [],
+            }
+        }
+    }
+
+
+class TestGetErrorDataPtidFilter:
+    """Tests for PTID filtering on get_error_data."""
+
+    def test_ptids_filters_to_matching_only(self):
+        """Calling with ptids returns errors only for matching PTIDs.
+
+        Validates: Requirements 1.1
+        """
+        files = [
+            _make_file_entry("PT001", "2024-01-15", "UDS", _qc_with_errors("PT001")),
+            _make_file_entry("PT002", "2024-01-16", "UDS", _qc_with_errors("PT002")),
+            _make_file_entry("PT003", "2024-01-17", "UDS", _qc_with_errors("PT003")),
+        ]
+        project = _make_project(files)
+
+        result = get_error_data(project, ptids={"PT001", "PT003"})
+
+        ptids_in_result = {row["ptid"] for row in result}
+        assert ptids_in_result == {"PT001", "PT003"}
+        assert "PT002" not in ptids_in_result
+
+    def test_no_ptids_returns_all(self):
+        """Calling without ptids returns errors for all submissions.
+
+        Validates: Requirements 1.2, 7.1
+        """
+        files = [
+            _make_file_entry("PT001", "2024-01-15", "UDS", _qc_with_errors("PT001")),
+            _make_file_entry("PT002", "2024-01-16", "UDS", _qc_with_errors("PT002")),
+            _make_file_entry("PT003", "2024-01-17", "UDS", _qc_with_errors("PT003")),
+        ]
+        project = _make_project(files)
+
+        result = get_error_data(project)
+
+        ptids_in_result = {row["ptid"] for row in result}
+        assert ptids_in_result == {"PT001", "PT002", "PT003"}
+
+    def test_modules_and_ptids_applies_both_filters(self):
+        """Calling with both modules and ptids applies both filters.
+
+        Validates: Requirements 1.3
+        """
+        files = [
+            _make_file_entry("PT001", "2024-01-15", "UDS", _qc_with_errors("PT001")),
+            _make_file_entry("PT001", "2024-01-16", "LBD", _qc_with_errors("PT001")),
+            _make_file_entry("PT002", "2024-01-17", "UDS", _qc_with_errors("PT002")),
+            _make_file_entry("PT002", "2024-01-18", "LBD", _qc_with_errors("PT002")),
+        ]
+        project = _make_project(files)
+
+        result = get_error_data(project, modules={"UDS"}, ptids={"PT001"})
+
+        assert len(result) == 1
+        assert result[0]["ptid"] == "PT001"
+        assert result[0]["module"] == "UDS"
+
+    def test_backward_compatible_with_modules_only(self):
+        """Calling with only modules (no ptids) works as before.
+
+        Validates: Requirements 7.1
+        """
+        files = [
+            _make_file_entry("PT001", "2024-01-15", "UDS", _qc_with_errors("PT001")),
+            _make_file_entry("PT001", "2024-01-16", "LBD", _qc_with_errors("PT001")),
+        ]
+        project = _make_project(files)
+
+        result = get_error_data(project, modules={"UDS"})
+
+        assert len(result) == 1
+        assert result[0]["module"] == "UDS"
+
+    def test_empty_ptids_set_returns_nothing(self):
+        """Calling with an empty ptids set returns no results."""
+        files = [
+            _make_file_entry("PT001", "2024-01-15", "UDS", _qc_with_errors("PT001")),
+        ]
+        project = _make_project(files)
+
+        result = get_error_data(project, ptids=set())
+
+        assert result == []
+
+
+class TestGetStatusDataPtidFilter:
+    """Tests for PTID filtering on get_status_data.
+
+    These tests verify that ptids is correctly wired through to
+    ProjectReportVisitor as ptid_set.
+    """
+
+    def test_ptids_passed_to_visitor(self):
+        """The ptids parameter is passed through as ptid_set to
+        ProjectReportVisitor.
+
+        Validates: Requirements 2.1, 2.2, 2.3
+        """
+        files = [
+            _make_file_entry("PT001", "2024-01-15", "UDS", _qc_passing()),
+            _make_file_entry("PT002", "2024-01-16", "UDS", _qc_passing()),
+        ]
+        project = _make_project(files)
+
+        with patch("nacc_common.error_data.ProjectReportVisitor") as mock_visitor_cls:
+            mock_visitor = MagicMock()
+            mock_visitor_cls.return_value = mock_visitor
+
+            get_status_data(project, ptids={"PT001"})
+
+            mock_visitor_cls.assert_called_once()
+            call_kwargs = mock_visitor_cls.call_args
+            assert call_kwargs.kwargs["ptid_set"] == {"PT001"}
+
+    def test_no_ptids_passes_none_to_visitor(self):
+        """Calling without ptids passes None for ptid_set, preserving existing
+        behavior.
+
+        Validates: Requirements 2.2, 7.2
+        """
+        files = [
+            _make_file_entry("PT001", "2024-01-15", "UDS", _qc_passing()),
+        ]
+        project = _make_project(files)
+
+        with patch("nacc_common.error_data.ProjectReportVisitor") as mock_visitor_cls:
+            mock_visitor = MagicMock()
+            mock_visitor_cls.return_value = mock_visitor
+
+            get_status_data(project)
+
+            call_kwargs = mock_visitor_cls.call_args
+            assert call_kwargs.kwargs["ptid_set"] is None
+
+    def test_modules_and_ptids_both_passed(self):
+        """Calling with both modules and ptids passes both to the visitor.
+
+        Validates: Requirements 2.3
+        """
+        files = [
+            _make_file_entry("PT001", "2024-01-15", "UDS", _qc_passing()),
+        ]
+        project = _make_project(files)
+
+        with patch("nacc_common.error_data.ProjectReportVisitor") as mock_visitor_cls:
+            mock_visitor = MagicMock()
+            mock_visitor_cls.return_value = mock_visitor
+
+            get_status_data(project, modules={"UDS"}, ptids={"PT001"})
+
+            call_kwargs = mock_visitor_cls.call_args
+            assert call_kwargs.kwargs["ptid_set"] == {"PT001"}
+            assert call_kwargs.kwargs["modules"] == {"UDS"}
+
+    def test_backward_compatible_without_ptids(self):
+        """Existing call signature with only project works.
+
+        Validates: Requirements 7.2
+        """
+        files = [
+            _make_file_entry("PT001", "2024-01-15", "UDS", _qc_passing()),
+        ]
+        project = _make_project(files)
+
+        with patch("nacc_common.error_data.ProjectReportVisitor") as mock_visitor_cls:
+            mock_visitor = MagicMock()
+            mock_visitor_cls.return_value = mock_visitor
+
+            # Call with just project — should not raise
+            get_status_data(project)
+
+            mock_visitor_cls.assert_called_once()

--- a/nacc-common/test/python/test_list_submissions.py
+++ b/nacc-common/test/python/test_list_submissions.py
@@ -1,0 +1,167 @@
+"""Property test for list_submissions.
+
+**Feature: nacc-common-data-access,
+  Property 4: Submission listing filter correctness**
+**Validates: Requirements 6.1, 6.2, 6.3, 6.4**
+"""
+
+import datetime
+from typing import Optional
+from unittest.mock import MagicMock
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from nacc_common.error_data import list_submissions
+
+# ---------------------------------------------------------------------------
+# Hypothesis strategies
+# ---------------------------------------------------------------------------
+
+# PTID: printable non-whitespace ASCII chars, 1-10 length
+# Matches QC_FILENAME_PATTERN group 1: [!-~]{1,10}
+# - Exclude underscore to prevent ambiguity in filename parsing
+# - Use alphanumeric chars that won't be altered by normalize_ptid
+#   (which strips leading zeros). Start with a letter to avoid
+#   all-zero or leading-zero PTIDs that normalize to something different.
+ptid_strategy = st.from_regex(r"[a-zA-Z][a-zA-Z0-9]{0,9}", fullmatch=True)
+
+# Module: word characters (\w+), at least 1 char
+module_strategy = st.from_regex(r"[A-Za-z][A-Za-z0-9]{0,5}", fullmatch=True)
+
+# Date: YYYY-MM-DD format with 4-digit year (required by QC_FILENAME_PATTERN)
+date_strategy = st.dates(
+    min_value=datetime.date(1000, 1, 1),
+    max_value=datetime.date(9999, 12, 31),
+).map(lambda d: d.strftime("%Y-%m-%d"))
+
+
+@st.composite
+def qc_filename_strategy(draw: st.DrawFn) -> tuple[str, str, str, str]:
+    """Generate a valid QC log filename and its components.
+
+    Returns (filename, ptid, date, module).
+    """
+    ptid = draw(ptid_strategy)
+    date = draw(date_strategy)
+    module = draw(module_strategy)
+    filename = f"{ptid}_{date}_{module}_qc-status.log"
+    return (filename, ptid, date, module)
+
+
+def _make_mock_file(filename: str) -> MagicMock:
+    """Create a mock FileEntry with the given filename and minimal QC info."""
+    mock_file = MagicMock()
+    mock_file.name = filename
+    mock_file.reload.return_value = mock_file
+    # Provide empty qc info so FileQCModel.create succeeds with empty qc
+    mock_file.info = {"qc": {}}
+    return mock_file
+
+
+@st.composite
+def files_and_filters_strategy(
+    draw: st.DrawFn,
+) -> tuple[list[tuple[str, str, str, str]], Optional[set[str]], Optional[set[str]]]:
+    """Generate a list of QC log file entries and a filter combination.
+
+    Returns (file_entries, modules_filter, ptids_filter).
+    """
+    file_entries = draw(
+        st.lists(
+            qc_filename_strategy(),
+            min_size=1,
+            max_size=10,
+            unique_by=lambda entry: entry[0],
+        )
+    )
+
+    all_ptids = sorted({entry[1] for entry in file_entries})
+    all_modules_upper = sorted({entry[3].upper() for entry in file_entries})
+
+    # Choose filter mode: none, modules only, ptids only, both
+    mode = draw(st.sampled_from(["none", "modules", "ptids", "both"]))
+
+    modules_filter: Optional[set[str]] = None
+    ptids_filter: Optional[set[str]] = None
+
+    if mode in ("modules", "both"):
+        # Pick a subset of known modules, possibly with extras
+        known_subset = draw(
+            st.lists(
+                st.sampled_from(all_modules_upper),
+                min_size=0,
+                max_size=len(all_modules_upper),
+                unique=True,
+            )
+        )
+        extra = draw(st.lists(module_strategy, min_size=0, max_size=2, unique=True))
+        modules_filter = {m.upper() for m in known_subset} | {m.upper() for m in extra}
+
+    if mode in ("ptids", "both"):
+        # Pick a subset of known ptids, possibly with extras
+        known_subset = draw(
+            st.lists(
+                st.sampled_from(all_ptids),
+                min_size=0,
+                max_size=len(all_ptids),
+                unique=True,
+            )
+        )
+        extra = draw(st.lists(ptid_strategy, min_size=0, max_size=2, unique=True))
+        ptids_filter = set(known_subset) | set(extra)
+
+    return (file_entries, modules_filter, ptids_filter)
+
+
+# ---------------------------------------------------------------------------
+# Property test
+# ---------------------------------------------------------------------------
+
+
+@given(data=files_and_filters_strategy())
+@settings(max_examples=100)
+def test_submission_listing_filter_correctness(
+    data: tuple[
+        list[tuple[str, str, str, str]], Optional[set[str]], Optional[set[str]]
+    ],
+):
+    """Property 4: Submission listing filter correctness.
+
+    **Feature: nacc-common-data-access,
+      Property 4: Submission listing filter correctness**
+    **Validates: Requirements 6.1, 6.2, 6.3, 6.4**
+
+    For any set of QC log files and any combination of modules and ptids
+    filters, every dict in the list returned by list_submissions SHALL
+    have a "ptid" value in the ptids set (when provided) AND a "module"
+    value (compared case-insensitively) in the modules set (when provided).
+    When neither filter is provided, the result SHALL include all QC log
+    files.
+    """
+    file_entries, modules_filter, ptids_filter = data
+
+    # Arrange — build mock project with mock FileEntry objects
+    mock_files = [_make_mock_file(entry[0]) for entry in file_entries]
+    mock_project = MagicMock()
+    mock_project.files = mock_files
+
+    # Act
+    result = list_submissions(mock_project, modules=modules_filter, ptids=ptids_filter)
+
+    # Assert — filter correctness on every result dict
+    for item in result:
+        if ptids_filter is not None:
+            assert item["ptid"] in ptids_filter, (
+                f"ptid {item['ptid']!r} not in filter {ptids_filter}"
+            )
+        if modules_filter is not None:
+            assert item["module"].upper() in modules_filter, (
+                f"module {item['module']!r} (upper: {item['module'].upper()!r}) "
+                f"not in filter {modules_filter}"
+            )
+
+    # When no filters are provided, result must include all QC log files
+    if modules_filter is None and ptids_filter is None:
+        assert len(result) == len(file_entries), (
+            f"Expected {len(file_entries)} results with no filters, got {len(result)}"
+        )

--- a/nacc-common/test/python/test_submission_qc_summary.py
+++ b/nacc-common/test/python/test_submission_qc_summary.py
@@ -1,0 +1,129 @@
+"""Property test for get_submission_qc_summary.
+
+**Feature: nacc-common-data-access,
+  Property 1: QC summary faithfully represents FileQCModel**
+**Validates: Requirements 3.1, 3.2, 3.3**
+"""
+
+from typing import Dict, Optional
+from unittest.mock import MagicMock, patch
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from nacc_common.error_data import get_submission_qc_summary
+from nacc_common.error_models import (
+    FileError,
+    FileQCModel,
+    GearQCModel,
+    QCStatus,
+    ValidationModel,
+)
+
+# ---------------------------------------------------------------------------
+# Hypothesis strategies
+# ---------------------------------------------------------------------------
+
+# Gear names: non-empty, reasonable identifiers (alphanumeric + underscore)
+gear_name_strategy = st.from_regex(r"[a-z][a-z0-9_]{0,29}", fullmatch=True)
+
+qc_status_strategy: st.SearchStrategy[Optional[QCStatus]] = st.sampled_from(
+    ["PASS", "FAIL", "IN REVIEW", None]
+)
+
+file_error_strategy: st.SearchStrategy[FileError] = st.builds(
+    FileError,
+    error_type=st.sampled_from(["alert", "error", "warning"]),
+    error_code=st.from_regex(r"[A-Z]{2,4}[0-9]{3}", fullmatch=True),
+    message=st.text(min_size=1, max_size=50),
+)
+
+gear_qc_model_strategy: st.SearchStrategy[GearQCModel] = st.builds(
+    GearQCModel,
+    validation=st.builds(
+        ValidationModel,
+        data=st.lists(file_error_strategy, min_size=0, max_size=5),
+        state=qc_status_strategy,
+        cleared=st.just([]),
+    ),
+)
+
+
+@st.composite
+def file_qc_model_strategy(draw: st.DrawFn) -> FileQCModel:
+    """Generate a FileQCModel with at least one gear."""
+    gear_names = draw(st.lists(gear_name_strategy, min_size=1, max_size=5, unique=True))
+    qc: Dict[str, GearQCModel] = {}
+    for name in gear_names:
+        qc[name] = draw(gear_qc_model_strategy)
+    return FileQCModel(qc=qc)
+
+
+# ---------------------------------------------------------------------------
+# Property test
+# ---------------------------------------------------------------------------
+
+
+@given(
+    file_qc=file_qc_model_strategy(),
+    identifier=st.text(min_size=1, max_size=60),
+)
+@settings(max_examples=100)
+def test_qc_summary_faithfully_represents_file_qc_model(
+    file_qc: FileQCModel,
+    identifier: str,
+):
+    """Property 1: QC summary faithfully represents FileQCModel.
+
+    **Feature: nacc-common-data-access,
+      Property 1: QC summary faithfully represents FileQCModel**
+    **Validates: Requirements 3.1, 3.2, 3.3**
+
+    For any valid FileQCModel with at least one gear,
+    get_submission_qc_summary SHALL return a dict where:
+    - "identifier" equals the input identifier
+    - "overall_status" equals FileQCModel.get_file_status()
+    - "stages" contains an entry for every gear in the model, where each
+      entry's "status" matches gear_model.get_status() and "error_count"
+      equals len(gear_model.get_errors())
+    """
+    # Arrange — build a mock project whose _find_submission returns a
+    # FileEntry that produces our generated FileQCModel.
+    mock_project = MagicMock()
+    mock_file_entry = MagicMock()
+    mock_file_entry.reload.return_value = mock_file_entry
+
+    with (
+        patch(
+            "nacc_common.error_data._find_submission",
+            return_value=mock_file_entry,
+        ),
+        patch(
+            "nacc_common.error_data.FileQCModel.create",
+            return_value=file_qc,
+        ),
+    ):
+        # Act
+        result = get_submission_qc_summary(mock_project, identifier)
+
+    # Assert — result must not be None since file_qc always has ≥1 gear
+    assert result is not None, "Expected a dict, got None"
+
+    # 3.1 — identifier matches
+    assert result["identifier"] == identifier
+
+    # 3.2 — overall_status matches get_file_status()
+    assert result["overall_status"] == file_qc.get_file_status()
+
+    # 3.3 — stages has entry for every gear with correct status & error count
+    assert set(result["stages"].keys()) == set(file_qc.qc.keys()), (
+        "stages keys must match gear names in the model"
+    )
+
+    for gear_name, gear_model in file_qc.qc.items():
+        stage = result["stages"][gear_name]
+        assert stage["status"] == gear_model.get_status(), (
+            f"status mismatch for gear {gear_name}"
+        )
+        assert stage["error_count"] == len(gear_model.get_errors()), (
+            f"error_count mismatch for gear {gear_name}"
+        )


### PR DESCRIPTION
## Add submission-oriented data access API to nacc-common

Extends `error_data.py` so centers can query per-submission QC summaries, errors, visit metadata, and submission listings using plain dicts — no Flywheel SDK or internal model exposure.

### What changed

- Added `get_submission_qc_summary`, `get_submission_errors`, `get_submission_visit_metadata`, `list_submissions`
- Added optional `ptids` filter to `get_error_data` and `get_status_data` (backward compatible)
- Added private helpers `_find_submission` and `_should_include_file`

### Testing

- 9 example tests for PTID filtering and backward compatibility
- 2 Hypothesis property tests (QC summary fidelity, listing filter correctness)

### Note

Version changed to 3.1.0
