### PR TITLE
Feature/disable users

### DIFF
--- a/.kiro/hooks/post-task-quality-check.kiro.hook
+++ b/.kiro/hooks/post-task-quality-check.kiro.hook
@@ -1,13 +1,13 @@
 {
   "enabled": true,
   "name": "Quality Check After Task Completion",
-  "description": "Runs full quality check (fix, lint, check, test) on the relevant code after a spec task is marked as completed, but only if code was actually modified",
-  "version": "1",
+  "description": "Runs full quality check (fix, lint, check, test) after a spec task is completed, but only if Python code was modified",
+  "version": "2",
   "when": {
     "type": "postTaskExecution"
   },
   "then": {
     "type": "askAgent",
-    "prompt": "A spec task was just completed. First, check if this task involved creating or modifying any Python code files (.py files). If NO code files were modified (e.g., only documentation, configuration, or planning tasks), respond with 'No code changes detected, skipping quality check.' and stop. If code WAS modified, run the full quality check workflow using the kiro-pants-power on the appropriate scope for the code that was modified. Use scope='directory' with the path to the gear or module that was worked on (e.g., path='gear/image_identifier_lookup/src/python' for image identifier lookup tasks), or scope='all' if changes span multiple areas. After running the quality check, report the results. If any checks fail, fix the issues and re-run the quality check until all checks pass."
+    "prompt": "A spec task was just completed. First, check if this task involved creating or modifying any Python code files (.py files). If NO code files were modified (e.g., only documentation, configuration, or planning tasks), respond with 'No code changes detected, skipping quality check.' and stop. If code WAS modified, you MUST call the kiro-pants-power full_quality_check tool with NO arguments (it defaults to scope='all' which runs fix, lint, check, and test on the entire codebase). Do NOT run individual pants tools (pants_fix, pants_lint, pants_check, pants_test) separately — use ONLY full_quality_check. Do NOT scope to a subdirectory — mypy errors in test files will be missed if you only check source directories. If full_quality_check fails, fix the issues and re-run full_quality_check until it passes."
   }
 }

--- a/.kiro/specs/disable-inactive-comanage-users/.config.kiro
+++ b/.kiro/specs/disable-inactive-comanage-users/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "49d51e77-787e-4f47-857f-bf39fd35322f", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/disable-inactive-comanage-users/design.md
+++ b/.kiro/specs/disable-inactive-comanage-users/design.md
@@ -1,0 +1,325 @@
+# Design Document: Disable Inactive COmanage Users
+
+## Overview
+
+This feature extends the existing inactive user workflow to suspend users in the COmanage registry when they are marked inactive in the NACC directory. Currently, `InactiveUserProcess` only disables users in Flywheel. After this change, it will also set the CO Person status to `"S"` (Suspended) in COmanage, revoking downstream OIDC authorization. A complementary re-enable path in `ActiveUserProcess` restores suspended users who become active again, avoiding duplicate record creation.
+
+The design follows the existing codebase patterns:
+- `UserRegistry` gains update capability (currently only has `add` and `get`)
+- `InactiveUserProcess` gains COmanage suspension (currently only disables in Flywheel)
+- `ActiveUserProcess` gains re-enable detection (currently only creates new records or routes to claimed/unclaimed queues)
+- All new write operations respect the existing dry-run mode pattern from `FlywheelProxy`
+
+## Architecture
+
+The feature integrates into the existing user management gear architecture without introducing new services or dependencies.
+
+```mermaid
+flowchart TD
+    A[UserProcess] --> B{entry.active?}
+    B -->|Yes| C[ActiveUserProcess]
+    B -->|No| D[InactiveUserProcess]
+
+    D --> E[Disable in Flywheel]
+    D --> F[Suspend in COmanage]
+    E -.->|independent| F
+
+    C --> G{Matching registry person?}
+    G -->|Yes, status=S| H[Re-enable in COmanage]
+    G -->|Yes, status=A| I[Existing claimed/unclaimed flow]
+    G -->|No| J[Create new registry record]
+
+    F --> K[UserRegistry.suspend]
+    H --> L[UserRegistry.re-enable]
+    K --> M[GET full CoPersonMessage]
+    L --> M
+    M --> N[Modify only CoPerson.status]
+    N --> O[PUT full CoPersonMessage]
+```
+
+### Key Design Decisions
+
+1. **Read-modify-write pattern**: The COmanage Core API PUT endpoint does not support patch semantics. Omitting related models causes the API to delete them. The update flow must always: GET the full `CoPersonMessage`, modify only the status field, PUT the entire record back.
+
+2. **Service independence**: Flywheel disable and COmanage suspend are independent operations. A failure in one does not prevent the other. This matches the existing error-handling philosophy where individual user processing errors are logged but don't stop batch processing.
+
+3. **Dry-run at the registry level**: Rather than adding dry-run awareness to `InactiveUserProcess` and `ActiveUserProcess`, the `UserRegistry` itself accepts a `dry_run` flag. This mirrors how `FlywheelProxy` handles dry-run — the proxy/registry layer decides whether to execute writes. Read operations (GET) still execute in dry-run mode to validate records exist.
+
+4. **Re-enable scope**: Only users matched by the same email address are re-enabled. Users who moved to a new institution get new records. This avoids false matches.
+
+## Components and Interfaces
+
+### UserRegistry (modified)
+
+New constructor parameter and methods added to the existing `UserRegistry` class.
+
+```python
+class UserRegistry:
+    def __init__(
+        self,
+        api_instance: DefaultApi,
+        coid: int,
+        name_normalizer: Callable[[str], str],
+        domain_config: Optional[DomainRelationshipConfig] = None,
+        dry_run: bool = False,  # NEW
+    ):
+        ...
+
+    # NEW: Suspend a CO Person
+    def suspend(self, registry_id: str) -> None:
+        """Suspend a CO Person by setting status to 'S'.
+
+        Retrieves the full CoPersonMessage, sets CoPerson.status to 'S',
+        and PUTs the entire record back. In dry-run mode, logs the
+        intended action without calling PUT.
+
+        Args:
+            registry_id: the NACC registry ID (naccid identifier)
+
+        Raises:
+            RegistryError: if the person cannot be found, has no registry ID,
+                          or the API call fails
+        """
+
+    # NEW: Re-enable a suspended CO Person
+    def re_enable(self, registry_id: str) -> None:
+        """Re-enable a suspended CO Person by setting status to 'A'.
+
+        Retrieves the full CoPersonMessage, sets CoPerson.status to 'A',
+        and PUTs the entire record back. In dry-run mode, logs the
+        intended action without calling PUT.
+
+        Args:
+            registry_id: the NACC registry ID (naccid identifier)
+
+        Raises:
+            RegistryError: if the person cannot be found or the API call fails
+        """
+
+    # PRIVATE: Shared update logic
+    def __update_status(self, registry_id: str, target_status: str) -> None:
+        """Retrieve the full CoPersonMessage, change only the status, PUT it back.
+
+        Args:
+            registry_id: the NACC registry ID
+            target_status: the target CoPerson status ('S' or 'A')
+
+        Raises:
+            RegistryError: on API errors or missing records
+        """
+
+    # PRIVATE: Fetch a single CoPersonMessage by identifier
+    def __get_person_message(self, registry_id: str) -> CoPersonMessage:
+        """Retrieve the full CoPersonMessage for a registry ID via GET.
+
+        Uses the DefaultApi.get_co_person with the identifier parameter
+        to fetch a single record.
+
+        Args:
+            registry_id: the NACC registry ID
+
+        Returns:
+            The full CoPersonMessage
+
+        Raises:
+            RegistryError: if the API call fails or no record is found
+        """
+```
+
+### InactiveUserProcess (modified)
+
+The `visit` method is extended to suspend in COmanage after disabling in Flywheel.
+
+```python
+class InactiveUserProcess(BaseUserProcess[UserEntry]):
+    def visit(self, entry: UserEntry) -> None:
+        """Process an inactive user entry.
+
+        1. Look up and disable matching Flywheel users (existing behavior)
+        2. Look up and suspend matching COmanage registry persons (NEW)
+
+        The two operations are independent — failure of either does not
+        prevent the other.
+        """
+```
+
+### ActiveUserProcess (modified)
+
+The `visit` method is extended to detect suspended registry persons and re-enable them.
+
+```python
+class ActiveUserProcess(BaseUserProcess[ActiveUserEntry]):
+    def visit(self, entry: ActiveUserEntry) -> None:
+        """Process an active user entry.
+
+        When a matching registry person is found with status 'S' (Suspended),
+        re-enable them instead of treating them as a new user. This prevents
+        duplicate record creation for returning users.
+
+        The re-enable check happens after the email lookup but before the
+        existing claimed/unclaimed routing.
+        """
+```
+
+### RegistryPerson (modified)
+
+A new method to check suspended status.
+
+```python
+class RegistryPerson:
+    def is_suspended(self) -> bool:
+        """Indicates whether the CoPerson record is suspended.
+
+        Returns:
+            True if the CoPerson status is 'S' (Suspended). False otherwise.
+        """
+```
+
+### UserProcessEnvironment (no changes)
+
+Already provides access to `user_registry` via its `user_registry` property. No new wiring needed.
+
+### Gear Entry Point — run.py (modified)
+
+The `UserRegistry` constructor call in `run.py` needs to pass the `dry_run` flag from the `FlywheelProxy`.
+
+```python
+registry=UserRegistry(
+    api_instance=DefaultApi(comanage_client),
+    coid=self.__comanage_coid,
+    name_normalizer=normalize_person_name,
+    domain_config=domain_config,
+    dry_run=self.proxy.dry_run,  # NEW: pass dry_run from proxy
+)
+```
+
+## Data Models
+
+### COmanage API Models (no changes)
+
+The existing generated SDK models are used as-is:
+
+- **`CoPersonMessage`**: The full record containing `CoPerson` and all related models (`Name`, `EmailAddress`, `CoPersonRole`, `Identifier`, `OrgIdentity`, `CoGroupMember`, `SshKey`, `Url`). This is the unit of read and write for the Core API.
+- **`CoPerson`**: Contains the `status` field. Valid statuses include `"A"` (Active) and `"S"` (Suspended).
+- **`DefaultApi`**: Provides `get_co_person(coid, identifier=...)` for fetching by registry ID and `update_co_person(coid, identifier, co_person_message)` for updating.
+
+### Event Models (no changes)
+
+The existing `EventCategory.USER_DISABLED` is reused for COmanage suspension events. Event messages distinguish between Flywheel disable and COmanage suspend:
+
+- Flywheel: `"User {user_id} disabled in Flywheel"` (existing)
+- COmanage: `"User {registry_id} suspended in COmanage"` (new)
+- COmanage re-enable: `"User {registry_id} re-enabled in COmanage"` (new, uses a success event)
+
+### Status Flow
+
+```mermaid
+stateDiagram-v2
+    [*] --> Active: User created
+    Active --> Suspended: User marked inactive → suspend()
+    Suspended --> Active: User marked active → re_enable()
+    Active --> Active: User remains active (no-op)
+    Suspended --> Suspended: User remains inactive (no-op, already suspended)
+```
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: Status update round-trip preserves all non-status fields
+
+*For any* valid `CoPersonMessage` retrieved from the COmanage API and *for any* target status (`"S"` or `"A"`), performing a status update (GET → modify status → PUT) SHALL preserve all non-status fields and all related models (`Name`, `EmailAddress`, `CoPersonRole`, `Identifier`, `OrgIdentity`, `CoGroupMember`, `SshKey`, `Url`) unchanged. Only the `CoPerson.status` field SHALL differ between the original and updated messages.
+
+**Validates: Requirements 1.1, 1.2, 2.1, 2.2, 6.1, 6.2, 6.3, 6.4**
+
+### Property 2: Flywheel disable and COmanage suspend are independent
+
+*For any* inactive user entry and *for any* combination of Flywheel and COmanage operation outcomes (success or failure), the failure of one service operation SHALL NOT prevent the other from being attempted. Specifically: if Flywheel disable raises an error, COmanage suspend is still attempted; if COmanage suspend raises an error, the Flywheel disable result is unaffected.
+
+**Validates: Requirements 3.1, 3.3, 3.4**
+
+### Property 3: Active process re-enables suspended users instead of creating duplicates
+
+*For any* active user entry whose email matches a `RegistryPerson` with status `"S"` (Suspended), the `ActiveUserProcess` SHALL call re-enable on that person rather than creating a new registry record. The registry `add` method SHALL NOT be called for that entry.
+
+**Validates: Requirements 4.1, 4.2**
+
+### Property 4: Dry-run mode skips writes but performs reads
+
+*For any* status update operation (suspend or re-enable) and *for any* valid registry ID, when dry-run mode is enabled, the `UserRegistry` SHALL call the GET endpoint to retrieve the record but SHALL NOT call the PUT endpoint. The intended action (registry ID and target status) SHALL be logged.
+
+**Validates: Requirements 5.1, 5.2, 5.3**
+
+## Error Handling
+
+### UserRegistry errors
+
+| Scenario | Behavior |
+|---|---|
+| Registry ID is `None` or empty | Raise `RegistryError("Cannot update person: no registry ID")` |
+| GET returns no matching record | Raise `RegistryError("No COmanage record found for registry ID {id}")` |
+| GET API call fails (`ApiException`) | Raise `RegistryError("API get_co_person call failed: {error}")` |
+| PUT API call fails (`ApiException`) | Raise `RegistryError("API update_co_person call failed: {error}")` |
+
+### InactiveUserProcess errors
+
+| Scenario | Behavior |
+|---|---|
+| No matching Flywheel users | Log info, continue to COmanage suspend |
+| Flywheel `disable_user` fails | Log error, collect `FLYWHEEL_ERROR` event, continue to COmanage suspend |
+| No matching COmanage registry persons | Log info, continue without error |
+| COmanage `suspend` fails (`RegistryError`) | Log error, collect error event with COmanage-specific message |
+| Both Flywheel and COmanage fail | Both errors logged and collected independently |
+
+### ActiveUserProcess errors
+
+| Scenario | Behavior |
+|---|---|
+| Re-enable fails (`RegistryError`) | Log error, collect error event, continue processing remaining users |
+| Multiple suspended persons for same email | Re-enable the first match (consistent with existing `get` behavior returning a list) |
+
+## Testing Strategy
+
+### Property-Based Tests (Hypothesis)
+
+Property-based testing is appropriate for this feature because:
+- The core logic (status update round-trip) is a pure transformation with clear input/output behavior
+- The input space is large (arbitrary `CoPersonMessage` structures with varying related models)
+- Universal properties hold across all valid inputs
+
+**Library**: [Hypothesis](https://hypothesis.readthedocs.io/) (already used in the project — see `test_inactive_user_process.py`)
+
+**Configuration**: Minimum 100 iterations per property test.
+
+**Tag format**: `Feature: disable-inactive-comanage-users, Property {number}: {property_text}`
+
+Each correctness property maps to a single property-based test:
+
+1. **Property 1 test**: Generate random `CoPersonMessage` objects with varying related models. Mock the API GET to return the generated message. Call `suspend` or `re_enable`. Capture the `CoPersonMessage` passed to the PUT mock. Assert all fields except `CoPerson.status` are identical.
+
+2. **Property 2 test**: Generate random inactive `UserEntry` objects and random Flywheel user lists. Parameterize Flywheel and COmanage to succeed or fail independently. Assert that each service's operation is attempted regardless of the other's outcome.
+
+3. **Property 3 test**: Generate random `ActiveUserEntry` objects and matching suspended `RegistryPerson` objects. Assert `re_enable` is called and `add` is not called.
+
+4. **Property 4 test**: Generate random registry IDs and target statuses. Enable dry-run. Assert GET is called but PUT is not called.
+
+### Unit Tests (pytest)
+
+Example-based tests for specific scenarios and edge cases:
+
+- Suspend with no registry ID raises `RegistryError`
+- Suspend when GET returns no record raises `RegistryError`
+- Suspend when PUT fails raises `RegistryError` with API error details
+- Re-enable when GET fails raises `RegistryError`
+- `RegistryPerson.is_suspended()` returns correct values for each status
+- `InactiveUserProcess` collects `USER_DISABLED` event with COmanage-specific message on success
+- `InactiveUserProcess` collects error event on COmanage failure
+- `InactiveUserProcess` logs and continues when no COmanage record found
+- `ActiveUserProcess` collects success event on re-enable
+- `ActiveUserProcess` collects error event on re-enable failure
+
+### Integration Points
+
+- The gear entry point (`run.py`) passes `dry_run` from `FlywheelProxy` to `UserRegistry`
+- `UserProcessEnvironment` already exposes `user_registry` — no new wiring needed
+- The generated `DefaultApi` client's `get_co_person` and `update_co_person` methods are used directly

--- a/.kiro/specs/disable-inactive-comanage-users/disable-users-in-comanage.md
+++ b/.kiro/specs/disable-inactive-comanage-users/disable-users-in-comanage.md
@@ -1,0 +1,74 @@
+# Disable Users in COmanage When Marked Inactive
+
+## Context
+
+When a user is marked inactive in the NACC directory, the system currently disables them in Flywheel (sets `disabled=True` and clears permissions via `InactiveUserProcess`). We need to also suspend them in the COmanage registry so that downstream OIDC authorization is revoked.
+
+### COmanage API Details
+
+- The COmanage Core API supports updating a CO Person record via `PUT /api/co/{coid}/core/v1/people?identifier={registry_id}` with a `CoPersonMessage` body
+- **The update does NOT support patch semantics.** Both create (POST) and update (PUT) require sending the **entire JSON document** representing the full desired state of the CoPerson and all related models. The correct pattern is: read the record, make the minor change, send back the entire (slightly) modified record.
+- **Critical**: If you strip out related models (e.g., only send `EmailAddress` without `Name`, `CoPersonRole`, `Identifier`, `OrgIdentity`, etc.), the API interprets that as a request to delete those missing models, which will throw a cryptic deletion error.
+- Per guidance from CILogon support (Scott Koranda), the correct approach is to set the **CO Person status to `"S"` (Suspended)** on the CO Person record (not the CO Person Role, since we don't use COUs)
+- Suspended status is reversible — the user can be re-enabled by setting status back to `"A"`
+- Suspending removes the user from the `CO:members:active` group, which controls authorization for downstream OIDC clients
+- Identifier associations are preserved when suspending
+
+### Update Pattern (from CILogon support)
+
+The generated SDK provides a `CoPersonMessage` object with a `co_person` property and list properties for related models (`EmailAddress`, `Name`, `CoPersonRole`, `Identifier`, `OrgIdentity`, etc.). To update a record:
+
+1. **GET** the full `CoPersonMessage` for the person
+2. Modify only the field you need (e.g., `co_person.status = "S"`)
+3. **PUT** the entire `CoPersonMessage` back — all related models must remain intact
+
+### Key Files
+
+- `common/src/python/users/user_registry.py` — `UserRegistry` class, `RegistryPerson` class
+- `common/src/python/users/user_processes.py` — `InactiveUserProcess` class
+- `common/src/python/users/user_process_environment.py` — `UserProcessEnvironment`
+- `comanage/coreapi.yaml` — COmanage Core API OpenAPI spec (PUT endpoint and `CoPerson.status` enum)
+- `gear/user_management/src/python/user_app/run.py` — gear entry point that wires up the environment
+
+## What Needs to Change
+
+### 1. UserRegistry — add update/suspend capability
+
+`UserRegistry` (`common/src/python/users/user_registry.py`) needs a new method to suspend a CO Person record via the COmanage Core API PUT endpoint. The `UserRegistry` currently has `add` and `get` methods but no `update` method.
+
+The suspend flow must:
+1. Retrieve the **full** `CoPersonMessage` from COmanage (using the existing `get` or `find_by_registry_id` method)
+2. Modify **only** the `CoPerson.status` field to `"S"` (Suspended) — all other fields and related models (`Name`, `CoPersonRole`, `Identifier`, `OrgIdentity`, `EmailAddress`, etc.) must remain unchanged
+3. Submit the **entire** modified `CoPersonMessage` back via PUT — omitting related models will cause the API to attempt to delete them
+
+### 2. InactiveUserProcess — suspend in COmanage after disabling in Flywheel
+
+`InactiveUserProcess` (`common/src/python/users/user_processes.py`) currently only disables users in Flywheel. It needs to also suspend the user in COmanage. The process should:
+
+- Disable the user in Flywheel first (existing behavior)
+- Then suspend the user in COmanage (new behavior)
+- The two services should be independent — a failure in one should not prevent the other from proceeding
+- Look up the user in COmanage by email to find their registry record
+- Set the CO Person status to `"S"` (Suspended) via the API
+- Handle COmanage API errors independently from Flywheel errors
+- Collect events using the existing `USER_DISABLED` category for the aggregate action across both services
+
+### 3. Re-enabling users
+
+When processing an active user entry, if a user already exists in COmanage with the same email but has status `"S"` (Suspended), re-enable them by setting status back to `"A"` (Active) instead of creating a new record. This does not cover users who have moved to a new institution — that would be a new record.
+
+### 4. Dry-run support
+
+The Flywheel proxy already supports dry-run mode. The COmanage suspension/re-enable operations should also respect dry-run mode, logging the intended action without calling the API.
+
+### 5. InactiveUserProcess already has access to UserRegistry
+
+`InactiveUserProcess` receives a `UserProcessEnvironment` which already has a `user_registry` property, so no new wiring should be needed.
+
+## Design Decisions
+
+- **Event tracking**: Use the existing `USER_DISABLED` `EventCategory` to capture the aggregate disable action across both Flywheel and COmanage. Event messages should distinguish which service was affected.
+- **Ordering**: Disable in Flywheel first, then suspend in COmanage. Failures are independent.
+- **Full record update**: The COmanage PUT endpoint does **not** support patch semantics. The entire `CoPersonMessage` with all related models must be sent back. Omitting models causes the API to try to delete them. Always: read → modify → write back the full record.
+- **Re-enable scope**: Only re-enable users with the same email. Users at new institutions get new records.
+- **Dry-run**: Supported for all new COmanage operations.

--- a/.kiro/specs/disable-inactive-comanage-users/requirements.md
+++ b/.kiro/specs/disable-inactive-comanage-users/requirements.md
@@ -1,0 +1,88 @@
+# Requirements Document
+
+## Introduction
+
+When a user is marked inactive in the NACC directory, the system currently disables them in Flywheel via `InactiveUserProcess`. This feature extends the inactive user workflow to also suspend the user in the COmanage registry, revoking downstream OIDC authorization. It also adds re-enablement logic so that a previously suspended user who becomes active again is restored in COmanage rather than duplicated. All new COmanage operations respect the existing dry-run mode.
+
+## Glossary
+
+- **User_Registry**: The `UserRegistry` class that interfaces with the COmanage Core API to manage CO Person records. Currently supports `add` and `get` operations.
+- **Registry_Person**: The `RegistryPerson` wrapper around a `CoPersonMessage` that provides convenient access to CO Person attributes such as email, name, identifiers, and status.
+- **Inactive_User_Process**: The `InactiveUserProcess` class that processes user entries marked inactive in the NACC directory. Currently disables users in Flywheel only.
+- **Active_User_Process**: The `ActiveUserProcess` class that processes active user entries, adding new users to the registry or routing them to claimed/unclaimed queues.
+- **COmanage_API**: The COmanage Core API accessed via the generated `DefaultApi` SDK client. Supports GET and PUT operations on CO Person records. The PUT endpoint requires the full `CoPersonMessage` (not patch semantics).
+- **CoPersonMessage**: The full JSON document representing a CO Person and all related models (Name, EmailAddress, CoPersonRole, Identifier, OrgIdentity, etc.). Omitting related models in a PUT causes the API to delete them.
+- **Suspended_Status**: CO Person status value `"S"` which removes the user from the `CO:members:active` group, revoking OIDC authorization. Reversible by setting status back to `"A"`.
+- **Active_Status**: CO Person status value `"A"` indicating the CO Person is active and authorized.
+- **Flywheel_Proxy**: The `FlywheelProxy` class that wraps Flywheel SDK calls and supports dry-run mode for all write operations.
+- **Dry_Run_Mode**: A mode where write operations are logged but not executed against external services. The Flywheel_Proxy already supports this via its `dry_run` property.
+- **Event_Collector**: The `UserEventCollector` that accumulates `UserProcessEvent` objects categorized by `EventCategory` during gear execution.
+
+## Requirements
+
+### Requirement 1: Suspend a CO Person in COmanage
+
+**User Story:** As a system administrator, I want the User_Registry to support suspending a CO Person record via the COmanage_API, so that inactive users lose OIDC authorization.
+
+#### Acceptance Criteria
+
+1. WHEN a suspend operation is requested for a Registry_Person with a valid registry ID, THE User_Registry SHALL retrieve the full CoPersonMessage from the COmanage_API, set the CoPerson status to Suspended_Status, and submit the entire modified CoPersonMessage back via the PUT endpoint.
+2. THE User_Registry SHALL preserve all related models (Name, EmailAddress, CoPersonRole, Identifier, OrgIdentity) unchanged when submitting the updated CoPersonMessage.
+3. IF the COmanage_API returns an error during the suspend operation, THEN THE User_Registry SHALL raise a RegistryError with a descriptive message including the API error details.
+4. IF the Registry_Person has no registry ID, THEN THE User_Registry SHALL raise a RegistryError indicating the person cannot be identified for update.
+
+### Requirement 2: Re-enable a CO Person in COmanage
+
+**User Story:** As a system administrator, I want the User_Registry to support re-enabling a suspended CO Person record, so that users who become active again regain OIDC authorization.
+
+#### Acceptance Criteria
+
+1. WHEN a re-enable operation is requested for a Registry_Person with Suspended_Status, THE User_Registry SHALL retrieve the full CoPersonMessage from the COmanage_API, set the CoPerson status to Active_Status, and submit the entire modified CoPersonMessage back via the PUT endpoint.
+2. THE User_Registry SHALL preserve all related models unchanged when submitting the updated CoPersonMessage for re-enablement.
+3. IF the COmanage_API returns an error during the re-enable operation, THEN THE User_Registry SHALL raise a RegistryError with a descriptive message including the API error details.
+
+### Requirement 3: Inactive User Process Suspends in COmanage
+
+**User Story:** As a system administrator, I want the Inactive_User_Process to suspend users in COmanage after disabling them in Flywheel, so that inactive users are fully deauthorized across both services.
+
+#### Acceptance Criteria
+
+1. WHEN processing an inactive user entry, THE Inactive_User_Process SHALL first disable the user in Flywheel, then suspend the user in COmanage.
+2. THE Inactive_User_Process SHALL look up the user in COmanage by email to find matching Registry_Person records.
+3. IF the Flywheel disable operation fails, THEN THE Inactive_User_Process SHALL still attempt to suspend the user in COmanage.
+4. IF the COmanage suspend operation fails, THEN THE Inactive_User_Process SHALL log the error and collect an error event without affecting the Flywheel disable result.
+5. IF no matching Registry_Person is found in COmanage for the user email, THEN THE Inactive_User_Process SHALL log that no COmanage record was found and continue without error.
+6. WHEN a user is successfully suspended in COmanage, THE Inactive_User_Process SHALL collect a success event with EventCategory USER_DISABLED and a message distinguishing the COmanage suspension from the Flywheel disable.
+7. IF the COmanage suspend operation fails, THEN THE Inactive_User_Process SHALL collect an error event with a message identifying the COmanage service and the error details.
+
+### Requirement 4: Active User Process Re-enables Suspended Users
+
+**User Story:** As a system administrator, I want the Active_User_Process to re-enable suspended COmanage users when they appear as active in the directory, so that returning users regain access without creating duplicate records.
+
+#### Acceptance Criteria
+
+1. WHEN processing an active user entry that matches a Registry_Person with Suspended_Status by email, THE Active_User_Process SHALL re-enable the Registry_Person by setting the status to Active_Status instead of creating a new registry record.
+2. THE Active_User_Process SHALL only re-enable Registry_Person records matched by the same email address.
+3. WHEN a user is successfully re-enabled in COmanage, THE Active_User_Process SHALL collect a success event indicating the user was re-enabled.
+4. IF the re-enable operation fails, THEN THE Active_User_Process SHALL collect an error event with the failure details and continue processing.
+
+### Requirement 5: Dry-Run Support for COmanage Operations
+
+**User Story:** As a system administrator, I want COmanage suspend and re-enable operations to respect dry-run mode, so that I can preview changes without modifying COmanage records.
+
+#### Acceptance Criteria
+
+1. WHILE Dry_Run_Mode is enabled, THE User_Registry SHALL log the intended suspend action (including the registry ID and target status) without calling the COmanage_API PUT endpoint.
+2. WHILE Dry_Run_Mode is enabled, THE User_Registry SHALL log the intended re-enable action (including the registry ID and target status) without calling the COmanage_API PUT endpoint.
+3. WHILE Dry_Run_Mode is enabled, THE User_Registry SHALL still perform read operations (GET) against the COmanage_API to validate that the target record exists.
+
+### Requirement 6: Full Record Integrity on Update
+
+**User Story:** As a system administrator, I want the COmanage update operations to always send the complete CoPersonMessage, so that related models are never accidentally deleted by the API.
+
+#### Acceptance Criteria
+
+1. THE User_Registry SHALL retrieve the full CoPersonMessage via GET before any status update operation.
+2. THE User_Registry SHALL modify only the CoPerson status field on the retrieved CoPersonMessage.
+3. THE User_Registry SHALL submit the complete CoPersonMessage (including all related models returned by GET) in the PUT request.
+4. FOR ALL valid CoPersonMessage objects retrieved from the COmanage_API, retrieving the record, modifying only the status field, and submitting the full record back SHALL preserve all non-status fields and related models (round-trip property).

--- a/.kiro/specs/disable-inactive-comanage-users/tasks.md
+++ b/.kiro/specs/disable-inactive-comanage-users/tasks.md
@@ -8,28 +8,28 @@ Sub-agents executing tasks should use the `kiro-pants-power` MCP tools (`pants_f
 
 ## Tasks
 
-- [ ] 1. Add `is_suspended` method to `RegistryPerson` and dry-run support to `UserRegistry`
-  - [ ] 1.1 Add `is_suspended()` method to `RegistryPerson` in `common/src/python/users/user_registry.py`
+- [x] 1. Add `is_suspended` method to `RegistryPerson` and dry-run support to `UserRegistry`
+  - [x] 1.1 Add `is_suspended()` method to `RegistryPerson` in `common/src/python/users/user_registry.py`
     - Add method that returns `True` when `CoPerson.status == "S"`, `False` otherwise
     - Follow the same pattern as the existing `is_active()` method
     - _Requirements: 4.1_
-  - [ ] 1.2 Add `dry_run` parameter to `UserRegistry.__init__` in `common/src/python/users/user_registry.py`
+  - [x] 1.2 Add `dry_run` parameter to `UserRegistry.__init__` in `common/src/python/users/user_registry.py`
     - Add `dry_run: bool = False` parameter to the constructor
     - Store as `self.__dry_run` private attribute
     - Add a `dry_run` property for read access
     - _Requirements: 5.1, 5.2_
-  - [ ]* 1.3 Write unit tests for `RegistryPerson.is_suspended()` in `common/test/python/user_test/test_registry_person_status.py`
+  - [x]* 1.3 Write unit tests for `RegistryPerson.is_suspended()` in `common/test/python/user_test/test_registry_person_status.py`
     - Test returns `True` for status `"S"`
     - Test returns `False` for status `"A"`, `"D"`, and `None`
     - Follow existing test patterns in `test_registry_person_status.py`
     - _Requirements: 4.1_
 
-- [ ] 2. Implement `UserRegistry` status update methods
-  - [ ] 2.1 Implement private `__get_person_message` method in `UserRegistry`
+- [x] 2. Implement `UserRegistry` status update methods
+  - [x] 2.1 Implement private `__get_person_message` method in `UserRegistry`
     - Retrieve the full `CoPersonMessage` for a given registry ID using `DefaultApi.get_co_person(coid, identifier=registry_id)`
     - Raise `RegistryError` if no record is found or the API call fails (`ApiException`)
     - _Requirements: 6.1, 1.1, 2.1_
-  - [ ] 2.2 Implement private `__update_status` method in `UserRegistry`
+  - [x] 2.2 Implement private `__update_status` method in `UserRegistry`
     - Accept `registry_id: str` and `target_status: str` parameters
     - Raise `RegistryError` if `registry_id` is `None` or empty
     - Call `__get_person_message` to GET the full `CoPersonMessage`
@@ -38,15 +38,15 @@ Sub-agents executing tasks should use the `kiro-pants-power` MCP tools (`pants_f
     - In normal mode: call `DefaultApi.update_co_person(coid, identifier=registry_id, co_person_message=modified_message)`
     - Raise `RegistryError` wrapping `ApiException` if PUT fails
     - _Requirements: 1.1, 1.2, 2.1, 2.2, 5.1, 5.2, 5.3, 6.1, 6.2, 6.3_
-  - [ ] 2.3 Implement public `suspend` method in `UserRegistry`
+  - [x] 2.3 Implement public `suspend` method in `UserRegistry`
     - Call `__update_status(registry_id, "S")`
     - Raise `RegistryError` if registry_id is missing or API calls fail
     - _Requirements: 1.1, 1.2, 1.3, 1.4_
-  - [ ] 2.4 Implement public `re_enable` method in `UserRegistry`
+  - [x] 2.4 Implement public `re_enable` method in `UserRegistry`
     - Call `__update_status(registry_id, "A")`
     - Raise `RegistryError` if registry_id is missing or API calls fail
     - _Requirements: 2.1, 2.2, 2.3_
-  - [ ] 2.5 Write unit tests for `UserRegistry.suspend` and `re_enable`
+  - [x] 2.5 Write unit tests for `UserRegistry.suspend` and `re_enable`
     - Test suspend with valid registry ID calls GET then PUT with status `"S"`
     - Test re_enable with valid registry ID calls GET then PUT with status `"A"`
     - Test suspend with no registry ID raises `RegistryError`
@@ -55,7 +55,7 @@ Sub-agents executing tasks should use the `kiro-pants-power` MCP tools (`pants_f
     - Test re_enable when GET fails raises `RegistryError`
     - Add tests to a new file `common/test/python/user_test/test_user_registry_update.py`
     - _Requirements: 1.1, 1.2, 1.3, 1.4, 2.1, 2.2, 2.3_
-  - [ ]* 2.6 Write property test for status update round-trip preservation
+  - [x]* 2.6 Write property test for status update round-trip preservation
     - **Property 1: Status update round-trip preserves all non-status fields**
     - **Validates: Requirements 1.1, 1.2, 2.1, 2.2, 6.1, 6.2, 6.3, 6.4**
     - Generate random `CoPersonMessage` objects using the existing `coperson_message_strategy` from `conftest.py`
@@ -65,7 +65,7 @@ Sub-agents executing tasks should use the `kiro-pants-power` MCP tools (`pants_f
     - Assert all fields except `CoPerson.status` are identical between original and updated messages
     - Add to a new file `common/test/python/user_test/test_property_status_roundtrip.py`
     - Use `@settings(max_examples=100)` per project convention
-  - [ ]* 2.7 Write property test for dry-run mode
+  - [x]* 2.7 Write property test for dry-run mode
     - **Property 4: Dry-run mode skips writes but performs reads**
     - **Validates: Requirements 5.1, 5.2, 5.3**
     - Generate random registry IDs and target statuses (`"S"` or `"A"`)
@@ -74,11 +74,11 @@ Sub-agents executing tasks should use the `kiro-pants-power` MCP tools (`pants_f
     - Add to a new file `common/test/python/user_test/test_property_dry_run.py`
     - Use `@settings(max_examples=100)` per project convention
 
-- [ ] 3. Checkpoint - Ensure all tests pass
+- [x] 3. Checkpoint - Ensure all tests pass
   - Ensure all tests pass, ask the user if questions arise.
 
-- [ ] 4. Extend `InactiveUserProcess` to suspend in COmanage
-  - [ ] 4.1 Modify `InactiveUserProcess.visit` in `common/src/python/users/user_processes.py`
+- [x] 4. Extend `InactiveUserProcess` to suspend in COmanage
+  - [x] 4.1 Modify `InactiveUserProcess.visit` in `common/src/python/users/user_processes.py`
     - After the existing Flywheel disable logic, add COmanage suspension logic
     - Look up the user in COmanage by email using `self.__env.user_registry.get(email=entry.email)`
     - If no matching `RegistryPerson` found, log info and continue without error
@@ -87,7 +87,7 @@ Sub-agents executing tasks should use the `kiro-pants-power` MCP tools (`pants_f
     - On `RegistryError`, log the error and collect an error event with a message identifying COmanage and the error details
     - Flywheel disable and COmanage suspend must be independent — failure of one does not prevent the other
     - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7_
-  - [ ] 4.2 Write unit tests for `InactiveUserProcess` COmanage suspension
+  - [x] 4.2 Write unit tests for `InactiveUserProcess` COmanage suspension
     - Test that COmanage suspend is attempted after Flywheel disable
     - Test that COmanage suspend is attempted even when Flywheel disable fails
     - Test that no error when no COmanage record found for user email
@@ -95,7 +95,7 @@ Sub-agents executing tasks should use the `kiro-pants-power` MCP tools (`pants_f
     - Test that error event is collected when COmanage suspend fails
     - Add tests to `common/test/python/user_test/test_inactive_user_process.py`
     - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7_
-  - [ ]* 4.3 Write property test for Flywheel/COmanage independence
+  - [x]* 4.3 Write property test for Flywheel/COmanage independence
     - **Property 2: Flywheel disable and COmanage suspend are independent**
     - **Validates: Requirements 3.1, 3.3, 3.4**
     - Generate random inactive `UserEntry` objects and random Flywheel user lists
@@ -104,15 +104,15 @@ Sub-agents executing tasks should use the `kiro-pants-power` MCP tools (`pants_f
     - Add to a new file `common/test/python/user_test/test_property_service_independence.py`
     - Use `@settings(max_examples=100)` per project convention
 
-- [ ] 5. Extend `ActiveUserProcess` to re-enable suspended users
-  - [ ] 5.1 Modify `ActiveUserProcess.visit` in `common/src/python/users/user_processes.py`
+- [x] 5. Extend `ActiveUserProcess` to re-enable suspended users
+  - [x] 5.1 Modify `ActiveUserProcess.visit` in `common/src/python/users/user_processes.py`
     - After the email lookup (`person_list = self.__env.user_registry.get(email=entry.auth_email)`) returns results, check if any `RegistryPerson` in the list has `is_suspended() == True`
     - If a suspended person is found, call `self.__env.user_registry.re_enable(registry_id)` instead of routing to claimed/unclaimed queues or creating a new record
     - On success, collect a `UserProcessEvent` with `EventType.SUCCESS`, `EventCategory.USER_DISABLED`, and message `"User {registry_id} re-enabled in COmanage"`
     - On `RegistryError`, collect an error event with failure details and continue processing
     - Only re-enable persons matched by the same email address (already guaranteed by the `get(email=...)` lookup)
     - _Requirements: 4.1, 4.2, 4.3, 4.4_
-  - [ ] 5.2 Write unit tests for `ActiveUserProcess` re-enable logic
+  - [x] 5.2 Write unit tests for `ActiveUserProcess` re-enable logic
     - Test that a suspended `RegistryPerson` matched by email is re-enabled
     - Test that `add` is not called when a suspended match exists
     - Test that success event is collected on re-enable
@@ -120,7 +120,7 @@ Sub-agents executing tasks should use the `kiro-pants-power` MCP tools (`pants_f
     - Test that active (non-suspended) persons follow the existing claimed/unclaimed flow
     - Add tests to a new file `common/test/python/user_test/test_active_user_reenable.py`
     - _Requirements: 4.1, 4.2, 4.3, 4.4_
-  - [ ]* 5.3 Write property test for re-enable instead of duplicate creation
+  - [x]* 5.3 Write property test for re-enable instead of duplicate creation
     - **Property 3: Active process re-enables suspended users instead of creating duplicates**
     - **Validates: Requirements 4.1, 4.2**
     - Generate random `ActiveUserEntry` objects and matching suspended `RegistryPerson` objects
@@ -128,13 +128,13 @@ Sub-agents executing tasks should use the `kiro-pants-power` MCP tools (`pants_f
     - Add to a new file `common/test/python/user_test/test_property_reenable_no_duplicate.py`
     - Use `@settings(max_examples=100)` per project convention
 
-- [ ] 6. Wire dry-run flag in gear entry point
-  - [ ] 6.1 Update `UserRegistry` constructor call in `gear/user_management/src/python/user_app/run.py`
+- [x] 6. Wire dry-run flag in gear entry point
+  - [x] 6.1 Update `UserRegistry` constructor call in `gear/user_management/src/python/user_app/run.py`
     - Pass `dry_run=self.proxy.dry_run` to the `UserRegistry` constructor in the `UserManagementVisitor.run` method
     - This ensures COmanage operations respect the same dry-run mode as Flywheel operations
     - _Requirements: 5.1, 5.2, 5.3_
 
-- [ ] 7. Final checkpoint - Ensure all tests pass
+- [x] 7. Final checkpoint - Ensure all tests pass
   - Ensure all tests pass, ask the user if questions arise.
 
 ## Notes

--- a/.kiro/specs/disable-inactive-comanage-users/tasks.md
+++ b/.kiro/specs/disable-inactive-comanage-users/tasks.md
@@ -1,0 +1,148 @@
+# Implementation Plan: Disable Inactive COmanage Users
+
+## Overview
+
+This plan implements the feature to suspend users in COmanage when they are marked inactive in the NACC directory, and re-enable suspended users who become active again. The implementation follows the existing codebase patterns: extending `UserRegistry` with update capability, modifying `InactiveUserProcess` to suspend in COmanage, and modifying `ActiveUserProcess` to detect and re-enable suspended users. All new write operations respect dry-run mode.
+
+Sub-agents executing tasks should use the `kiro-pants-power` MCP tools (`pants_fix`, `pants_lint`, `pants_check`, `pants_test`) for all code quality operations rather than manual shell commands.
+
+## Tasks
+
+- [ ] 1. Add `is_suspended` method to `RegistryPerson` and dry-run support to `UserRegistry`
+  - [ ] 1.1 Add `is_suspended()` method to `RegistryPerson` in `common/src/python/users/user_registry.py`
+    - Add method that returns `True` when `CoPerson.status == "S"`, `False` otherwise
+    - Follow the same pattern as the existing `is_active()` method
+    - _Requirements: 4.1_
+  - [ ] 1.2 Add `dry_run` parameter to `UserRegistry.__init__` in `common/src/python/users/user_registry.py`
+    - Add `dry_run: bool = False` parameter to the constructor
+    - Store as `self.__dry_run` private attribute
+    - Add a `dry_run` property for read access
+    - _Requirements: 5.1, 5.2_
+  - [ ]* 1.3 Write unit tests for `RegistryPerson.is_suspended()` in `common/test/python/user_test/test_registry_person_status.py`
+    - Test returns `True` for status `"S"`
+    - Test returns `False` for status `"A"`, `"D"`, and `None`
+    - Follow existing test patterns in `test_registry_person_status.py`
+    - _Requirements: 4.1_
+
+- [ ] 2. Implement `UserRegistry` status update methods
+  - [ ] 2.1 Implement private `__get_person_message` method in `UserRegistry`
+    - Retrieve the full `CoPersonMessage` for a given registry ID using `DefaultApi.get_co_person(coid, identifier=registry_id)`
+    - Raise `RegistryError` if no record is found or the API call fails (`ApiException`)
+    - _Requirements: 6.1, 1.1, 2.1_
+  - [ ] 2.2 Implement private `__update_status` method in `UserRegistry`
+    - Accept `registry_id: str` and `target_status: str` parameters
+    - Raise `RegistryError` if `registry_id` is `None` or empty
+    - Call `__get_person_message` to GET the full `CoPersonMessage`
+    - Modify only `co_person.status` to `target_status` on the retrieved message
+    - In dry-run mode: log the intended action (registry ID and target status) and return without calling PUT
+    - In normal mode: call `DefaultApi.update_co_person(coid, identifier=registry_id, co_person_message=modified_message)`
+    - Raise `RegistryError` wrapping `ApiException` if PUT fails
+    - _Requirements: 1.1, 1.2, 2.1, 2.2, 5.1, 5.2, 5.3, 6.1, 6.2, 6.3_
+  - [ ] 2.3 Implement public `suspend` method in `UserRegistry`
+    - Call `__update_status(registry_id, "S")`
+    - Raise `RegistryError` if registry_id is missing or API calls fail
+    - _Requirements: 1.1, 1.2, 1.3, 1.4_
+  - [ ] 2.4 Implement public `re_enable` method in `UserRegistry`
+    - Call `__update_status(registry_id, "A")`
+    - Raise `RegistryError` if registry_id is missing or API calls fail
+    - _Requirements: 2.1, 2.2, 2.3_
+  - [ ] 2.5 Write unit tests for `UserRegistry.suspend` and `re_enable`
+    - Test suspend with valid registry ID calls GET then PUT with status `"S"`
+    - Test re_enable with valid registry ID calls GET then PUT with status `"A"`
+    - Test suspend with no registry ID raises `RegistryError`
+    - Test suspend when GET returns no record raises `RegistryError`
+    - Test suspend when PUT fails raises `RegistryError` with API error details
+    - Test re_enable when GET fails raises `RegistryError`
+    - Add tests to a new file `common/test/python/user_test/test_user_registry_update.py`
+    - _Requirements: 1.1, 1.2, 1.3, 1.4, 2.1, 2.2, 2.3_
+  - [ ]* 2.6 Write property test for status update round-trip preservation
+    - **Property 1: Status update round-trip preserves all non-status fields**
+    - **Validates: Requirements 1.1, 1.2, 2.1, 2.2, 6.1, 6.2, 6.3, 6.4**
+    - Generate random `CoPersonMessage` objects using the existing `coperson_message_strategy` from `conftest.py`
+    - Mock `DefaultApi.get_co_person` to return the generated message
+    - Call `suspend` or `re_enable`
+    - Capture the `CoPersonMessage` passed to the `update_co_person` mock
+    - Assert all fields except `CoPerson.status` are identical between original and updated messages
+    - Add to a new file `common/test/python/user_test/test_property_status_roundtrip.py`
+    - Use `@settings(max_examples=100)` per project convention
+  - [ ]* 2.7 Write property test for dry-run mode
+    - **Property 4: Dry-run mode skips writes but performs reads**
+    - **Validates: Requirements 5.1, 5.2, 5.3**
+    - Generate random registry IDs and target statuses (`"S"` or `"A"`)
+    - Enable dry-run on `UserRegistry`
+    - Assert GET (`get_co_person`) is called but PUT (`update_co_person`) is not called
+    - Add to a new file `common/test/python/user_test/test_property_dry_run.py`
+    - Use `@settings(max_examples=100)` per project convention
+
+- [ ] 3. Checkpoint - Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [ ] 4. Extend `InactiveUserProcess` to suspend in COmanage
+  - [ ] 4.1 Modify `InactiveUserProcess.visit` in `common/src/python/users/user_processes.py`
+    - After the existing Flywheel disable logic, add COmanage suspension logic
+    - Look up the user in COmanage by email using `self.__env.user_registry.get(email=entry.email)`
+    - If no matching `RegistryPerson` found, log info and continue without error
+    - For each matching `RegistryPerson` with a registry ID, call `self.__env.user_registry.suspend(registry_id)`
+    - On success, collect a `UserProcessEvent` with `EventType.SUCCESS`, `EventCategory.USER_DISABLED`, and message `"User {registry_id} suspended in COmanage"`
+    - On `RegistryError`, log the error and collect an error event with a message identifying COmanage and the error details
+    - Flywheel disable and COmanage suspend must be independent — failure of one does not prevent the other
+    - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7_
+  - [ ] 4.2 Write unit tests for `InactiveUserProcess` COmanage suspension
+    - Test that COmanage suspend is attempted after Flywheel disable
+    - Test that COmanage suspend is attempted even when Flywheel disable fails
+    - Test that no error when no COmanage record found for user email
+    - Test that success event is collected with COmanage-specific message
+    - Test that error event is collected when COmanage suspend fails
+    - Add tests to `common/test/python/user_test/test_inactive_user_process.py`
+    - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7_
+  - [ ]* 4.3 Write property test for Flywheel/COmanage independence
+    - **Property 2: Flywheel disable and COmanage suspend are independent**
+    - **Validates: Requirements 3.1, 3.3, 3.4**
+    - Generate random inactive `UserEntry` objects and random Flywheel user lists
+    - Parameterize Flywheel and COmanage to succeed or fail independently
+    - Assert that each service's operation is attempted regardless of the other's outcome
+    - Add to a new file `common/test/python/user_test/test_property_service_independence.py`
+    - Use `@settings(max_examples=100)` per project convention
+
+- [ ] 5. Extend `ActiveUserProcess` to re-enable suspended users
+  - [ ] 5.1 Modify `ActiveUserProcess.visit` in `common/src/python/users/user_processes.py`
+    - After the email lookup (`person_list = self.__env.user_registry.get(email=entry.auth_email)`) returns results, check if any `RegistryPerson` in the list has `is_suspended() == True`
+    - If a suspended person is found, call `self.__env.user_registry.re_enable(registry_id)` instead of routing to claimed/unclaimed queues or creating a new record
+    - On success, collect a `UserProcessEvent` with `EventType.SUCCESS`, `EventCategory.USER_DISABLED`, and message `"User {registry_id} re-enabled in COmanage"`
+    - On `RegistryError`, collect an error event with failure details and continue processing
+    - Only re-enable persons matched by the same email address (already guaranteed by the `get(email=...)` lookup)
+    - _Requirements: 4.1, 4.2, 4.3, 4.4_
+  - [ ] 5.2 Write unit tests for `ActiveUserProcess` re-enable logic
+    - Test that a suspended `RegistryPerson` matched by email is re-enabled
+    - Test that `add` is not called when a suspended match exists
+    - Test that success event is collected on re-enable
+    - Test that error event is collected on re-enable failure and processing continues
+    - Test that active (non-suspended) persons follow the existing claimed/unclaimed flow
+    - Add tests to a new file `common/test/python/user_test/test_active_user_reenable.py`
+    - _Requirements: 4.1, 4.2, 4.3, 4.4_
+  - [ ]* 5.3 Write property test for re-enable instead of duplicate creation
+    - **Property 3: Active process re-enables suspended users instead of creating duplicates**
+    - **Validates: Requirements 4.1, 4.2**
+    - Generate random `ActiveUserEntry` objects and matching suspended `RegistryPerson` objects
+    - Assert `re_enable` is called and `add` is not called
+    - Add to a new file `common/test/python/user_test/test_property_reenable_no_duplicate.py`
+    - Use `@settings(max_examples=100)` per project convention
+
+- [ ] 6. Wire dry-run flag in gear entry point
+  - [ ] 6.1 Update `UserRegistry` constructor call in `gear/user_management/src/python/user_app/run.py`
+    - Pass `dry_run=self.proxy.dry_run` to the `UserRegistry` constructor in the `UserManagementVisitor.run` method
+    - This ensures COmanage operations respect the same dry-run mode as Flywheel operations
+    - _Requirements: 5.1, 5.2, 5.3_
+
+- [ ] 7. Final checkpoint - Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for faster MVP
+- Each task references specific requirements for traceability
+- Checkpoints ensure incremental validation
+- Property tests validate universal correctness properties from the design document
+- Unit tests validate specific scenarios and edge cases
+- All code quality checks (fix, lint, check, test) are handled by hooks — no need for manual quality check sub-tasks
+- Sub-agents should use the `kiro-pants-power` MCP tools for code quality operations

--- a/.kiro/specs/disable-inactive-users/.config.kiro
+++ b/.kiro/specs/disable-inactive-users/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "14291167-a113-4e6d-8359-30dfee4ec497", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/disable-inactive-users/design.md
+++ b/.kiro/specs/disable-inactive-users/design.md
@@ -1,0 +1,292 @@
+# Design Document: Disable Inactive Users
+
+## Overview
+
+This feature updates the `InactiveUserProcess` in the user management gear to disable matching Flywheel users when a directory entry is marked inactive. Currently, `InactiveUserProcess` is a no-op that logs and skips inactive entries. The new behavior looks up Flywheel users by email, disables each match via the Flywheel SDK, and captures events through the existing `UserEventCollector` pattern.
+
+The changes are scoped to four areas:
+
+1. **FlywheelProxy** — add `find_user_by_email` and `disable_user` methods
+2. **InactiveUserProcess** — accept `UserProcessEnvironment`, use proxy to look up and disable users, collect events
+3. **UserProcess** — pass environment to `InactiveUserProcess`
+4. **Type stub** — update `modify_user` signature to accept `bool` values and `clear_permissions`
+
+Registry cleanup (COManage) and REDCap removal are explicitly out of scope.
+
+## Architecture
+
+The feature fits within the existing gear architecture with no new services or infrastructure. The data flow for inactive entries changes from:
+
+```
+UserProcess → InactiveUserProcess → log and skip
+```
+
+to:
+
+```
+UserProcess → InactiveUserProcess → FlywheelProxy.find_user_by_email
+                                  → FlywheelProxy.disable_user (per match)
+                                  → UserEventCollector.collect (success/error)
+```
+
+```mermaid
+sequenceDiagram
+    participant UP as UserProcess
+    participant IUP as InactiveUserProcess
+    participant FP as FlywheelProxy
+    participant FW as Flywheel SDK
+    participant EC as UserEventCollector
+
+    UP->>IUP: visit(entry) [active=False]
+    IUP->>IUP: log "processing inactive entry"
+    IUP->>FP: find_user_by_email(entry.email)
+    FP->>FW: users.find(f"email={email}")
+    FW-->>FP: List[User]
+    FP-->>IUP: List[User]
+
+    alt No matching users
+        IUP->>IUP: log "no matching users found"
+    else One or more matches
+        loop For each matching user
+            IUP->>FP: disable_user(user)
+            alt dry_run is False
+                FP->>FW: modify_user(user.id, {"disabled": True}, clear_permissions=True)
+                FW-->>FP: success
+            else dry_run is True
+                FP->>FP: log "Dry run: would disable user"
+            end
+            FP-->>IUP: return
+            IUP->>IUP: log disable action
+            IUP->>EC: collect(success event)
+        end
+    end
+
+    alt Disable fails
+        FP-->>IUP: raise FlywheelError
+        IUP->>EC: collect(error event)
+    end
+```
+
+### Design Decisions
+
+1. **Environment injection via constructor**: `InactiveUserProcess.__init__` gains a `UserProcessEnvironment` parameter. This follows the same pattern used by `UpdateUserProcess`, `ActiveUserProcess`, and `ClaimedUserProcess`. The environment provides access to `FlywheelProxy` without coupling `InactiveUserProcess` to the proxy directly.
+
+2. **Email-based lookup**: The directory entry's `email` field is used for the Flywheel lookup (not `auth_email`). The `email` field is the contact email that corresponds to the Flywheel user's email. The `auth_email` is the authentication email used for registry lookups and may differ.
+
+3. **Per-user error handling**: If disabling one user fails, the error is collected and processing continues with the next match. This follows the existing batch-processing pattern where individual failures don't halt the run.
+
+4. **Dry run for disable, not for lookup**: `find_user_by_email` executes the lookup even in dry-run mode (read-only operation). `disable_user` respects the dry-run flag and only logs the intended action.
+
+## Components and Interfaces
+
+### FlywheelProxy (modified)
+
+Two new public methods:
+
+```python
+def find_user_by_email(self, email: str) -> List[flywheel.User]:
+    """Find Flywheel users matching the given email address.
+
+    Executes the lookup regardless of dry_run mode (read-only operation).
+
+    Args:
+        email: email address to search for
+
+    Returns:
+        List of matching User objects. Empty list if none found.
+    """
+
+def disable_user(self, user: flywheel.User) -> None:
+    """Disable a Flywheel user account and clear permissions.
+
+    In dry_run mode, logs the intended action without calling the API.
+
+    Args:
+        user: the Flywheel user to disable
+
+    Raises:
+        FlywheelError: if the Flywheel SDK call fails
+    """
+```
+
+### InactiveUserProcess (modified)
+
+Constructor signature changes:
+
+```python
+class InactiveUserProcess(BaseUserProcess[UserEntry]):
+    def __init__(
+        self,
+        environment: UserProcessEnvironment,
+        collector: UserEventCollector,
+    ) -> None:
+```
+
+The `visit` method changes from a no-op log to:
+
+1. Log that the inactive entry is being processed (preserves existing log)
+2. Call `environment.proxy.find_user_by_email(entry.email)`
+3. If no matches: log and return
+4. For each match: call `environment.proxy.disable_user(user)`, log, collect success event
+5. On failure: collect error event, continue with next user
+
+### UserProcess (modified)
+
+The `execute` method changes to pass the environment when constructing `InactiveUserProcess`:
+
+```python
+# Before
+InactiveUserProcess(self.collector).execute(self.__inactive_queue)
+
+# After
+InactiveUserProcess(self.__env, self.collector).execute(self.__inactive_queue)
+```
+
+### EventCategory (modified)
+
+Add a new enum member:
+
+```python
+class EventCategory(Enum):
+    # ... existing members ...
+    USER_DISABLED = "User Disabled"
+```
+
+### Flywheel Client Type Stub (modified)
+
+```python
+def modify_user(
+    self,
+    user_id: str,
+    body: Dict[str, str | bool],
+    clear_permissions: bool = False,
+) -> None: ...
+```
+
+## Data Models
+
+### Existing Models (unchanged)
+
+- **UserEntry**: Base directory entry with `name`, `email`, `auth_email`, `active`, `approved` fields. The `active` field determines routing to `InactiveUserProcess`.
+- **UserProcessEnvironment**: Aggregates `FlywheelProxy`, `UserRegistry`, `NotificationClient`, `NACCGroup`, `AuthMap`. Already passed to active-side processes; now also passed to `InactiveUserProcess`.
+- **UserProcessEvent**: Event model with `event_type`, `category`, `user_context`, `message`, `action_needed`. Used for both success and error events.
+- **UserContext**: Context attached to events with `email`, `name`, `center_id`, `registry_id`, `auth_email`.
+
+### New Enum Value
+
+- **EventCategory.USER_DISABLED**: New category `"User Disabled"` for disable success events. Error events during disable use `EventCategory.FLYWHEEL_ERROR`.
+
+### UserContext Construction for Inactive Entries
+
+`UserContext.from_user_entry` currently requires an `ActiveUserEntry`. For inactive entries (plain `UserEntry`), the `InactiveUserProcess` will construct `UserContext` directly:
+
+```python
+UserContext(
+    email=entry.email,
+    name=entry.name.as_str(),
+    center_id=entry.adcid if isinstance(entry, CenterUserEntry) else None,
+)
+```
+
+This avoids modifying the existing `UserContext.from_user_entry` class method, which is typed for `ActiveUserEntry`.
+
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: Inactive entry processing disables all matching Flywheel users
+
+*For any* inactive `UserEntry` and *for any* list of Flywheel users returned by `find_user_by_email(entry.email)`, `InactiveUserProcess.visit` SHALL call `disable_user` exactly once per matching user. When the match list is empty, `disable_user` SHALL not be called.
+
+**Validates: Requirements 1.1, 1.2, 1.4, 2.2**
+
+### Property 2: Email lookup returns matches regardless of dry-run mode
+
+*For any* email string and *for any* dry-run setting (True or False), `FlywheelProxy.find_user_by_email(email)` SHALL return the list of users from the underlying Flywheel client's `users.find` call without modification.
+
+**Validates: Requirements 3.1, 3.2, 3.3**
+
+### Property 3: Disable user calls SDK if and only if not in dry-run mode
+
+*For any* Flywheel `User` object, `FlywheelProxy.disable_user(user)` SHALL call `modify_user(user.id, {"disabled": True}, clear_permissions=True)` when `dry_run` is False, and SHALL NOT call `modify_user` when `dry_run` is True.
+
+**Validates: Requirements 4.1, 4.2**
+
+### Property 4: Disable user wraps SDK errors in FlywheelError
+
+*For any* Flywheel `User` object, if the underlying `modify_user` call raises an `ApiException`, then `FlywheelProxy.disable_user` SHALL raise a `FlywheelError` containing a descriptive message.
+
+**Validates: Requirements 4.3**
+
+### Property 5: Successful disable produces correctly-shaped success event
+
+*For any* inactive `UserEntry` and *for any* successfully disabled Flywheel user, the `UserEventCollector` SHALL receive a success event with category `USER_DISABLED` and a `UserContext` containing the entry's email, name, and center ID (when the entry is a `CenterUserEntry`).
+
+**Validates: Requirements 6.1, 6.4**
+
+### Property 6: Failed disable produces error event
+
+*For any* inactive `UserEntry` and *for any* Flywheel user whose disable operation raises a `FlywheelError`, the `UserEventCollector` SHALL receive an error event with a descriptive message and the entry's email in the `UserContext`.
+
+**Validates: Requirements 6.3**
+
+## Error Handling
+
+### FlywheelProxy.find_user_by_email
+
+- If the Flywheel SDK `users.find` call raises `ApiException`, the method raises `FlywheelError`. This is consistent with other proxy methods like `find_groups`.
+
+### FlywheelProxy.disable_user
+
+- If `modify_user` raises `ApiException`, the method wraps it in `FlywheelError` with a message including the user ID and the original error.
+- The caller (`InactiveUserProcess`) catches `FlywheelError` per-user and collects an error event, then continues with the next match.
+
+### InactiveUserProcess.visit
+
+- Errors from `find_user_by_email` propagate up to `UserQueue.apply`, which catches `FlywheelError` and logs it (existing batch-processing pattern).
+- Errors from `disable_user` are caught within the per-user loop inside `visit`, collected as error events, and processing continues.
+- If `entry.email` is None or empty, the lookup returns an empty list and no action is taken (no special handling needed).
+
+### Existing Error Boundaries
+
+The `UserQueue.apply` method already catches `FlywheelError`, `ValueError`, `KeyError`, and `AttributeError` per entry, logging the error and continuing. This ensures a single bad entry doesn't halt the entire inactive queue.
+
+## Testing Strategy
+
+### Property-Based Testing
+
+This feature is suitable for property-based testing because:
+- The core logic (lookup → disable → collect events) is pure function-like behavior with clear inputs and outputs
+- Input variation (different emails, different numbers of matches, dry-run vs not) reveals edge cases
+- The proxy methods are thin wrappers around SDK calls with clear contracts
+
+**Library**: [Hypothesis](https://hypothesis.readthedocs.io/) (Python PBT library, already available in the project ecosystem)
+
+**Configuration**: Minimum 100 iterations per property test.
+
+**Tag format**: `Feature: disable-inactive-users, Property {number}: {property_text}`
+
+Each correctness property maps to a single property-based test.
+
+### Unit Tests (Example-Based)
+
+- **Constructor acceptance** (Req 2.1): Verify `InactiveUserProcess` accepts both `UserProcessEnvironment` and `UserEventCollector`.
+- **Environment wiring** (Req 2.3): Verify `UserProcess.execute` passes environment to `InactiveUserProcess`.
+- **Log preservation** (Req 7.1): Verify the "processing inactive entry" log message appears before disable attempts.
+- **Log content** (Req 1.3): Verify disable log includes user ID and email.
+- **EventCategory member** (Req 6.2): Verify `EventCategory.USER_DISABLED` exists with value `"User Disabled"`.
+- **Type stub** (Req 5.1, 5.2): Verified by `pants check` (mypy). No runtime test needed.
+
+### Test Organization
+
+Tests go in `common/test/python/user_test/` following the existing test directory structure. Property tests and unit tests can coexist in the same test file or be split by component:
+
+- `test_inactive_user_process.py` — property tests for Properties 1, 5, 6 and unit tests for InactiveUserProcess
+- `test_flywheel_proxy_disable.py` — property tests for Properties 2, 3, 4 and unit tests for FlywheelProxy new methods
+
+### Mocking Strategy
+
+- **FlywheelProxy**: Mock the Flywheel `Client` (specifically `users.find` and `modify_user`) using `unittest.mock`. The proxy is constructed with the mock client.
+- **InactiveUserProcess**: Mock `FlywheelProxy` methods (`find_user_by_email`, `disable_user`) on a real or mock `UserProcessEnvironment`. Use a real `UserEventCollector` to verify collected events.
+- **Hypothesis generators**: Generate random `UserEntry` objects (with `active=False`), random email strings, and random lists of mock `flywheel.User` objects.

--- a/.kiro/specs/disable-inactive-users/disable-users-spec-prompt.md
+++ b/.kiro/specs/disable-inactive-users/disable-users-spec-prompt.md
@@ -1,0 +1,75 @@
+# Spec Prompt: Disable Inactive Users in User Management Gear
+
+## Goal
+
+Update the user management gear so that users marked inactive in the NACC directory are disabled in Flywheel rather than silently ignored.
+
+## Background
+
+The user management gear processes a directory of user entries. Each entry has an `active` flag. Currently, `InactiveUserProcess` simply logs "ignoring inactive entry" and does nothing. The desired behavior is to disable these users in Flywheel and clean up their associated records.
+
+## Current State
+
+- `InactiveUserProcess` in `common/src/python/users/user_processes.py` is a no-op — it logs and skips inactive entries
+- `FlywheelProxy` in `common/src/python/flywheel_adaptor/flywheel_proxy.py` has `find_user(user_id)` and `set_user_email()` but no method to disable a user or find users by email
+- `UserRegistry` in `common/src/python/users/user_registry.py` has no delete/removal capability
+- The mypy stub for `modify_user` in `mypy-stubs/src/python/flywheel/client.pyi` currently only accepts `Dict[str, str]` — it needs to also accept `bool` values and the `clear_permissions` parameter
+- `InactiveUserProcess` currently receives only a `UserEventCollector` — it has no access to `UserProcessEnvironment` and therefore no access to the Flywheel proxy or registry
+
+## Flywheel SDK Details
+
+The Flywheel SDK `Client.modify_user` method supports disabling a user:
+
+```python
+client.modify_user(user_id, {"disabled": True}, clear_permissions=True)
+```
+
+This disables the user account and removes all project/group permissions.
+
+## Requirements
+
+### Disable user in Flywheel
+
+When a user entry is marked inactive:
+1. Look up Flywheel users matching the entry's email address
+2. Disable each matching Flywheel user via `modify_user` with `{"disabled": True}` and `clear_permissions=True`
+3. Log each disable action
+
+### Provide access to environment
+
+`InactiveUserProcess` needs access to `UserProcessEnvironment` (or at minimum the `FlywheelProxy`) to perform the disable operation. Currently it only receives a `UserEventCollector`.
+
+### Update FlywheelProxy
+
+Add methods to `FlywheelProxy`:
+- `find_user_by_email(email: str)` — returns list of users matching the email
+- `disable_user(user: flywheel.User)` — calls `modify_user(user.id, {"disabled": True}, clear_permissions=True)`
+
+Both methods should respect the existing `dry_run` flag on the proxy.
+
+### Update type stub
+
+Update the `modify_user` signature in `mypy-stubs/src/python/flywheel/client.pyi` to:
+
+```python
+def modify_user(self, user_id: str, body: Dict[str, str | bool], clear_permissions: Optional[bool] = False) -> None:
+```
+
+### Event collection
+
+Disable events should be captured through the existing `UserEventCollector` pattern so they appear in the gear's output reporting.
+
+## Out of Scope (for now)
+
+- **Registry cleanup**: Deleting or deactivating records in the COManage registry. The previous branch had this commented out with a TODO. Defer until the COManage API behavior is confirmed.
+- **REDCap removal**: Removing users from REDCap projects. The previous branch had an empty stub for this. Defer to a separate effort.
+
+## Key Files
+
+- #[[file:common/src/python/users/user_processes.py]] — `InactiveUserProcess` class
+- #[[file:common/src/python/flywheel_adaptor/flywheel_proxy.py]] — `FlywheelProxy` class
+- #[[file:common/src/python/users/user_process_environment.py]] — `UserProcessEnvironment`
+- #[[file:common/src/python/users/user_entry.py]] — `UserEntry` model
+- #[[file:mypy-stubs/src/python/flywheel/client.pyi]] — type stub for Flywheel client
+- #[[file:gear/user_management/src/python/user_app/run.py]] — gear entry point
+- #[[file:gear/user_management/src/python/user_app/main.py]] — gear main logic

--- a/.kiro/specs/disable-inactive-users/requirements.md
+++ b/.kiro/specs/disable-inactive-users/requirements.md
@@ -1,0 +1,88 @@
+# Requirements Document
+
+## Introduction
+
+The user management gear processes a directory of user entries, each with an `active` flag. Currently, entries marked inactive are silently ignored by `InactiveUserProcess`, which only logs a message and takes no action. This feature updates the inactive user handling to disable matching Flywheel users and capture disable events for reporting. Registry cleanup (COManage) and REDCap removal are explicitly out of scope.
+
+## Glossary
+
+- **User_Management_Gear**: The Flywheel gear that processes a directory of user entries, splitting them into active and inactive queues and applying the appropriate process to each.
+- **InactiveUserProcess**: The user process class responsible for handling user entries marked inactive in the directory. Currently a no-op that logs and skips entries.
+- **UserEntry**: A base data model representing a single user record from the NACC directory, including fields for name, email, auth_email, active flag, and approved flag.
+- **FlywheelProxy**: A proxy class that wraps the Flywheel SDK client, providing methods for user lookup, creation, and modification while respecting a dry_run flag.
+- **UserProcessEnvironment**: An environment object that aggregates services (FlywheelProxy, UserRegistry, NotificationClient, NACCGroup, AuthMap) used by user process classes.
+- **UserEventCollector**: A collector that accumulates UserProcessEvent objects (successes and errors) during gear execution for downstream reporting and CSV export.
+- **Flywheel_User**: A user account on the Flywheel platform, identified by a user ID and email address.
+- **Dry_Run_Mode**: A mode in which FlywheelProxy logs intended actions without executing them against the Flywheel API.
+- **EventCategory**: An enumeration of event categories used to classify UserProcessEvent objects for reporting.
+
+## Requirements
+
+### Requirement 1: Disable Flywheel Users for Inactive Directory Entries
+
+**User Story:** As a system administrator, I want inactive directory entries to result in their matching Flywheel users being disabled, so that users who are no longer active in the NACC directory cannot access the platform.
+
+#### Acceptance Criteria
+
+1. WHEN a UserEntry with active=False is processed, THE InactiveUserProcess SHALL look up all Flywheel_User accounts matching the entry's email address.
+2. WHEN one or more matching Flywheel_User accounts are found for an inactive entry, THE InactiveUserProcess SHALL disable each matching Flywheel_User by calling FlywheelProxy with disabled=True and clear_permissions=True.
+3. WHEN a matching Flywheel_User is successfully disabled, THE InactiveUserProcess SHALL log the disable action including the user ID and email address.
+4. WHEN no matching Flywheel_User accounts are found for an inactive entry, THE InactiveUserProcess SHALL log that no matching users were found and take no further action.
+
+### Requirement 2: Provide Environment Access to InactiveUserProcess
+
+**User Story:** As a developer, I want InactiveUserProcess to have access to UserProcessEnvironment, so that it can use FlywheelProxy to disable users.
+
+#### Acceptance Criteria
+
+1. THE InactiveUserProcess SHALL accept a UserProcessEnvironment parameter in addition to the existing UserEventCollector parameter.
+2. THE InactiveUserProcess SHALL use the FlywheelProxy from the UserProcessEnvironment to look up and disable Flywheel users.
+3. WHEN the UserProcess class instantiates InactiveUserProcess, THE UserProcess SHALL pass the UserProcessEnvironment to InactiveUserProcess.
+
+### Requirement 3: Add Email-Based User Lookup to FlywheelProxy
+
+**User Story:** As a developer, I want FlywheelProxy to support looking up Flywheel users by email address, so that InactiveUserProcess can find users to disable.
+
+#### Acceptance Criteria
+
+1. THE FlywheelProxy SHALL provide a find_user_by_email method that accepts an email address string and returns a list of matching Flywheel_User objects.
+2. WHEN no Flywheel_User accounts match the provided email address, THE FlywheelProxy find_user_by_email method SHALL return an empty list.
+3. WHILE Dry_Run_Mode is enabled, THE FlywheelProxy find_user_by_email method SHALL execute the lookup and return results without modification, since lookups are read-only operations.
+
+### Requirement 4: Add User Disable Method to FlywheelProxy
+
+**User Story:** As a developer, I want FlywheelProxy to provide a method to disable a Flywheel user, so that the disable logic is encapsulated and respects the dry_run flag.
+
+#### Acceptance Criteria
+
+1. THE FlywheelProxy SHALL provide a disable_user method that accepts a Flywheel_User object and calls the Flywheel SDK modify_user with the user's ID, a body of {"disabled": True}, and clear_permissions=True.
+2. WHILE Dry_Run_Mode is enabled, THE FlywheelProxy disable_user method SHALL log the intended disable action and skip the actual API call.
+3. IF the Flywheel SDK modify_user call fails with an API error, THEN THE FlywheelProxy disable_user method SHALL raise a FlywheelError with a descriptive message.
+
+### Requirement 5: Update Flywheel Client Type Stub
+
+**User Story:** As a developer, I want the mypy type stub for the Flywheel Client.modify_user method to accept boolean values in the body dictionary and the clear_permissions parameter, so that the disable_user implementation passes type checking.
+
+#### Acceptance Criteria
+
+1. THE modify_user signature in the Flywheel Client type stub SHALL accept a body parameter of type Dict[str, str | bool].
+2. THE modify_user signature in the Flywheel Client type stub SHALL accept an optional clear_permissions parameter of type bool with a default value of False.
+
+### Requirement 6: Capture Disable Events via UserEventCollector
+
+**User Story:** As a system administrator, I want disable actions to be captured as events, so that they appear in the gear's output reporting alongside other user processing events.
+
+#### Acceptance Criteria
+
+1. WHEN a Flywheel_User is successfully disabled, THE InactiveUserProcess SHALL collect a success event through the UserEventCollector with a category indicating the user was disabled.
+2. THE EventCategory enumeration SHALL include a category for user disable events.
+3. IF a Flywheel_User disable operation fails, THEN THE InactiveUserProcess SHALL collect an error event through the UserEventCollector with a descriptive error message.
+4. THE disable events collected by the UserEventCollector SHALL include the user's email address, name, and center ID when available in the UserContext.
+
+### Requirement 7: Preserve Existing Inactive Entry Logging
+
+**User Story:** As a developer, I want the existing log output for inactive entries to be preserved, so that operational logs remain consistent.
+
+#### Acceptance Criteria
+
+1. WHEN an inactive UserEntry is processed, THE InactiveUserProcess SHALL log that it is processing the inactive entry before attempting to disable matching Flywheel users.

--- a/.kiro/specs/disable-inactive-users/tasks.md
+++ b/.kiro/specs/disable-inactive-users/tasks.md
@@ -1,0 +1,109 @@
+# Implementation Plan: Disable Inactive Users
+
+## Overview
+
+Update the user management gear so that users marked inactive in the NACC directory are disabled in Flywheel. The implementation adds email-based user lookup and disable methods to `FlywheelProxy`, updates `InactiveUserProcess` to use the environment for disabling users, adds a new `EventCategory` member, updates the type stub for `modify_user`, and wires the environment through `UserProcess`.
+
+## Tasks
+
+- [x] 1. Update Flywheel Client type stub and add EventCategory member
+  - [x] 1.1 Update `modify_user` signature in `mypy-stubs/src/python/flywheel/client.pyi`
+    - Change `body` parameter type from `Dict[str, str]` to `Dict[str, str | bool]`
+    - Add `clear_permissions: bool = False` parameter
+    - _Requirements: 5.1, 5.2_
+  - [x] 1.2 Add `USER_DISABLED` member to `EventCategory` in `common/src/python/users/event_models.py`
+    - Add `USER_DISABLED = "User Disabled"` to the `EventCategory` enum
+    - _Requirements: 6.2_
+
+- [x] 2. Add `find_user_by_email` and `disable_user` methods to FlywheelProxy
+  - [x] 2.1 Implement `find_user_by_email` in `common/src/python/flywheel_adaptor/flywheel_proxy.py`
+    - Add method `find_user_by_email(self, email: str) -> List[flywheel.User]`
+    - Use `self.__fw.users.find(f"email={email}")` to look up users
+    - Execute lookup regardless of `dry_run` mode (read-only operation)
+    - Raise `FlywheelError` if `ApiException` occurs
+    - _Requirements: 3.1, 3.2, 3.3_
+  - [x] 2.2 Implement `disable_user` in `common/src/python/flywheel_adaptor/flywheel_proxy.py`
+    - Add method `disable_user(self, user: flywheel.User) -> None`
+    - In non-dry-run mode: call `self.__fw.modify_user(user.id, {"disabled": True}, clear_permissions=True)`
+    - In dry-run mode: log the intended action and return without calling the API
+    - Wrap `ApiException` in `FlywheelError` with a descriptive message including user ID
+    - _Requirements: 4.1, 4.2, 4.3_
+  - [ ]* 2.3 Write property test for `find_user_by_email` (Property 2: Email lookup returns matches regardless of dry-run mode)
+    - **Property 2: Email lookup returns matches regardless of dry-run mode**
+    - **Validates: Requirements 3.1, 3.2, 3.3**
+    - Create `common/test/python/user_test/test_flywheel_proxy_disable.py`
+    - Use Hypothesis to generate random email strings and dry-run settings
+    - Mock the Flywheel `Client.users.find` method
+    - Verify the lookup result is returned unmodified for both dry_run=True and dry_run=False
+  - [x] 2.4 Write property test for `disable_user` dry-run behavior (Property 3: Disable user calls SDK if and only if not in dry-run mode)
+    - **Property 3: Disable user calls SDK if and only if not in dry-run mode**
+    - **Validates: Requirements 4.1, 4.2**
+    - Add to `common/test/python/user_test/test_flywheel_proxy_disable.py`
+    - Use Hypothesis to generate mock User objects and dry-run settings
+    - Verify `modify_user` is called exactly when `dry_run=False` and not called when `dry_run=True`
+  - [x] 2.5 Write property test for `disable_user` error wrapping (Property 4: Disable user wraps SDK errors in FlywheelError)
+    - **Property 4: Disable user wraps SDK errors in FlywheelError**
+    - **Validates: Requirements 4.3**
+    - Add to `common/test/python/user_test/test_flywheel_proxy_disable.py`
+    - Use Hypothesis to generate mock User objects
+    - Configure mock `modify_user` to raise `ApiException`
+    - Verify `FlywheelError` is raised with a descriptive message
+
+- [x] 3. Update `InactiveUserProcess` to disable matching Flywheel users
+  - [x] 3.1 Update `InactiveUserProcess.__init__` to accept `UserProcessEnvironment`
+    - Add `environment: UserProcessEnvironment` parameter before `collector`
+    - Store environment as `self.__env`
+    - _Requirements: 2.1, 2.2_
+  - [x] 3.2 Implement disable logic in `InactiveUserProcess.visit`
+    - Preserve existing log message for the inactive entry (Req 7.1)
+    - Call `self.__env.proxy.find_user_by_email(entry.email)` to look up matching users
+    - If no matches: log that no matching users were found and return
+    - For each match: call `self.__env.proxy.disable_user(user)`, log the disable action with user ID and email
+    - On successful disable: collect a success event with category `USER_DISABLED` and `UserContext` containing email, name, and center_id
+    - On `FlywheelError`: collect an error event with descriptive message, continue with next user
+    - Construct `UserContext` directly (not via `from_user_entry`) since entry is a plain `UserEntry`
+    - _Requirements: 1.1, 1.2, 1.3, 1.4, 6.1, 6.3, 6.4, 7.1_
+  - [x] 3.3 Write property test for inactive entry processing (Property 1: Inactive entry processing disables all matching Flywheel users)
+    - **Property 1: Inactive entry processing disables all matching Flywheel users**
+    - **Validates: Requirements 1.1, 1.2, 1.4, 2.2**
+    - Create `common/test/python/user_test/test_inactive_user_process.py`
+    - Use Hypothesis to generate `UserEntry` objects with `active=False` and random lists of mock Flywheel users
+    - Mock `FlywheelProxy.find_user_by_email` and `FlywheelProxy.disable_user`
+    - Verify `disable_user` is called exactly once per matching user, and not called when match list is empty
+  - [ ]* 3.4 Write property test for successful disable events (Property 5: Successful disable produces correctly-shaped success event)
+    - **Property 5: Successful disable produces correctly-shaped success event**
+    - **Validates: Requirements 6.1, 6.4**
+    - Add to `common/test/python/user_test/test_inactive_user_process.py`
+    - Use Hypothesis to generate inactive `UserEntry` and `CenterUserEntry` objects with mock Flywheel users
+    - Verify collected success events have category `USER_DISABLED` and `UserContext` with correct email, name, and center_id
+  - [ ]* 3.5 Write property test for failed disable events (Property 6: Failed disable produces error event)
+    - **Property 6: Failed disable produces error event**
+    - **Validates: Requirements 6.3**
+    - Add to `common/test/python/user_test/test_inactive_user_process.py`
+    - Use Hypothesis to generate inactive `UserEntry` objects
+    - Configure mock `disable_user` to raise `FlywheelError`
+    - Verify an error event is collected with a descriptive message and the entry's email in `UserContext`
+
+- [x] 4. Wire environment through `UserProcess` to `InactiveUserProcess`
+  - [x] 4.1 Update `UserProcess.execute` to pass environment to `InactiveUserProcess`
+    - Change `InactiveUserProcess(self.collector)` to `InactiveUserProcess(self.__env, self.collector)`
+    - _Requirements: 2.3_
+  - [ ]* 4.2 Write unit tests for environment wiring and log preservation
+    - Add to `common/test/python/user_test/test_inactive_user_process.py`
+    - Verify `InactiveUserProcess` accepts both `UserProcessEnvironment` and `UserEventCollector` (Req 2.1)
+    - Verify `UserProcess.execute` passes environment to `InactiveUserProcess` (Req 2.3)
+    - Verify the "processing inactive entry" log message appears before disable attempts (Req 7.1)
+    - Verify disable log includes user ID and email (Req 1.3)
+    - _Requirements: 1.3, 2.1, 2.3, 7.1_
+
+- [x] 5. Final checkpoint - Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for faster MVP
+- Each task references specific requirements for traceability
+- Property tests validate universal correctness properties from the design document
+- Unit tests validate specific examples and edge cases
+- The design uses Python — no language selection needed
+- Registry cleanup (COManage) and REDCap removal are explicitly out of scope

--- a/.kiro/specs/redcap-user-disable/.config.kiro
+++ b/.kiro/specs/redcap-user-disable/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "49d51e77-787e-4f47-857f-bf39fd35322f", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/redcap-user-disable/design.md
+++ b/.kiro/specs/redcap-user-disable/design.md
@@ -1,0 +1,351 @@
+# Design Document: REDCap User Disable
+
+## Overview
+
+This feature adds REDCap user role removal to the `InactiveUserProcess` disable flow and reorders the steps so that COmanage suspension happens last. When a user is marked inactive in the NACC directory, the system currently disables them in Flywheel and suspends them in COmanage. This design extends that flow to also unassign the user's role from all REDCap projects they may have access to, and sends a notification email to administrators for manual REDCap account suspension (which is not available via the REDCap API).
+
+The new step order is: (1) Flywheel disable, (2) COmanage lookup (resolve auth_email), (3) REDCap role removal, (4) COmanage suspend. This ensures all service-level access is removed before the identity-provider-level suspension.
+
+The design follows the existing patterns in `InactiveUserProcess`: best-effort processing, independent steps, dry-run support, and event collection via `UserEventCollector`.
+
+### Key Design Decisions
+
+1. **Local wrapper, not library modification**: A local helper function wraps `REDCapProject.assign_user_role(username, "")` rather than modifying the external `redcap_api` library. This keeps the change self-contained.
+2. **Visitor pattern for center iteration**: A new `REDCapDisableVisitor` implements `AbstractCenterMetadataVisitor` to traverse center metadata and find all REDCap projects, consistent with how `CenterAuthorizationVisitor` grants access.
+3. **Auth email resolution reuses COmanage lookup**: The COmanage registry lookup is separated from the suspend action. The lookup runs early (Step 2) to resolve `auth_email` for the REDCap step, while the actual suspend runs last (Step 4) so that COmanage suspension happens after all other services have been disabled.
+4. **Notification per user, not per project**: A single notification email is sent per user listing all affected REDCap projects, rather than one email per project.
+5. **COmanage suspend runs last**: COmanage suspension is deferred to Step 4 so that Flywheel and REDCap are disabled first. This ensures the user's COmanage record remains active while the other services are being cleaned up, and places the identity-provider-level action last in the sequence.
+
+## Architecture
+
+The disable flow in `InactiveUserProcess.visit()` is restructured into four steps. The COmanage registry lookup (Step 2) is separated from the COmanage suspend (Step 4) so that the `auth_email` is available for the REDCap step (Step 3) while the actual suspension happens last. Each step remains independent — failure of one does not block the others.
+
+1. **Step 1: Disable in Flywheel** — find and disable matching Flywheel users
+2. **Step 2: COmanage lookup** — look up registry persons to resolve `auth_email` (no suspend yet)
+3. **Step 3: Remove REDCap roles** — unassign user roles from all REDCap projects, send admin notification
+4. **Step 4: Suspend in COmanage** — suspend the registry persons found in Step 2
+
+```mermaid
+flowchart TD
+    A[InactiveUserProcess.visit] --> B[Step 1: Disable in Flywheel]
+    A --> C[Step 2: COmanage lookup]
+    C --> D{Registry person found?}
+    D -->|Yes| E[Extract auth_email + person_list]
+    D -->|No| F[auth_email = None]
+    
+    E --> G[Step 3: Remove REDCap roles]
+    F --> G
+    
+    G --> H[Resolve REDCap username]
+    H --> I{auth_email available?}
+    I -->|From entry| J[Use entry.auth_email]
+    I -->|From Step 2| K[Use resolved auth_email]
+    I -->|No match| L[Use directory email]
+    
+    J --> M[Iterate all centers]
+    K --> M
+    L --> M
+    
+    M --> N[For each center]
+    N --> O[Get CenterMetadata]
+    O --> P[For each FormIngestProject]
+    P --> Q[For each REDCap project]
+    Q --> R{Dry run?}
+    R -->|Yes| S[Log intended action]
+    R -->|No| T[Call unassign_user_role]
+    T --> U{Success?}
+    U -->|Yes| V[Collect success event]
+    U -->|No| W[Collect error event]
+    
+    M --> X{Any successes?}
+    X -->|Yes| Y[Send admin notification email]
+    X -->|No| Z[Skip notification]
+    
+    G --> AA[Step 4: Suspend in COmanage]
+    AA --> AB{person_list from Step 2?}
+    AB -->|Yes| AC[Suspend each person]
+    AB -->|No| AD[Skip - no persons found]
+```
+
+## Components and Interfaces
+
+### 1. Local Helper Function: `unassign_user_role`
+
+**Location**: `common/src/python/users/redcap_user_operations.py` (new file)
+
+```python
+def unassign_user_role(redcap_project: REDCapProject, username: str) -> int:
+    """Unassign a user from their role in a REDCap project.
+
+    Calls assign_user_role with an empty role string, which removes the
+    user's role-based permissions without deleting the user record.
+
+    Args:
+        redcap_project: The REDCap project instance
+        username: The REDCap username (typically the auth_email)
+
+    Returns:
+        Number of user-role assignments updated
+
+    Raises:
+        REDCapConnectionError: If the underlying API call fails
+    """
+```
+
+This is a thin wrapper that calls `redcap_project.assign_user_role(username, "")` and returns the result. It does not catch `REDCapConnectionError` — that is left to the caller.
+
+### 2. REDCapDisableVisitor
+
+**Location**: `common/src/python/users/redcap_disable_visitor.py` (new file)
+
+Implements `AbstractCenterMetadataVisitor` to traverse center metadata and collect all REDCap project PIDs associated with form ingest projects.
+
+```python
+class REDCapDisableVisitor(AbstractCenterMetadataVisitor):
+    """Visitor that collects REDCap project PIDs from center metadata."""
+
+    @property
+    def redcap_pids(self) -> list[int]:
+        """Returns the list of REDCap project PIDs found."""
+```
+
+The visitor walks the center metadata tree:
+- `visit_center` → iterates studies
+- `visit_study` → iterates ingest projects
+- `visit_form_ingest_project` → collects `redcap_pid` from each `REDCapFormProjectMetadata`
+- All other visit methods are no-ops
+
+### 3. REDCap Disable Logic in InactiveUserProcess
+
+**Location**: Modified `common/src/python/users/user_processes.py`
+
+New private method `__disable_in_redcap` added to `InactiveUserProcess`:
+
+```python
+def __disable_in_redcap(
+    self,
+    entry: UserEntry,
+    user_context: UserContext,
+    auth_email: Optional[str],
+) -> None:
+    """Step 3: Remove user roles from all REDCap projects.
+
+    Args:
+        entry: The inactive user entry
+        user_context: The user context for event collection
+        auth_email: The resolved auth_email from COmanage lookup in Step 2 (if found)
+    """
+```
+
+**Username resolution logic**:
+
+1. If `entry.auth_email` is set, use it directly (no additional lookup needed)
+2. Else if `auth_email` parameter is provided (from Step 2's COmanage lookup), use it
+3. Else fall back to `entry.email` (directory email)
+
+**Iteration logic**:
+1. Get center map from `self.__env.admin_group.get_center_map()`
+2. For each center, call `self.__env.admin_group.get_center(adcid)` to get `CenterGroup`
+3. If center cannot be retrieved, log and continue
+4. Get `CenterMetadata` via `center_group.get_project_info()`
+5. Apply `REDCapDisableVisitor` to collect REDCap PIDs
+6. For each PID, get `REDCapProject` via `center_group.get_redcap_project(pid)`
+7. If project unavailable, log and continue
+8. Call `unassign_user_role(redcap_project, username)`
+9. Collect success or error event with `REDCAP_USER_DISABLED` category
+10. Track successes for notification
+
+**Dry-run support**: Check `self.__env.proxy.dry_run` before calling `unassign_user_role`. In dry-run mode, log the intended action and collect a success event noting it was a dry run.
+
+### 4. Notification Email
+
+After iterating all centers, if any role unassignments succeeded, send a notification email using `EmailClient.send_raw`:
+
+- **To**: Support email addresses (passed to `InactiveUserProcess` at construction)
+- **Subject**: `[REDCap] inactive users to suspend`
+- **Body**: Plain text containing:
+  - User's directory email
+  - Resolved REDCap username
+  - List of REDCap projects where roles were removed (title and PID)
+  - Note that manual suspension is required
+
+### 5. Updated InactiveUserProcess Constructor
+
+`InactiveUserProcess` needs access to:
+- **Support email addresses**: Passed as a new constructor parameter `support_emails: list[str]`
+- **EmailClient**: Passed as a new constructor parameter `email_client: Optional[EmailClient]`
+
+These are wired in `gear/user_management/src/python/user_app/run.py` where the `EmailClient` and support emails are already available.
+
+### 6. New EventCategory
+
+**Location**: Modified `common/src/python/users/event_models.py`
+
+```python
+class EventCategory(Enum):
+    # ... existing categories ...
+    REDCAP_USER_DISABLED = "REDCap User Disabled"
+```
+
+### 7. Updated UserProcessEnvironment
+
+No changes needed to `UserProcessEnvironment` itself — `InactiveUserProcess` already has access to `admin_group` (which provides `NACCGroup` with center map and REDCap param repo) and `proxy` (which provides `dry_run`). The email client and support emails are passed directly to `InactiveUserProcess` as constructor parameters to avoid broadening the `UserProcessEnvironment` interface unnecessarily.
+
+## Data Models
+
+### Existing Models (No Changes)
+
+- **`REDCapProject`**: Used as-is. `assign_user_role(username, "")` performs role unassignment.
+- **`REDCapParametersRepository`**: Used as-is. Provides `get_redcap_project(pid)` to obtain `REDCapProject` instances.
+- **`CenterMetadata`** / **`FormIngestProjectMetadata`** / **`REDCapFormProjectMetadata`**: Used as-is for traversal.
+- **`UserContext`**: Used as-is for event collection.
+- **`UserProcessEvent`**: Used as-is for event collection.
+
+### Modified Models
+
+- **`EventCategory`**: Add `REDCAP_USER_DISABLED = "REDCap User Disabled"` enum member.
+
+### New Models
+
+No new data models are needed. The `REDCapDisableVisitor` collects PIDs as a simple `list[int]` and the notification email is built from plain strings.
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    A[UserEntry.email] --> B[Registry Lookup]
+    B --> C[RegistryPerson.email_address.mail]
+    C --> D[REDCap username]
+    A --> D
+    
+    E[NACCGroup.get_center_map] --> F[CenterGroup]
+    F --> G[CenterMetadata]
+    G --> H[FormIngestProjectMetadata]
+    H --> I[REDCapFormProjectMetadata.redcap_pid]
+    I --> J[REDCapParametersRepository.get_redcap_project]
+    J --> K[REDCapProject]
+    
+    D --> L[unassign_user_role]
+    K --> L
+    L --> M[UserProcessEvent]
+```
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: Auth email resolution correctness
+
+*For any* inactive user entry and any COmanage registry person with an `email_address`, when the registry lookup returns that person, the REDCap username used for role unassignment should equal the registry person's primary email address (auth_email). When no registry person is found and the entry has no `auth_email`, the directory email should be used instead.
+
+**Validates: Requirements 2.2, 2.3, 2.4**
+
+### Property 2: Complete REDCap project iteration
+
+*For any* set of centers in the NACCGroup, each containing an arbitrary number of studies with form ingest projects referencing REDCap projects, the disable step should attempt role unassignment in every REDCap project found across all centers (where API credentials are available).
+
+**Validates: Requirements 3.1, 3.3**
+
+### Property 3: Step independence
+
+*For any* combination of failures across the four disable steps (Flywheel disable, COmanage lookup, REDCap role removal, COmanage suspend), each step that does not itself fail should still execute successfully. Specifically, a failure in any one step should not prevent the other steps from running. The COmanage lookup (Step 2) feeds data to both the REDCap step (Step 3) and the COmanage suspend step (Step 4), but a lookup failure should result in graceful fallback (directory email for REDCap, skip for suspend) rather than blocking those steps.
+
+**Validates: Requirements 3.6**
+
+### Property 4: Event correctness
+
+*For any* REDCap project (with a title and PID) and any user (with email, name, and center ID), when a role unassignment is attempted, the collected `UserProcessEvent` should have category `REDCAP_USER_DISABLED`, the message should contain the project title and PID, and the `UserContext` should contain the user's email, name, and center ID.
+
+**Validates: Requirements 4.2, 4.3, 4.4**
+
+### Property 5: Notification email content completeness
+
+*For any* user directory email, resolved REDCap username, and non-empty list of REDCap projects where roles were successfully removed, the notification email body should contain the directory email, the REDCap username, and every project's title and PID from the success list.
+
+**Validates: Requirements 5.2**
+
+### Property 6: Summary accuracy
+
+*For any* combination of successful and failed REDCap project role unassignments, the summary used for notification and event reporting should accurately reflect which projects succeeded and which failed, with no projects missing or miscategorized.
+
+**Validates: Requirements 7.4**
+
+## Error Handling
+
+### Error Categories
+
+| Error Scenario | Handling | Event |
+|---|---|---|
+| CenterGroup cannot be retrieved | Log warning, skip center, continue | No event (not a user-specific error) |
+| CenterMetadata parse failure | Log warning, skip center, continue | No event |
+| No form ingest projects in center | Log info, skip center, continue | No event |
+| REDCap project credentials unavailable | Log warning, skip project, continue | Error event (REDCAP_USER_DISABLED) |
+| `assign_user_role` raises `REDCapConnectionError` | Log error, collect error event, continue | Error event (REDCAP_USER_DISABLED) |
+| Notification email fails to send | Log error, continue processing | No event (notification is best-effort) |
+| No registry person found for email | Use directory email as fallback | No event |
+
+### Error Propagation
+
+- Errors within the REDCap disable step are caught and logged per-project. They do not propagate to the caller.
+- The REDCap step does not raise exceptions that would prevent subsequent users from being processed.
+- `REDCapConnectionError` from the helper function is caught by the `__disable_in_redcap` method.
+- `EmailSendError` from the notification email is caught and logged.
+
+### Dry-Run Mode
+
+When `self.__env.proxy.dry_run` is `True`:
+- `unassign_user_role` is **not** called
+- A log message is emitted: `"DRY RUN: Would unassign role for {username} in REDCap project {title} (PID {pid})"`
+- A success event is still collected (with a dry-run note in the message) so the notification email reflects what *would* happen
+- The notification email is still sent (so admins can review the dry-run results)
+
+## Testing Strategy
+
+### Property-Based Tests
+
+Property-based testing is appropriate for this feature because the core logic involves:
+- Username resolution with multiple fallback paths (varies with input)
+- Iteration over arbitrary center/project configurations (varies with structure)
+- Event collection with varying user and project data
+
+**Library**: [Hypothesis](https://hypothesis.readthedocs.io/) (already available in the project's test dependencies)
+
+**Configuration**: Minimum 100 iterations per property test.
+
+**Tag format**: `Feature: redcap-user-disable, Property {number}: {property_text}`
+
+Each correctness property from the design should be implemented as a single property-based test.
+
+### Unit Tests (Example-Based)
+
+| Test | Validates |
+|---|---|
+| `test_unassign_user_role_calls_assign_with_empty_role` | Req 1.1 |
+| `test_unassign_user_role_returns_count` | Req 1.2 |
+| `test_unassign_user_role_propagates_connection_error` | Req 1.3 |
+| `test_registry_lookup_uses_directory_email` | Req 2.1 |
+| `test_entry_auth_email_skips_registry_lookup` | Req 2.4 |
+| `test_fallback_to_directory_email_when_no_registry_match` | Req 2.3 |
+| `test_skip_center_with_no_form_ingest_projects` | Req 3.2 |
+| `test_skip_project_with_unavailable_credentials` | Req 3.4 |
+| `test_continue_after_unassignment_failure` | Req 3.5 |
+| `test_dry_run_skips_api_calls` | Req 3.7 |
+| `test_redcap_user_disabled_event_category_exists` | Req 4.1 |
+| `test_notification_sent_on_success` | Req 5.1 |
+| `test_notification_subject` | Req 5.3 |
+| `test_notification_uses_send_raw` | Req 5.4 |
+| `test_no_notification_when_no_unassignments` | Req 5.5 |
+| `test_notification_failure_does_not_raise` | Req 5.6 |
+| `test_continue_after_center_retrieval_failure` | Req 7.2 |
+
+### Integration Points
+
+- The `REDCapDisableVisitor` should be tested against realistic `CenterMetadata` structures (using the existing test fixtures for center metadata if available).
+- The wiring in `run.py` should be verified to ensure `EmailClient` and `support_emails` are passed to `InactiveUserProcess`.
+
+### Test File Locations
+
+Following the project's test directory conventions:
+- `common/test/python/user_test/test_redcap_user_operations.py` — tests for the helper function
+- `common/test/python/user_test/test_redcap_disable_visitor.py` — tests for the visitor
+- `common/test/python/user_test/test_inactive_user_process_redcap.py` — tests for the REDCap disable step in `InactiveUserProcess`

--- a/.kiro/specs/redcap-user-disable/requirements.md
+++ b/.kiro/specs/redcap-user-disable/requirements.md
@@ -1,0 +1,108 @@
+# Requirements Document
+
+## Introduction
+
+The user management gear's `InactiveUserProcess` currently disables users in Flywheel and suspends them in COmanage when they are marked inactive in the directory. However, it does not touch REDCap. Users who have been granted role-based access to REDCap projects retain those permissions after being disabled elsewhere. This feature adds REDCap user role removal as a third step in the inactive user disable flow, and sends a notification email to REDCap administrators flagging the user for manual account suspension (which is not available via the REDCap API).
+
+## Glossary
+
+- **InactiveUserProcess**: The user process class responsible for handling user entries marked inactive in the directory. Currently disables Flywheel users and suspends COmanage registry persons.
+- **REDCapProject**: A class in the `redcap_api` library representing a REDCap project, providing methods for user-role assignment, record import/export, and role management.
+- **REDCapParametersRepository**: A repository holding API credentials (keyed by PID) for REDCap projects, used to obtain `REDCapProject` instances.
+- **NACCGroup**: A singleton class representing the NACC admin group, holding center information and the `REDCapParametersRepository`.
+- **CenterGroup**: An adaptor for a Flywheel group representing a research center, providing access to center metadata and REDCap project connections.
+- **CenterMetadata**: Metadata stored in a center's metadata project, containing study information and associated ingest projects.
+- **FormIngestProjectMetadata**: Metadata for a form ingest project within a center, containing references to associated REDCap projects via `redcap_projects`.
+- **REDCapFormProjectMetadata**: Metadata for a specific REDCap form project, including the `redcap_pid` used to retrieve the `REDCapProject` from the repository.
+- **UserProcessEnvironment**: An environment object aggregating services (FlywheelProxy, UserRegistry, NotificationClient, NACCGroup, AuthMap) used by user process classes.
+- **UserEventCollector**: A collector that accumulates `UserProcessEvent` objects (successes and errors) during gear execution for downstream reporting and CSV export.
+- **EventCategory**: An enumeration of event categories used to classify `UserProcessEvent` objects for reporting.
+- **EmailClient**: A wrapper for the boto3 SES client used to send notification emails.
+- **UserRegistry**: A wrapper for the COmanage registry API, providing methods to look up, add, suspend, and re-enable registry persons.
+- **RegistryPerson**: A data model representing a person record in the COmanage registry, including email addresses and authentication identifiers.
+- **Auth_Email**: The authentication email address from the COmanage registry, used as the REDCap username when granting project access.
+- **Directory_Email**: The email address from the NACC directory entry, which may differ from the auth_email.
+- **Role_Unassignment**: The act of removing a user's role-based permissions in a REDCap project by calling `assign_user_role(username, "")`, which passes an empty `unique_role_name`.
+- **Dry_Run_Mode**: A mode in which operations are logged but not executed against external APIs.
+
+## Requirements
+
+### Requirement 1: Provide Local Wrapper for REDCap Role Unassignment
+
+**User Story:** As a developer, I want a local helper function that unassigns a user from their role in a REDCap project, so that the disable flow can remove REDCap permissions using a clear, intention-revealing API without modifying the external `redcap_api` library.
+
+#### Acceptance Criteria
+
+1. THE codebase SHALL provide a local helper function (not in the `redcap_api` library) that accepts a REDCapProject instance and a username string, and calls `REDCapProject.assign_user_role` with the username and an empty string for the role to perform Role_Unassignment.
+2. WHEN the helper function is called, THE helper function SHALL return the number of user-role assignments updated.
+3. IF the underlying `assign_user_role` call raises a REDCapConnectionError, THEN THE helper function SHALL propagate the error to the caller.
+
+### Requirement 2: Resolve REDCap Username from Directory Entry
+
+**User Story:** As a developer, I want the disable flow to determine the correct REDCap username for an inactive user, so that role unassignment targets the correct account in each REDCap project.
+
+#### Acceptance Criteria
+
+1. WHEN an inactive user entry is processed for REDCap role removal, THE InactiveUserProcess SHALL look up the user in the COmanage registry using the directory email to obtain the auth_email.
+2. WHEN a matching COmanage registry person is found with an auth_email, THE InactiveUserProcess SHALL use the auth_email as the REDCap username for role unassignment.
+3. WHEN no matching COmanage registry person is found, THE InactiveUserProcess SHALL fall back to using the directory email as the REDCap username.
+4. WHEN the user entry already contains an auth_email field, THE InactiveUserProcess SHALL use the auth_email from the entry without an additional registry lookup.
+
+### Requirement 3: Remove REDCap Roles When a User Is Disabled
+
+**User Story:** As a system administrator, I want inactive users to have their role assignments removed from all REDCap projects they may have access to, so that disabled users lose REDCap permissions as part of the standard disable flow.
+
+#### Acceptance Criteria
+
+1. WHEN an inactive user entry is processed, THE InactiveUserProcess SHALL iterate over all centers in the NACCGroup and examine each center's CenterMetadata for form ingest projects that have associated REDCap projects (via `FormIngestProjectMetadata.redcap_projects`).
+2. WHEN a center's metadata contains no form ingest projects or no REDCap project references, THE InactiveUserProcess SHALL skip that center without error.
+3. WHEN a REDCap project is found in a center's form ingest metadata, THE InactiveUserProcess SHALL attempt to unassign the user's role in that REDCap project using the resolved REDCap username.
+4. WHEN a REDCap project's API credentials are unavailable in the REDCapParametersRepository, THE InactiveUserProcess SHALL log the error and continue processing remaining projects.
+5. IF a role unassignment call fails for a specific REDCap project, THEN THE InactiveUserProcess SHALL log the error, collect an error event, and continue processing remaining REDCap projects.
+6. THE REDCap role removal step SHALL be independent of the Flywheel disable and COmanage suspend steps; failure of any one step SHALL NOT prevent the other steps from executing.
+7. WHILE Dry_Run_Mode is enabled, THE InactiveUserProcess SHALL log the intended REDCap role unassignment actions and skip the actual API calls.
+
+### Requirement 4: Add Event Tracking for REDCap Disable Actions
+
+**User Story:** As a system administrator, I want REDCap disable actions to be tracked as distinct events, so that they appear separately from Flywheel disable events in reporting and error CSV output.
+
+#### Acceptance Criteria
+
+1. THE EventCategory enumeration SHALL include a `REDCAP_USER_DISABLED` category with the display value "REDCap User Disabled".
+2. WHEN a user's role is successfully unassigned from a REDCap project, THE InactiveUserProcess SHALL collect a success event through the UserEventCollector with the `REDCAP_USER_DISABLED` category, including the REDCap project title and PID in the message.
+3. IF a REDCap role unassignment fails, THEN THE InactiveUserProcess SHALL collect an error event through the UserEventCollector with the `REDCAP_USER_DISABLED` category, including the error details and REDCap project identifier in the message.
+4. THE REDCap disable events collected by the UserEventCollector SHALL include the user's email address, name, and center ID in the UserContext when available.
+
+### Requirement 5: Send Notification for Manual REDCap Suspension
+
+**User Story:** As a REDCap administrator, I want to receive a notification email when a user's REDCap roles have been removed, so that I can manually suspend the user's REDCap account (which cannot be done via the API).
+
+#### Acceptance Criteria
+
+1. WHEN one or more REDCap role unassignments are completed for an inactive user, THE InactiveUserProcess SHALL send a notification email to the configured support email addresses (the same addresses already stored in AWS SSM Parameter Store and used for error notifications in user management).
+2. THE notification email SHALL include the user's directory email, the resolved REDCap username, and a list of REDCap projects from which roles were removed (including project title and PID).
+3. THE notification email subject SHALL be "[REDCap] inactive users to suspend".
+4. THE notification email SHALL be sent using the existing EmailClient infrastructure with the `send_raw` method.
+5. IF no REDCap role unassignments were performed for the user (no REDCap projects found or all attempts failed), THEN THE InactiveUserProcess SHALL NOT send a REDCap suspension notification for that user.
+6. IF the notification email fails to send, THEN THE InactiveUserProcess SHALL log the error and continue processing remaining users without raising an exception.
+
+### Requirement 6: Provide REDCap Access to InactiveUserProcess
+
+**User Story:** As a developer, I want `InactiveUserProcess` to have access to the NACCGroup and its REDCap infrastructure, so that it can iterate over centers and their REDCap projects during the disable flow.
+
+#### Acceptance Criteria
+
+1. THE InactiveUserProcess SHALL access the NACCGroup through the existing UserProcessEnvironment to retrieve center groups and their associated REDCap projects.
+2. THE InactiveUserProcess SHALL access the support email addresses (already stored in AWS SSM Parameter Store for error notifications) through the UserProcessEnvironment or a parameter passed at construction.
+3. THE UserProcessEnvironment SHALL provide access to the email source address and EmailClient needed for sending REDCap suspension notifications, reusing the same email infrastructure already configured for error notifications in the user management gear.
+
+### Requirement 7: Support Best-Effort REDCap Role Removal
+
+**User Story:** As a system administrator, I want the REDCap disable step to operate on a best-effort basis, so that failures in individual REDCap projects do not prevent role removal from other projects or block the overall disable flow.
+
+#### Acceptance Criteria
+
+1. WHEN iterating over REDCap projects for role removal, THE InactiveUserProcess SHALL process each project independently, catching and logging errors for each project.
+2. IF a CenterGroup cannot be retrieved for a given ADCID, THEN THE InactiveUserProcess SHALL log the error and continue with the next center.
+3. IF center metadata cannot be parsed or contains no form ingest projects, THEN THE InactiveUserProcess SHALL log the condition and continue with the next center.
+4. THE InactiveUserProcess SHALL collect a summary of all REDCap projects where role removal succeeded and where it failed, for use in the notification email and event reporting.

--- a/.kiro/specs/redcap-user-disable/tasks.md
+++ b/.kiro/specs/redcap-user-disable/tasks.md
@@ -1,0 +1,108 @@
+# Implementation Plan: REDCap User Disable
+
+## Overview
+
+Add REDCap user role removal to the `InactiveUserProcess` disable flow and reorder the steps so that COmanage suspension happens last. The new step order is: (1) Flywheel disable, (2) COmanage lookup (resolve auth_email), (3) REDCap role removal with admin notification, (4) COmanage suspend.
+
+Implementation proceeds bottom-up: helper function → visitor → event category → core disable logic → gear wiring → tests.
+
+## Tasks
+
+- [ ] 1. Create `unassign_user_role` helper function
+  - [ ] 1.1 Create `common/src/python/users/redcap_user_operations.py` with `unassign_user_role(redcap_project, username)` function
+    - Import `REDCapProject` from `redcap_api.redcap_project`
+    - Call `redcap_project.assign_user_role(username, "")` and return the result
+    - Let `REDCapConnectionError` propagate to the caller
+    - Add a `BUILD` entry or confirm the existing `BUILD` file in `common/src/python/users/` covers new source files
+    - _Requirements: 1.1, 1.2, 1.3_
+
+- [ ] 2. Create `REDCapDisableVisitor`
+  - [ ] 2.1 Create `common/src/python/users/redcap_disable_visitor.py` implementing `AbstractCenterMetadataVisitor`
+    - Import visitor base class and metadata types from `centers.center_group`
+    - Implement `visit_center` → iterate studies, `visit_study` → iterate ingest projects, `visit_form_ingest_project` → collect `redcap_pid` from each `REDCapFormProjectMetadata` in `redcap_projects`
+    - All other visit methods (`visit_project`, `visit_ingest_project`, `visit_redcap_form_project`, `visit_distribution_project`, `visit_dashboard_project`, `visit_page_project`) are no-ops
+    - Expose collected PIDs via a `redcap_pids` property returning `list[int]`
+    - _Requirements: 3.1, 3.2_
+
+- [ ] 3. Add `REDCAP_USER_DISABLED` event category
+  - [ ] 3.1 Modify `common/src/python/users/event_models.py` to add `REDCAP_USER_DISABLED = "REDCap User Disabled"` to the `EventCategory` enum
+    - Place it in the "Disable/re-enable categories" section alongside `USER_DISABLED` and `USER_RE_ENABLED`
+    - _Requirements: 4.1_
+
+- [ ] 4. Implement REDCap disable logic in `InactiveUserProcess`
+  - [ ] 4.1 Add `email_client` and `support_emails` constructor parameters to `InactiveUserProcess`
+    - Add `email_client: Optional[EmailClient] = None` and `support_emails: Optional[list[str]] = None` parameters
+    - Store as private instance attributes `self.__email_client` and `self.__support_emails`
+    - Import `EmailClient` from `notifications.email` and `EmailSendError` from `notifications.email`
+    - _Requirements: 6.2, 6.3_
+
+  - [ ] 4.2 Add private `__disable_in_redcap` method to `InactiveUserProcess`
+    - Method signature: `__disable_in_redcap(self, entry: UserEntry, user_context: UserContext, auth_email: Optional[str]) -> None`
+    - **Username resolution**: if `entry.auth_email` is set use it; else if `auth_email` parameter is provided use it; else fall back to `entry.email`
+    - **Center iteration**: get center map from `self.__env.admin_group.get_center_map()`, iterate ADCIDs, call `self.__env.admin_group.get_center(adcid)` for each
+    - If center cannot be retrieved, log warning and continue
+    - Get `CenterMetadata` via `center_group.get_project_info()`, apply `REDCapDisableVisitor` to collect PIDs
+    - For each PID, get `REDCapProject` via `center_group.get_redcap_project(pid)`, if unavailable log and collect error event with `REDCAP_USER_DISABLED` category, continue
+    - **Dry-run check**: if `self.__env.proxy.dry_run`, log intended action and collect success event with dry-run note, skip API call
+    - Otherwise call `unassign_user_role(redcap_project, username)`, collect success event on success or error event on `REDCapConnectionError`
+    - Track list of successfully unassigned projects (title and PID) for notification
+    - After iteration, if any successes and `self.__email_client` is available, send notification email via `email_client.send_raw` with subject `[REDCap] inactive users to suspend`, body containing directory email, REDCap username, and list of affected projects
+    - Catch `EmailSendError` from notification send, log and continue
+    - Import `unassign_user_role` from `users.redcap_user_operations` and `REDCapDisableVisitor` from `users.redcap_disable_visitor`
+    - _Requirements: 2.1, 2.2, 2.3, 2.4, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 4.2, 4.3, 4.4, 5.1, 5.2, 5.3, 5.4, 5.5, 5.6, 7.1, 7.2, 7.3, 7.4_
+
+  - [ ] 4.3 Restructure `InactiveUserProcess.visit()` into four steps
+    - **Step 1 — Flywheel disable**: keep existing Flywheel disable logic unchanged
+    - **Step 2 — COmanage lookup**: call `self.__env.user_registry.get(email=entry.email)` to get `person_list`, extract `auth_email` from first person's `email_address.mail` if found, store `person_list` for Step 4
+    - **Step 3 — REDCap role removal**: call `self.__disable_in_redcap(entry, user_context, auth_email)`
+    - **Step 4 — COmanage suspend**: move existing COmanage suspend logic here, use `person_list` from Step 2 (skip if no persons found)
+    - Each step is independent — wrap each in its own try/except so failure of one does not block others
+    - _Requirements: 3.6, 6.1_
+
+- [ ] 5. Wire `EmailClient` and support emails into `InactiveUserProcess` in `run.py`
+  - [ ] 5.1 Modify `gear/user_management/src/python/user_app/run.py` to pass `email_client` and `support_emails` to `InactiveUserProcess`
+    - In the `UserProcess` construction area, create an `EmailClient` instance (reuse `create_ses_client()` and `self.__email_source`) and pass it along with `self.__support_emails` to `InactiveUserProcess`
+    - This requires `InactiveUserProcess` to be constructed separately from `UserProcess`, or `UserProcess` to forward these parameters — follow the existing pattern where `UserProcess` creates `InactiveUserProcess` internally in its `execute()` method
+    - Update `UserProcess.__init__` to accept and store `email_client` and `support_emails`, then pass them when constructing `InactiveUserProcess` in `execute()`
+    - Update the `UserProcess(...)` call in `run.py` to pass the new parameters
+    - _Requirements: 6.1, 6.2, 6.3_
+
+- [ ] 6. Write unit tests for `unassign_user_role` helper
+  - [ ] 6.1 Create `common/test/python/user_test/test_redcap_user_operations.py`
+    - Test that `unassign_user_role` calls `redcap_project.assign_user_role(username, "")` with correct arguments
+    - Test that it returns the count from `assign_user_role`
+    - Test that `REDCapConnectionError` propagates to the caller
+    - Use `unittest.mock.Mock` for `REDCapProject`
+    - _Requirements: 1.1, 1.2, 1.3_
+
+- [ ] 7. Write unit tests for `REDCapDisableVisitor`
+  - [ ] 7.1 Create `common/test/python/user_test/test_redcap_disable_visitor.py`
+    - Test visitor collects PIDs from `FormIngestProjectMetadata` with `redcap_projects`
+    - Test visitor returns empty list when no form ingest projects exist
+    - Test visitor skips non-form ingest projects (plain `IngestProjectMetadata`, `DistributionProjectMetadata`)
+    - Test visitor collects PIDs across multiple studies and multiple form ingest projects
+    - Build test `CenterMetadata` / `CenterStudyMetadata` / `FormIngestProjectMetadata` / `REDCapFormProjectMetadata` objects directly
+    - _Requirements: 3.1, 3.2_
+
+- [ ] 8. Write unit tests for REDCap disable step in `InactiveUserProcess`
+  - [ ] 8.1 Create `common/test/python/user_test/test_inactive_user_process_redcap.py`
+    - Test auth email resolution: entry with `auth_email` uses it directly, COmanage lookup result used when entry has no `auth_email`, fallback to directory email when no registry match
+    - Test center iteration: skips centers with no form ingest projects, skips projects with unavailable credentials, continues after unassignment failure
+    - Test dry-run mode: logs intended action, does not call `unassign_user_role`
+    - Test event collection: success events have `REDCAP_USER_DISABLED` category with project title and PID, error events have `REDCAP_USER_DISABLED` category with error details
+    - Test notification: sent when unassignments succeed, not sent when no unassignments, notification failure does not raise
+    - Test step independence: REDCap step runs even if Flywheel disable fails, COmanage suspend runs even if REDCap step fails
+    - Test four-step ordering: COmanage lookup happens before REDCap step, COmanage suspend happens after REDCap step
+    - Mock `UserProcessEnvironment`, `NACCGroup`, `CenterGroup`, `REDCapProject`, `EmailClient`, `UserRegistry`
+    - _Requirements: 2.1, 2.2, 2.3, 2.4, 3.2, 3.4, 3.5, 3.6, 3.7, 4.2, 4.3, 4.4, 5.1, 5.3, 5.5, 5.6, 7.1, 7.2, 7.3_
+
+- [ ] 9. Final checkpoint - Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- The implementation language is Python, matching the existing codebase
+- Each task references specific requirements for traceability
+- The design has a Correctness Properties section but property-based tests are omitted per user request (skip optional tasks)
+- All checkpoint tasks beyond the final one are omitted per user request
+- Tasks build incrementally: helper → visitor → event category → core logic → wiring → tests

--- a/.kiro/specs/redcap-user-disable/tasks.md
+++ b/.kiro/specs/redcap-user-disable/tasks.md
@@ -8,35 +8,35 @@ Implementation proceeds bottom-up: helper function → visitor → event categor
 
 ## Tasks
 
-- [ ] 1. Create `unassign_user_role` helper function
-  - [ ] 1.1 Create `common/src/python/users/redcap_user_operations.py` with `unassign_user_role(redcap_project, username)` function
+- [x] 1. Create `unassign_user_role` helper function
+  - [x] 1.1 Create `common/src/python/users/redcap_user_operations.py` with `unassign_user_role(redcap_project, username)` function
     - Import `REDCapProject` from `redcap_api.redcap_project`
     - Call `redcap_project.assign_user_role(username, "")` and return the result
     - Let `REDCapConnectionError` propagate to the caller
     - Add a `BUILD` entry or confirm the existing `BUILD` file in `common/src/python/users/` covers new source files
     - _Requirements: 1.1, 1.2, 1.3_
 
-- [ ] 2. Create `REDCapDisableVisitor`
-  - [ ] 2.1 Create `common/src/python/users/redcap_disable_visitor.py` implementing `AbstractCenterMetadataVisitor`
+- [x] 2. Create `REDCapDisableVisitor`
+  - [x] 2.1 Create `common/src/python/users/redcap_disable_visitor.py` implementing `AbstractCenterMetadataVisitor`
     - Import visitor base class and metadata types from `centers.center_group`
     - Implement `visit_center` → iterate studies, `visit_study` → iterate ingest projects, `visit_form_ingest_project` → collect `redcap_pid` from each `REDCapFormProjectMetadata` in `redcap_projects`
     - All other visit methods (`visit_project`, `visit_ingest_project`, `visit_redcap_form_project`, `visit_distribution_project`, `visit_dashboard_project`, `visit_page_project`) are no-ops
     - Expose collected PIDs via a `redcap_pids` property returning `list[int]`
     - _Requirements: 3.1, 3.2_
 
-- [ ] 3. Add `REDCAP_USER_DISABLED` event category
-  - [ ] 3.1 Modify `common/src/python/users/event_models.py` to add `REDCAP_USER_DISABLED = "REDCap User Disabled"` to the `EventCategory` enum
+- [x] 3. Add `REDCAP_USER_DISABLED` event category
+  - [x] 3.1 Modify `common/src/python/users/event_models.py` to add `REDCAP_USER_DISABLED = "REDCap User Disabled"` to the `EventCategory` enum
     - Place it in the "Disable/re-enable categories" section alongside `USER_DISABLED` and `USER_RE_ENABLED`
     - _Requirements: 4.1_
 
-- [ ] 4. Implement REDCap disable logic in `InactiveUserProcess`
-  - [ ] 4.1 Add `email_client` and `support_emails` constructor parameters to `InactiveUserProcess`
+- [x] 4. Implement REDCap disable logic in `InactiveUserProcess`
+  - [x] 4.1 Add `email_client` and `support_emails` constructor parameters to `InactiveUserProcess`
     - Add `email_client: Optional[EmailClient] = None` and `support_emails: Optional[list[str]] = None` parameters
     - Store as private instance attributes `self.__email_client` and `self.__support_emails`
     - Import `EmailClient` from `notifications.email` and `EmailSendError` from `notifications.email`
     - _Requirements: 6.2, 6.3_
 
-  - [ ] 4.2 Add private `__disable_in_redcap` method to `InactiveUserProcess`
+  - [x] 4.2 Add private `__disable_in_redcap` method to `InactiveUserProcess`
     - Method signature: `__disable_in_redcap(self, entry: UserEntry, user_context: UserContext, auth_email: Optional[str]) -> None`
     - **Username resolution**: if `entry.auth_email` is set use it; else if `auth_email` parameter is provided use it; else fall back to `entry.email`
     - **Center iteration**: get center map from `self.__env.admin_group.get_center_map()`, iterate ADCIDs, call `self.__env.admin_group.get_center(adcid)` for each
@@ -51,7 +51,7 @@ Implementation proceeds bottom-up: helper function → visitor → event categor
     - Import `unassign_user_role` from `users.redcap_user_operations` and `REDCapDisableVisitor` from `users.redcap_disable_visitor`
     - _Requirements: 2.1, 2.2, 2.3, 2.4, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 4.2, 4.3, 4.4, 5.1, 5.2, 5.3, 5.4, 5.5, 5.6, 7.1, 7.2, 7.3, 7.4_
 
-  - [ ] 4.3 Restructure `InactiveUserProcess.visit()` into four steps
+  - [x] 4.3 Restructure `InactiveUserProcess.visit()` into four steps
     - **Step 1 — Flywheel disable**: keep existing Flywheel disable logic unchanged
     - **Step 2 — COmanage lookup**: call `self.__env.user_registry.get(email=entry.email)` to get `person_list`, extract `auth_email` from first person's `email_address.mail` if found, store `person_list` for Step 4
     - **Step 3 — REDCap role removal**: call `self.__disable_in_redcap(entry, user_context, auth_email)`
@@ -59,24 +59,24 @@ Implementation proceeds bottom-up: helper function → visitor → event categor
     - Each step is independent — wrap each in its own try/except so failure of one does not block others
     - _Requirements: 3.6, 6.1_
 
-- [ ] 5. Wire `EmailClient` and support emails into `InactiveUserProcess` in `run.py`
-  - [ ] 5.1 Modify `gear/user_management/src/python/user_app/run.py` to pass `email_client` and `support_emails` to `InactiveUserProcess`
+- [x] 5. Wire `EmailClient` and support emails into `InactiveUserProcess` in `run.py`
+  - [x] 5.1 Modify `gear/user_management/src/python/user_app/run.py` to pass `email_client` and `support_emails` to `InactiveUserProcess`
     - In the `UserProcess` construction area, create an `EmailClient` instance (reuse `create_ses_client()` and `self.__email_source`) and pass it along with `self.__support_emails` to `InactiveUserProcess`
     - This requires `InactiveUserProcess` to be constructed separately from `UserProcess`, or `UserProcess` to forward these parameters — follow the existing pattern where `UserProcess` creates `InactiveUserProcess` internally in its `execute()` method
     - Update `UserProcess.__init__` to accept and store `email_client` and `support_emails`, then pass them when constructing `InactiveUserProcess` in `execute()`
     - Update the `UserProcess(...)` call in `run.py` to pass the new parameters
     - _Requirements: 6.1, 6.2, 6.3_
 
-- [ ] 6. Write unit tests for `unassign_user_role` helper
-  - [ ] 6.1 Create `common/test/python/user_test/test_redcap_user_operations.py`
+- [x] 6. Write unit tests for `unassign_user_role` helper
+  - [x] 6.1 Create `common/test/python/user_test/test_redcap_user_operations.py`
     - Test that `unassign_user_role` calls `redcap_project.assign_user_role(username, "")` with correct arguments
     - Test that it returns the count from `assign_user_role`
     - Test that `REDCapConnectionError` propagates to the caller
     - Use `unittest.mock.Mock` for `REDCapProject`
     - _Requirements: 1.1, 1.2, 1.3_
 
-- [ ] 7. Write unit tests for `REDCapDisableVisitor`
-  - [ ] 7.1 Create `common/test/python/user_test/test_redcap_disable_visitor.py`
+- [x] 7. Write unit tests for `REDCapDisableVisitor`
+  - [x] 7.1 Create `common/test/python/user_test/test_redcap_disable_visitor.py`
     - Test visitor collects PIDs from `FormIngestProjectMetadata` with `redcap_projects`
     - Test visitor returns empty list when no form ingest projects exist
     - Test visitor skips non-form ingest projects (plain `IngestProjectMetadata`, `DistributionProjectMetadata`)
@@ -84,8 +84,8 @@ Implementation proceeds bottom-up: helper function → visitor → event categor
     - Build test `CenterMetadata` / `CenterStudyMetadata` / `FormIngestProjectMetadata` / `REDCapFormProjectMetadata` objects directly
     - _Requirements: 3.1, 3.2_
 
-- [ ] 8. Write unit tests for REDCap disable step in `InactiveUserProcess`
-  - [ ] 8.1 Create `common/test/python/user_test/test_inactive_user_process_redcap.py`
+- [x] 8. Write unit tests for REDCap disable step in `InactiveUserProcess`
+  - [x] 8.1 Create `common/test/python/user_test/test_inactive_user_process_redcap.py`
     - Test auth email resolution: entry with `auth_email` uses it directly, COmanage lookup result used when entry has no `auth_email`, fallback to directory email when no registry match
     - Test center iteration: skips centers with no form ingest projects, skips projects with unavailable credentials, continues after unassignment failure
     - Test dry-run mode: logs intended action, does not call `unassign_user_role`
@@ -96,7 +96,7 @@ Implementation proceeds bottom-up: helper function → visitor → event categor
     - Mock `UserProcessEnvironment`, `NACCGroup`, `CenterGroup`, `REDCapProject`, `EmailClient`, `UserRegistry`
     - _Requirements: 2.1, 2.2, 2.3, 2.4, 3.2, 3.4, 3.5, 3.6, 3.7, 4.2, 4.3, 4.4, 5.1, 5.3, 5.5, 5.6, 7.1, 7.2, 7.3_
 
-- [ ] 9. Final checkpoint - Ensure all tests pass
+- [x] 9. Final checkpoint - Ensure all tests pass
   - Ensure all tests pass, ask the user if questions arise.
 
 ## Notes

--- a/common/src/python/flywheel_adaptor/flywheel_proxy.py
+++ b/common/src/python/flywheel_adaptor/flywheel_proxy.py
@@ -174,6 +174,48 @@ class FlywheelProxy:
 
         self.__fw.modify_user(user.id, {"email": email})
 
+    def find_user_by_email(self, email: str) -> List[flywheel.User]:
+        """Find Flywheel users matching the given email address.
+
+        Executes the lookup regardless of dry_run mode (read-only operation).
+
+        Args:
+            email: email address to search for
+
+        Returns:
+            List of matching User objects. Empty list if none found.
+
+        Raises:
+            FlywheelError: if the Flywheel SDK call fails
+        """
+        try:
+            return self.__fw.users.find(f"email={email}")
+        except ApiException as error:
+            raise FlywheelError(
+                f"Failed to find users by email {email}: {error}"
+            ) from error
+
+    def disable_user(self, user: flywheel.User) -> None:
+        """Disable a Flywheel user account and clear permissions.
+
+        In dry_run mode, logs the intended action without calling the API.
+
+        Args:
+            user: the Flywheel user to disable
+
+        Raises:
+            FlywheelError: if the Flywheel SDK call fails
+        """
+        assert user.id
+        if self.dry_run:
+            log.info("Dry run: would disable user %s", user.id)
+            return
+
+        try:
+            self.__fw.modify_user(user.id, {"disabled": True}, clear_permissions=True)
+        except ApiException as error:
+            raise FlywheelError(f"Failed to disable user {user.id}: {error}") from error
+
     def get_file(self, file_id: str) -> FileEntry:
         """Returns file object with the file ID.
 

--- a/common/src/python/users/event_models.py
+++ b/common/src/python/users/event_models.py
@@ -46,8 +46,10 @@ class EventCategory(Enum):
     FLYWHEEL_ERROR = "Flywheel Errors"
 
     # Disable/re-enable categories
-    USER_DISABLED = "User Disabled"
+    FLYWHEEL_USER_DISABLED = "Flywheel User Disabled"
+    COMANAGE_USER_SUSPENDED = "COmanage User Suspended"
     USER_RE_ENABLED = "User Re-Enabled"
+    REDCAP_USER_DISABLED = "REDCap User Disabled"
 
     # Near-miss categories
     DOMAIN_NEAR_MISS = "Domain Near-Miss"

--- a/common/src/python/users/event_models.py
+++ b/common/src/python/users/event_models.py
@@ -45,6 +45,9 @@ class EventCategory(Enum):
     DUPLICATE_USER_RECORDS = "Duplicate/Wrong User Records"
     FLYWHEEL_ERROR = "Flywheel Errors"
 
+    # Disable category
+    USER_DISABLED = "User Disabled"
+
     # Near-miss categories
     DOMAIN_NEAR_MISS = "Domain Near-Miss"
     NAME_NEAR_MISS = "Name Near-Miss"

--- a/common/src/python/users/event_models.py
+++ b/common/src/python/users/event_models.py
@@ -45,8 +45,9 @@ class EventCategory(Enum):
     DUPLICATE_USER_RECORDS = "Duplicate/Wrong User Records"
     FLYWHEEL_ERROR = "Flywheel Errors"
 
-    # Disable category
+    # Disable/re-enable categories
     USER_DISABLED = "User Disabled"
+    USER_RE_ENABLED = "User Re-Enabled"
 
     # Near-miss categories
     DOMAIN_NEAR_MISS = "Domain Near-Miss"

--- a/common/src/python/users/redcap_disable_visitor.py
+++ b/common/src/python/users/redcap_disable_visitor.py
@@ -1,0 +1,64 @@
+"""Visitor that collects REDCap project PIDs from center metadata."""
+
+from centers.center_group import (
+    AbstractCenterMetadataVisitor,
+    CenterMetadata,
+    CenterStudyMetadata,
+    DashboardProjectMetadata,
+    DistributionProjectMetadata,
+    FormIngestProjectMetadata,
+    IngestProjectMetadata,
+    PageProjectMetadata,
+    ProjectMetadata,
+    REDCapFormProjectMetadata,
+)
+
+
+class REDCapDisableVisitor(AbstractCenterMetadataVisitor):
+    """Visitor that collects REDCap project PIDs from center metadata.
+
+    Walks the center metadata tree to find all REDCap projects
+    associated with form ingest projects. Collected PIDs can be used to
+    look up REDCapProject instances for role unassignment.
+    """
+
+    def __init__(self) -> None:
+        self.__pids: list[int] = []
+
+    @property
+    def redcap_pids(self) -> list[int]:
+        """Returns the list of REDCap project PIDs found."""
+        return self.__pids
+
+    def visit_center(self, center: CenterMetadata) -> None:
+        """Iterate over studies in the center metadata."""
+        for study in center.studies.values():
+            study.apply(self)
+
+    def visit_study(self, study: CenterStudyMetadata) -> None:
+        """Iterate over ingest projects in the study."""
+        for project in study.ingest_projects.values():
+            project.apply(self)
+
+    def visit_form_ingest_project(self, project: FormIngestProjectMetadata) -> None:
+        """Collect redcap_pid from each REDCapFormProjectMetadata."""
+        for redcap_project in project.redcap_projects.values():
+            self.__pids.append(redcap_project.redcap_pid)
+
+    def visit_project(self, project: ProjectMetadata) -> None:
+        """No-op for generic projects."""
+
+    def visit_ingest_project(self, project: IngestProjectMetadata) -> None:
+        """No-op for non-form ingest projects."""
+
+    def visit_redcap_form_project(self, project: REDCapFormProjectMetadata) -> None:
+        """No-op — PIDs are collected in visit_form_ingest_project."""
+
+    def visit_distribution_project(self, project: DistributionProjectMetadata) -> None:
+        """No-op for distribution projects."""
+
+    def visit_dashboard_project(self, project: DashboardProjectMetadata) -> None:
+        """No-op for dashboard projects."""
+
+    def visit_page_project(self, project: PageProjectMetadata) -> None:
+        """No-op for page projects."""

--- a/common/src/python/users/redcap_user_operations.py
+++ b/common/src/python/users/redcap_user_operations.py
@@ -1,0 +1,22 @@
+"""Helper functions for REDCap user operations."""
+
+from redcap_api.redcap_project import REDCapProject
+
+
+def unassign_user_role(redcap_project: REDCapProject, username: str) -> int:
+    """Unassign a user from their role in a REDCap project.
+
+    Calls assign_user_role with an empty role string, which removes the
+    user's role-based permissions without deleting the user record.
+
+    Args:
+        redcap_project: The REDCap project instance
+        username: The REDCap username (typically the auth_email)
+
+    Returns:
+        Number of user-role assignments updated
+
+    Raises:
+        REDCapConnectionError: If the underlying API call fails
+    """
+    return redcap_project.assign_user_role(username, "")

--- a/common/src/python/users/user_processes.py
+++ b/common/src/python/users/user_processes.py
@@ -23,7 +23,7 @@ from users.event_models import (
 from users.failure_analyzer import FailureAnalyzer
 from users.user_entry import ActiveUserEntry, CenterUserEntry, UserEntry
 from users.user_process_environment import NotificationClient, UserProcessEnvironment
-from users.user_registry import DomainCandidate, RegistryPerson
+from users.user_registry import DomainCandidate, RegistryError, RegistryPerson
 
 log = logging.getLogger(__name__)
 
@@ -102,7 +102,13 @@ class UserQueue(Generic[T]):
             entry = self.__dequeue()
             try:
                 process.visit(entry)
-            except (FlywheelError, ValueError, KeyError, AttributeError) as error:
+            except (
+                FlywheelError,
+                RegistryError,
+                ValueError,
+                KeyError,
+                AttributeError,
+            ) as error:
                 # Individual user processing errors should not stop the batch
                 # Log the error and continue with the next user
                 log.error(
@@ -132,17 +138,17 @@ class InactiveUserProcess(BaseUserProcess[UserEntry]):
     def visit(self, entry: UserEntry) -> None:
         """Visit method for an inactive user entry.
 
-        Looks up matching Flywheel users by email and disables each one.
+        1. Looks up matching Flywheel users by email and disables each one.
+        2. Looks up matching COmanage registry persons by email and suspends
+           each one.
+
+        The two operations are independent — failure of either does not
+        prevent the other.
 
         Args:
           entry: the inactive user entry
         """
         log.info("processing inactive entry %s", entry.email)
-
-        users = self.__env.proxy.find_user_by_email(entry.email)
-        if not users:
-            log.info("no matching Flywheel users found for %s", entry.email)
-            return
 
         center_id = entry.adcid if isinstance(entry, CenterUserEntry) else None
         user_context = UserContext(
@@ -151,35 +157,87 @@ class InactiveUserProcess(BaseUserProcess[UserEntry]):
             center_id=center_id,
         )
 
-        for user in users:
-            try:
-                self.__env.proxy.disable_user(user)
-                log.info(
-                    "disabled user %s (%s)",
-                    user.id,
-                    entry.email,
-                )
-                success_event = UserProcessEvent(
-                    event_type=EventType.SUCCESS,
-                    category=EventCategory.USER_DISABLED,
-                    user_context=user_context,
-                    message=f"User {user.id} disabled in Flywheel",
-                )
-                self.collector.collect(success_event)
-            except FlywheelError as error:
-                log.error(
-                    "failed to disable user %s (%s): %s",
-                    user.id,
-                    entry.email,
-                    error,
-                )
-                error_event = UserProcessEvent(
-                    event_type=EventType.ERROR,
-                    category=EventCategory.FLYWHEEL_ERROR,
-                    user_context=user_context,
-                    message=f"Failed to disable user {user.id}: {error}",
-                )
-                self.collector.collect(error_event)
+        # Step 1: Disable in Flywheel
+        users = self.__env.proxy.find_user_by_email(entry.email)
+        if not users:
+            log.info("no matching Flywheel users found for %s", entry.email)
+        else:
+            for user in users:
+                try:
+                    self.__env.proxy.disable_user(user)
+                    log.info(
+                        "disabled user %s (%s)",
+                        user.id,
+                        entry.email,
+                    )
+                    success_event = UserProcessEvent(
+                        event_type=EventType.SUCCESS,
+                        category=EventCategory.USER_DISABLED,
+                        user_context=user_context,
+                        message=f"User {user.id} disabled in Flywheel",
+                    )
+                    self.collector.collect(success_event)
+                except FlywheelError as error:
+                    log.error(
+                        "failed to disable user %s (%s): %s",
+                        user.id,
+                        entry.email,
+                        error,
+                    )
+                    error_event = UserProcessEvent(
+                        event_type=EventType.ERROR,
+                        category=EventCategory.FLYWHEEL_ERROR,
+                        user_context=user_context,
+                        message=f"Failed to disable user {user.id}: {error}",
+                    )
+                    self.collector.collect(error_event)
+
+        # Step 2: Suspend in COmanage
+        person_list = self.__env.user_registry.get(email=entry.email)
+        if not person_list:
+            log.info("no matching COmanage registry persons for %s", entry.email)
+        else:
+            for person in person_list:
+                registry_id = person.registry_id()
+                if not registry_id:
+                    continue
+                if person.is_suspended():
+                    log.info(
+                        "user %s (%s) already suspended in COmanage, skipping",
+                        registry_id,
+                        entry.email,
+                    )
+                    continue
+                try:
+                    self.__env.user_registry.suspend(registry_id)
+                    log.info(
+                        "suspended user %s (%s) in COmanage",
+                        registry_id,
+                        entry.email,
+                    )
+                    success_event = UserProcessEvent(
+                        event_type=EventType.SUCCESS,
+                        category=EventCategory.USER_DISABLED,
+                        user_context=user_context,
+                        message=f"User {registry_id} suspended in COmanage",
+                    )
+                    self.collector.collect(success_event)
+                except RegistryError as error:
+                    log.error(
+                        "failed to suspend user %s (%s) in COmanage: %s",
+                        registry_id,
+                        entry.email,
+                        error,
+                    )
+                    error_event = UserProcessEvent(
+                        event_type=EventType.ERROR,
+                        category=EventCategory.USER_DISABLED,
+                        user_context=user_context,
+                        message=(
+                            f"Failed to suspend user {registry_id} in COmanage: {error}"
+                        ),
+                    )
+                    self.collector.collect(error_event)
 
     def execute(self, queue: UserQueue[UserEntry]) -> None:
         """Applies this process to the queue.
@@ -674,6 +732,13 @@ class ActiveUserProcess(BaseUserProcess[ActiveUserEntry]):
         """Adds a new user to user registry, otherwise, adds the user to
         claimed or unclaimed queues.
 
+        When a matching registry person is found with status 'S' (Suspended),
+        re-enables them instead of treating them as a new user. This prevents
+        duplicate record creation for returning users.
+
+        The re-enable check happens after the email lookup but before the
+        existing claimed/unclaimed routing.
+
         Args:
           entry: the user entry
         """
@@ -748,6 +813,12 @@ class ActiveUserProcess(BaseUserProcess[ActiveUserEntry]):
             )
             return
 
+        # Check for suspended persons and re-enable them
+        suspended = [person for person in person_list if person.is_suspended()]
+        if suspended:
+            self.__re_enable_suspended(entry, suspended)
+            return
+
         creation_date = self.__get_creation_date(person_list)
         if not creation_date:
             log.warning("person record for %s has no creation date", entry.email)
@@ -773,6 +844,55 @@ class ActiveUserProcess(BaseUserProcess[ActiveUserEntry]):
           the claimed registry person objects
         """
         return [person for person in person_list if person.is_claimed()]
+
+    def __re_enable_suspended(
+        self,
+        entry: ActiveUserEntry,
+        suspended: List[RegistryPerson],
+    ) -> None:
+        """Re-enable suspended registry persons matched by email.
+
+        For each suspended person with a registry ID, calls re_enable on
+        the user registry. Collects success or error events for each.
+
+        Args:
+          entry: the active user entry
+          suspended: list of suspended RegistryPerson objects
+        """
+        for person in suspended:
+            registry_id = person.registry_id()
+            if not registry_id:
+                continue
+            try:
+                self.__env.user_registry.re_enable(registry_id)
+                log.info(
+                    "re-enabled user %s (%s) in COmanage",
+                    registry_id,
+                    entry.auth_email,
+                )
+                success_event = UserProcessEvent(
+                    event_type=EventType.SUCCESS,
+                    category=EventCategory.USER_RE_ENABLED,
+                    user_context=UserContext.from_user_entry(entry),
+                    message=(f"User {registry_id} re-enabled in COmanage"),
+                )
+                self.collector.collect(success_event)
+            except RegistryError as error:
+                log.error(
+                    "failed to re-enable user %s (%s) in COmanage: %s",
+                    registry_id,
+                    entry.auth_email,
+                    error,
+                )
+                error_event = UserProcessEvent(
+                    event_type=EventType.ERROR,
+                    category=EventCategory.USER_RE_ENABLED,
+                    user_context=UserContext.from_user_entry(entry),
+                    message=(
+                        f"Failed to re-enable user {registry_id} in COmanage: {error}"
+                    ),
+                )
+                self.collector.collect(error_event)
 
     def __emit_near_miss_events(
         self,

--- a/common/src/python/users/user_processes.py
+++ b/common/src/python/users/user_processes.py
@@ -115,21 +115,71 @@ class UserQueue(Generic[T]):
 class InactiveUserProcess(BaseUserProcess[UserEntry]):
     """User process for user entries marked inactive."""
 
-    def __init__(self, collector: UserEventCollector) -> None:
+    def __init__(
+        self,
+        environment: UserProcessEnvironment,
+        collector: UserEventCollector,
+    ) -> None:
         """Initialize the inactive user process.
 
         Args:
+            environment: The user process environment
             collector: Error collector for capturing error events
         """
         super().__init__(collector)
+        self.__env = environment
 
     def visit(self, entry: UserEntry) -> None:
         """Visit method for an inactive user entry.
 
+        Looks up matching Flywheel users by email and disables each one.
+
         Args:
           entry: the inactive user entry
         """
-        log.info("ignoring inactive entry %s", entry.email)
+        log.info("processing inactive entry %s", entry.email)
+
+        users = self.__env.proxy.find_user_by_email(entry.email)
+        if not users:
+            log.info("no matching Flywheel users found for %s", entry.email)
+            return
+
+        center_id = entry.adcid if isinstance(entry, CenterUserEntry) else None
+        user_context = UserContext(
+            email=entry.email,
+            name=entry.name.as_str(),
+            center_id=center_id,
+        )
+
+        for user in users:
+            try:
+                self.__env.proxy.disable_user(user)
+                log.info(
+                    "disabled user %s (%s)",
+                    user.id,
+                    entry.email,
+                )
+                success_event = UserProcessEvent(
+                    event_type=EventType.SUCCESS,
+                    category=EventCategory.USER_DISABLED,
+                    user_context=user_context,
+                    message=f"User {user.id} disabled in Flywheel",
+                )
+                self.collector.collect(success_event)
+            except FlywheelError as error:
+                log.error(
+                    "failed to disable user %s (%s): %s",
+                    user.id,
+                    entry.email,
+                    error,
+                )
+                error_event = UserProcessEvent(
+                    event_type=EventType.ERROR,
+                    category=EventCategory.FLYWHEEL_ERROR,
+                    user_context=user_context,
+                    message=f"Failed to disable user {user.id}: {error}",
+                )
+                self.collector.collect(error_event)
 
     def execute(self, queue: UserQueue[UserEntry]) -> None:
         """Applies this process to the queue.
@@ -940,4 +990,4 @@ class UserProcess(BaseUserProcess[UserEntry]):
         queue.apply(self)
 
         ActiveUserProcess(self.__env, self.collector).execute(self.__active_queue)
-        InactiveUserProcess(self.collector).execute(self.__inactive_queue)
+        InactiveUserProcess(self.__env, self.collector).execute(self.__inactive_queue)

--- a/common/src/python/users/user_processes.py
+++ b/common/src/python/users/user_processes.py
@@ -4,9 +4,11 @@ from collections import defaultdict, deque
 from datetime import datetime
 from typing import Dict, Generic, List, Optional, TypeVar
 
+from centers.center_group import CenterError, CenterGroup
 from coreapi_client.models.identifier import Identifier
 from flywheel.models.user import User
 from flywheel_adaptor.flywheel_proxy import FlywheelError
+from redcap_api.redcap_connection import REDCapConnectionError
 
 from users.authorization_visitor import (
     CenterAuthorizationVisitor,
@@ -21,6 +23,8 @@ from users.event_models import (
     UserProcessEvent,
 )
 from users.failure_analyzer import FailureAnalyzer
+from users.redcap_disable_visitor import REDCapDisableVisitor
+from users.redcap_user_operations import unassign_user_role
 from users.user_entry import ActiveUserEntry, CenterUserEntry, UserEntry
 from users.user_process_environment import NotificationClient, UserProcessEnvironment
 from users.user_registry import DomainCandidate, RegistryError, RegistryPerson
@@ -135,15 +139,270 @@ class InactiveUserProcess(BaseUserProcess[UserEntry]):
         super().__init__(collector)
         self.__env = environment
 
+    def __resolve_redcap_username(
+        self,
+        entry: UserEntry,
+        auth_email: Optional[str],
+    ) -> str:
+        """Resolve the REDCap username for role unassignment.
+
+        Priority: entry.auth_email > COmanage auth_email > directory email.
+
+        Args:
+            entry: The inactive user entry
+            auth_email: The resolved auth_email from COmanage lookup
+
+        Returns:
+            The resolved username string
+        """
+        if entry.auth_email:
+            return entry.auth_email
+        if auth_email:
+            return auth_email
+        return entry.email
+
+    def __unassign_redcap_project(
+        self,
+        center_group: CenterGroup,
+        pid: int,
+        username: str,
+        user_context: UserContext,
+    ) -> None:
+        """Attempt to unassign a user's role from a single REDCap project.
+
+        Args:
+            center_group: The center group providing REDCap project access
+            pid: The REDCap project ID
+            username: The REDCap username to unassign
+            user_context: The user context for event collection
+        """
+        redcap_project = center_group.get_redcap_project(pid)
+        if not redcap_project:
+            log.warning(
+                "REDCap project credentials unavailable for PID %s, skipping",
+                pid,
+            )
+            error_event = UserProcessEvent(
+                event_type=EventType.ERROR,
+                category=EventCategory.REDCAP_USER_DISABLED,
+                user_context=user_context,
+                message=f"REDCap project credentials unavailable for PID {pid}",
+            )
+            self.collector.collect(error_event)
+            return
+
+        title = redcap_project.title
+
+        if self.__env.proxy.dry_run:
+            log.info(
+                "DRY RUN: Would unassign role for %s in REDCap project %s (PID %s)",
+                username,
+                title,
+                pid,
+            )
+            success_event = UserProcessEvent(
+                event_type=EventType.SUCCESS,
+                category=EventCategory.REDCAP_USER_DISABLED,
+                user_context=user_context,
+                message=(
+                    f"DRY RUN: Would unassign role for {username} "
+                    f"in REDCap project {title} (PID {pid})"
+                ),
+            )
+            self.collector.collect(success_event)
+            return
+
+        try:
+            unassign_user_role(redcap_project, username)
+            log.info(
+                "unassigned role for %s in REDCap project %s (PID %s)",
+                username,
+                title,
+                pid,
+            )
+            success_event = UserProcessEvent(
+                event_type=EventType.SUCCESS,
+                category=EventCategory.REDCAP_USER_DISABLED,
+                user_context=user_context,
+                message=(
+                    f"Unassigned role for {username} "
+                    f"in REDCap project {title} (PID {pid})"
+                ),
+            )
+            self.collector.collect(success_event)
+        except REDCapConnectionError as error:
+            log.error(
+                "failed to unassign role for %s in REDCap project %s (PID %s): %s",
+                username,
+                title,
+                pid,
+                error,
+            )
+            error_event = UserProcessEvent(
+                event_type=EventType.ERROR,
+                category=EventCategory.REDCAP_USER_DISABLED,
+                user_context=user_context,
+                message=(
+                    f"Failed to unassign role for {username} "
+                    f"in REDCap project {title} (PID {pid}): {error}"
+                ),
+            )
+            self.collector.collect(error_event)
+
+    def __disable_in_redcap(
+        self,
+        entry: UserEntry,
+        user_context: UserContext,
+        auth_email: Optional[str],
+    ) -> None:
+        """Step 3: Remove user roles from all REDCap projects.
+
+        Iterates over all centers, finds REDCap projects via the visitor
+        pattern, and unassigns the user's role from each project.
+
+        Args:
+            entry: The inactive user entry
+            user_context: The user context for event collection
+            auth_email: The resolved auth_email from COmanage lookup
+                in Step 2 (if found)
+        """
+        username = self.__resolve_redcap_username(entry, auth_email)
+        center_map = self.__env.admin_group.get_center_map()
+
+        for adcid in center_map.get_adcids():
+            center_group = self.__env.admin_group.get_center(adcid)
+            if not center_group:
+                log.warning(
+                    "could not retrieve center group for ADCID %s, skipping",
+                    adcid,
+                )
+                continue
+
+            project_info = center_group.get_project_info()
+            visitor = REDCapDisableVisitor()
+            project_info.apply(visitor)
+
+            for pid in visitor.redcap_pids:
+                self.__unassign_redcap_project(
+                    center_group, pid, username, user_context
+                )
+
+    def __disable_in_flywheel(
+        self,
+        entry: UserEntry,
+        user_context: UserContext,
+    ) -> None:
+        """Step 1: Disable matching Flywheel users.
+
+        Args:
+            entry: The inactive user entry
+            user_context: The user context for event collection
+        """
+        users = self.__env.proxy.find_user_by_email(entry.email)
+        if not users:
+            log.info("no matching Flywheel users found for %s", entry.email)
+            return
+
+        for user in users:
+            try:
+                self.__env.proxy.disable_user(user)
+                log.info(
+                    "disabled user %s (%s)",
+                    user.id,
+                    entry.email,
+                )
+                success_event = UserProcessEvent(
+                    event_type=EventType.SUCCESS,
+                    category=EventCategory.FLYWHEEL_USER_DISABLED,
+                    user_context=user_context,
+                    message=f"User {user.id} disabled in Flywheel",
+                )
+                self.collector.collect(success_event)
+            except FlywheelError as error:
+                log.error(
+                    "failed to disable user %s (%s): %s",
+                    user.id,
+                    entry.email,
+                    error,
+                )
+                error_event = UserProcessEvent(
+                    event_type=EventType.ERROR,
+                    category=EventCategory.FLYWHEEL_ERROR,
+                    user_context=user_context,
+                    message=f"Failed to disable user {user.id}: {error}",
+                )
+                self.collector.collect(error_event)
+
+    def __suspend_in_comanage(
+        self,
+        entry: UserEntry,
+        user_context: UserContext,
+        person_list: Optional[list[RegistryPerson]],
+    ) -> None:
+        """Step 4: Suspend matching COmanage registry persons.
+
+        Args:
+            entry: The inactive user entry
+            user_context: The user context for event collection
+            person_list: The list of registry persons from Step 2
+        """
+        if not person_list:
+            log.info("no matching COmanage registry persons for %s", entry.email)
+            return
+
+        for person in person_list:
+            registry_id = person.registry_id()
+            if not registry_id:
+                continue
+            if person.is_suspended():
+                log.info(
+                    "user %s (%s) already suspended in COmanage, skipping",
+                    registry_id,
+                    entry.email,
+                )
+                continue
+            try:
+                self.__env.user_registry.suspend(registry_id)
+                log.info(
+                    "suspended user %s (%s) in COmanage",
+                    registry_id,
+                    entry.email,
+                )
+                success_event = UserProcessEvent(
+                    event_type=EventType.SUCCESS,
+                    category=EventCategory.COMANAGE_USER_SUSPENDED,
+                    user_context=user_context,
+                    message=f"User {registry_id} suspended in COmanage",
+                )
+                self.collector.collect(success_event)
+            except RegistryError as error:
+                log.error(
+                    "failed to suspend user %s (%s) in COmanage: %s",
+                    registry_id,
+                    entry.email,
+                    error,
+                )
+                error_event = UserProcessEvent(
+                    event_type=EventType.ERROR,
+                    category=EventCategory.COMANAGE_USER_SUSPENDED,
+                    user_context=user_context,
+                    message=(
+                        f"Failed to suspend user {registry_id} in COmanage: {error}"
+                    ),
+                )
+                self.collector.collect(error_event)
+
     def visit(self, entry: UserEntry) -> None:
         """Visit method for an inactive user entry.
 
-        1. Looks up matching Flywheel users by email and disables each one.
-        2. Looks up matching COmanage registry persons by email and suspends
-           each one.
+        Processes the entry through four independent steps:
+        1. Disable in Flywheel
+        2. COmanage lookup (resolve auth_email)
+        3. REDCap role removal
+        4. COmanage suspend
 
-        The two operations are independent — failure of either does not
-        prevent the other.
+        Each step is wrapped in its own try/except so failure of one
+        does not block the others.
 
         Args:
           entry: the inactive user entry
@@ -158,86 +417,55 @@ class InactiveUserProcess(BaseUserProcess[UserEntry]):
         )
 
         # Step 1: Disable in Flywheel
-        users = self.__env.proxy.find_user_by_email(entry.email)
-        if not users:
-            log.info("no matching Flywheel users found for %s", entry.email)
-        else:
-            for user in users:
-                try:
-                    self.__env.proxy.disable_user(user)
-                    log.info(
-                        "disabled user %s (%s)",
-                        user.id,
-                        entry.email,
-                    )
-                    success_event = UserProcessEvent(
-                        event_type=EventType.SUCCESS,
-                        category=EventCategory.USER_DISABLED,
-                        user_context=user_context,
-                        message=f"User {user.id} disabled in Flywheel",
-                    )
-                    self.collector.collect(success_event)
-                except FlywheelError as error:
-                    log.error(
-                        "failed to disable user %s (%s): %s",
-                        user.id,
-                        entry.email,
-                        error,
-                    )
-                    error_event = UserProcessEvent(
-                        event_type=EventType.ERROR,
-                        category=EventCategory.FLYWHEEL_ERROR,
-                        user_context=user_context,
-                        message=f"Failed to disable user {user.id}: {error}",
-                    )
-                    self.collector.collect(error_event)
+        try:
+            self.__disable_in_flywheel(entry, user_context)
+        except FlywheelError as error:
+            log.error(
+                "Step 1 (Flywheel disable) failed for %s: %s",
+                entry.email,
+                error,
+                exc_info=True,
+            )
 
-        # Step 2: Suspend in COmanage
-        person_list = self.__env.user_registry.get(email=entry.email)
-        if not person_list:
-            log.info("no matching COmanage registry persons for %s", entry.email)
-        else:
-            for person in person_list:
-                registry_id = person.registry_id()
-                if not registry_id:
-                    continue
-                if person.is_suspended():
-                    log.info(
-                        "user %s (%s) already suspended in COmanage, skipping",
-                        registry_id,
-                        entry.email,
-                    )
-                    continue
-                try:
-                    self.__env.user_registry.suspend(registry_id)
-                    log.info(
-                        "suspended user %s (%s) in COmanage",
-                        registry_id,
-                        entry.email,
-                    )
-                    success_event = UserProcessEvent(
-                        event_type=EventType.SUCCESS,
-                        category=EventCategory.USER_DISABLED,
-                        user_context=user_context,
-                        message=f"User {registry_id} suspended in COmanage",
-                    )
-                    self.collector.collect(success_event)
-                except RegistryError as error:
-                    log.error(
-                        "failed to suspend user %s (%s) in COmanage: %s",
-                        registry_id,
-                        entry.email,
-                        error,
-                    )
-                    error_event = UserProcessEvent(
-                        event_type=EventType.ERROR,
-                        category=EventCategory.USER_DISABLED,
-                        user_context=user_context,
-                        message=(
-                            f"Failed to suspend user {registry_id} in COmanage: {error}"
-                        ),
-                    )
-                    self.collector.collect(error_event)
+        # Step 2: COmanage lookup
+        # (resolve auth_email for Step 3, person_list for Step 4)
+        auth_email: Optional[str] = None
+        person_list: Optional[list[RegistryPerson]] = None
+        try:
+            person_list = self.__env.user_registry.get(email=entry.email)
+            if not entry.auth_email and person_list:
+                first_person = person_list[0]
+                if first_person.email_address:
+                    auth_email = first_person.email_address.mail
+        except RegistryError as error:
+            log.error(
+                "Step 2 (COmanage lookup) failed for %s: %s",
+                entry.email,
+                error,
+                exc_info=True,
+            )
+
+        # Step 3: REDCap role removal
+        try:
+            self.__disable_in_redcap(entry, user_context, auth_email)
+        except (REDCapConnectionError, CenterError) as error:
+            log.error(
+                "Step 3 (REDCap role removal) failed for %s: %s",
+                entry.email,
+                error,
+                exc_info=True,
+            )
+
+        # Step 4: COmanage suspend
+        try:
+            self.__suspend_in_comanage(entry, user_context, person_list)
+        except RegistryError as error:
+            log.error(
+                "Step 4 (COmanage suspend) failed for %s: %s",
+                entry.email,
+                error,
+                exc_info=True,
+            )
 
     def execute(self, queue: UserQueue[UserEntry]) -> None:
         """Applies this process to the queue.

--- a/common/src/python/users/user_registry.py
+++ b/common/src/python/users/user_registry.py
@@ -259,6 +259,21 @@ class RegistryPerson:
 
         return self.__coperson_message.co_person.status == "A"
 
+    def is_suspended(self) -> bool:
+        """Indicates whether the CoPerson record is suspended.
+
+        A person is considered suspended if their CoPerson status is "S"
+        (suspended). Suspended status removes the user from the
+        CO:members:active group, revoking OIDC authorization.
+
+        Returns:
+          True if the CoPerson status is "S" (Suspended). False otherwise.
+        """
+        if self.__coperson_message.co_person is None:
+            return False
+
+        return self.__coperson_message.co_person.status == "S"
+
     def identifiers(
         self, predicate: Callable[[Identifier], bool] = lambda x: True
     ) -> List[Identifier]:
@@ -479,6 +494,7 @@ class UserRegistry:
         coid: int,
         name_normalizer: Callable[[str], str],
         domain_config: Optional[DomainRelationshipConfig] = None,
+        dry_run: bool = False,
     ):
         self.__api_instance = api_instance
         self.__coid = coid
@@ -490,6 +506,19 @@ class UserRegistry:
         self.__name_map: Dict[str, List[RegistryPerson]] = {}
         self.__domain_config = domain_config or DomainRelationshipConfig()
         self.__name_normalizer = name_normalizer
+        self.__dry_run = dry_run
+
+    @property
+    def dry_run(self) -> bool:
+        """Returns whether dry-run mode is enabled.
+
+        When dry-run mode is enabled, write operations (suspend, re-enable)
+        are logged but not executed against the COmanage API.
+
+        Returns:
+          True if dry-run mode is enabled. False otherwise.
+        """
+        return self.__dry_run
 
     @property
     def coid(self) -> int:
@@ -515,6 +544,106 @@ class UserRegistry:
             )
         except ApiException as error:
             raise RegistryError(f"API add_co_person call failed: {error}") from error
+
+    def suspend(self, registry_id: str) -> None:
+        """Suspend a CO Person by setting status to 'S'.
+
+        Retrieves the full CoPersonMessage, sets CoPerson.status to 'S',
+        and PUTs the entire record back. In dry-run mode, logs the
+        intended action without calling PUT.
+
+        Args:
+            registry_id: the NACC registry ID (naccid identifier)
+
+        Raises:
+            RegistryError: if the person cannot be found, has no registry ID,
+                          or the API call fails
+        """
+        self.__update_status(registry_id, "S")
+
+    def re_enable(self, registry_id: str) -> None:
+        """Re-enable a suspended CO Person by setting status to 'A'.
+
+        Retrieves the full CoPersonMessage, sets CoPerson.status to 'A',
+        and PUTs the entire record back. In dry-run mode, logs the
+        intended action without calling PUT.
+
+        Args:
+            registry_id: the NACC registry ID (naccid identifier)
+
+        Raises:
+            RegistryError: if the person cannot be found or the API call fails
+        """
+        self.__update_status(registry_id, "A")
+
+    def __get_person_message(self, registry_id: str) -> CoPersonMessage:
+        """Retrieve the full CoPersonMessage for a registry ID via GET.
+
+        Uses the DefaultApi.get_co_person with the identifier parameter
+        to fetch a single record.
+
+        Args:
+            registry_id: the NACC registry ID
+
+        Returns:
+            The full CoPersonMessage
+
+        Raises:
+            RegistryError: if the API call fails or no record is found
+        """
+        try:
+            response = self.__api_instance.get_co_person(
+                coid=self.__coid, identifier=registry_id
+            )
+        except ApiException as error:
+            raise RegistryError(f"API get_co_person call failed: {error}") from error
+
+        if not response.var_0:
+            raise RegistryError(
+                f"No COmanage record found for registry ID {registry_id}"
+            )
+
+        return response.var_0
+
+    def __update_status(self, registry_id: str, target_status: str) -> None:
+        """Retrieve the full CoPersonMessage, change only the status, PUT it
+        back.
+
+        Args:
+            registry_id: the NACC registry ID
+            target_status: the target CoPerson status ('S' or 'A')
+
+        Raises:
+            RegistryError: on API errors or missing records
+        """
+        if not registry_id:
+            raise RegistryError("Cannot update person: no registry ID")
+
+        person_message = self.__get_person_message(registry_id)
+
+        if not person_message.co_person:
+            raise RegistryError(
+                f"No CoPerson object in record for registry ID {registry_id}"
+            )
+
+        person_message.co_person.status = target_status
+
+        if self.__dry_run:
+            log.info(
+                "DRY RUN: Would update registry ID %s to status %s",
+                registry_id,
+                target_status,
+            )
+            return
+
+        try:
+            self.__api_instance.update_co_person(
+                coid=self.__coid,
+                identifier=registry_id,
+                co_person_message=person_message,
+            )
+        except ApiException as error:
+            raise RegistryError(f"API update_co_person call failed: {error}") from error
 
     def get(self, email: str) -> List[RegistryPerson]:
         """Returns the list of person objects with the email address.
@@ -776,4 +905,4 @@ class UserRegistry:
 
 
 class RegistryError(Exception):
-    pass
+    """Error raised by UserRegistry operations."""

--- a/common/test/python/user_test/test_active_user_reenable.py
+++ b/common/test/python/user_test/test_active_user_reenable.py
@@ -1,0 +1,225 @@
+"""Unit tests for ActiveUserProcess re-enable logic.
+
+Tests that the ActiveUserProcess correctly re-enables suspended
+RegistryPerson records matched by email, collects appropriate events,
+and preserves existing claimed/unclaimed routing for non-suspended
+persons.
+"""
+
+import logging
+from typing import Optional
+from unittest.mock import Mock
+
+import pytest
+from users.authorizations import Authorizations
+from users.event_models import (
+    EventCategory,
+    EventType,
+    UserEventCollector,
+)
+from users.user_entry import CenterUserEntry, PersonName
+from users.user_processes import ActiveUserProcess, UserProcessEnvironment
+from users.user_registry import RegistryError, RegistryPerson
+
+
+class TestActiveUserProcessReEnable:
+    """Unit tests for ActiveUserProcess suspended-user re-enable logic."""
+
+    @pytest.fixture
+    def mock_environment(self):
+        """Create a mock UserProcessEnvironment."""
+        mock_env = Mock(spec=UserProcessEnvironment)
+        mock_env.user_registry = Mock()
+        mock_env.notification_client = Mock()
+
+        mock_env.find_user = Mock(return_value=None)
+        mock_env.get_from_registry = Mock(
+            side_effect=lambda email: mock_env.user_registry.get(email=email)
+        )
+
+        # Default: no domain/name candidates
+        mock_env.user_registry.get_by_parent_domain = Mock(return_value=[])
+        mock_env.user_registry.get_by_name = Mock(return_value=[])
+
+        return mock_env
+
+    @pytest.fixture
+    def collector(self):
+        """Create a UserEventCollector."""
+        return UserEventCollector()
+
+    @pytest.fixture
+    def sample_active_entry(self):
+        """Create a sample CenterUserEntry for testing."""
+        return CenterUserEntry(
+            name=PersonName(first_name="Alice", last_name="Smith"),
+            email="alice@example.com",
+            auth_email="alice.auth@example.com",
+            active=True,
+            approved=True,
+            org_name="Test Center",
+            adcid=100,
+            authorizations=Authorizations(),
+            study_authorizations=[],
+        )
+
+    def _make_suspended_person(self, registry_id: Optional[str] = "NACC-001") -> Mock:
+        """Create a mock suspended RegistryPerson."""
+        person = Mock(spec=RegistryPerson)
+        person.is_suspended.return_value = True
+        person.is_claimed.return_value = False
+        person.registry_id.return_value = registry_id
+        person.creation_date = None
+        return person
+
+    def _make_active_person(
+        self,
+        registry_id: str = "NACC-002",
+        claimed: bool = True,
+    ) -> Mock:
+        """Create a mock active (non-suspended) RegistryPerson."""
+        person = Mock(spec=RegistryPerson)
+        person.is_suspended.return_value = False
+        person.is_claimed.return_value = claimed
+        person.registry_id.return_value = registry_id
+        person.creation_date = "2024-01-01"
+        return person
+
+    def test_suspended_person_is_re_enabled(
+        self, mock_environment, collector, sample_active_entry
+    ):
+        """Test that a suspended RegistryPerson matched by email is re-
+        enabled."""
+        suspended = self._make_suspended_person("NACC-001")
+        mock_environment.user_registry.get.return_value = [suspended]
+
+        process = ActiveUserProcess(mock_environment, collector)
+        process.visit(sample_active_entry)
+
+        mock_environment.user_registry.re_enable.assert_called_once_with("NACC-001")
+
+    def test_add_not_called_when_suspended_match_exists(
+        self, mock_environment, collector, sample_active_entry
+    ):
+        """Test that add is not called when a suspended match exists."""
+        suspended = self._make_suspended_person("NACC-001")
+        mock_environment.user_registry.get.return_value = [suspended]
+
+        process = ActiveUserProcess(mock_environment, collector)
+        process.visit(sample_active_entry)
+
+        mock_environment.user_registry.add.assert_not_called()
+
+    def test_success_event_collected_on_re_enable(
+        self, mock_environment, collector, sample_active_entry
+    ):
+        """Test that a success event is collected on successful re-enable."""
+        suspended = self._make_suspended_person("NACC-001")
+        mock_environment.user_registry.get.return_value = [suspended]
+
+        process = ActiveUserProcess(mock_environment, collector)
+        process.visit(sample_active_entry)
+
+        successes = collector.get_successes()
+        assert len(successes) == 1
+
+        event = successes[0]
+        assert event.event_type == EventType.SUCCESS.value
+        assert event.category == EventCategory.USER_RE_ENABLED.value
+        assert "NACC-001" in event.message
+        assert "re-enabled" in event.message
+
+    def test_error_event_collected_on_re_enable_failure(
+        self, mock_environment, collector, sample_active_entry, caplog
+    ):
+        """Test that an error event is collected on re-enable failure and
+        processing continues."""
+        suspended = self._make_suspended_person("NACC-001")
+        mock_environment.user_registry.get.return_value = [suspended]
+        mock_environment.user_registry.re_enable.side_effect = RegistryError(
+            "API update_co_person call failed: 500"
+        )
+
+        process = ActiveUserProcess(mock_environment, collector)
+
+        with caplog.at_level(logging.ERROR):
+            process.visit(sample_active_entry)
+
+        errors = collector.get_errors()
+        assert len(errors) == 1
+
+        error_event = errors[0]
+        assert error_event.event_type == EventType.ERROR.value
+        assert error_event.category == EventCategory.USER_RE_ENABLED.value
+        assert "NACC-001" in error_event.message
+        assert "Failed to re-enable" in error_event.message
+
+    def test_active_person_follows_claimed_flow(
+        self, mock_environment, collector, sample_active_entry
+    ):
+        """Test that active (non-suspended) claimed persons follow the existing
+        claimed flow."""
+        active_person = self._make_active_person("NACC-002", claimed=True)
+        mock_environment.user_registry.get.return_value = [active_person]
+        mock_environment.user_registry.has_bad_claim.return_value = False
+
+        process = ActiveUserProcess(mock_environment, collector)
+        process.visit(sample_active_entry)
+
+        # re_enable should NOT be called for active persons
+        mock_environment.user_registry.re_enable.assert_not_called()
+
+        # The entry should be registered with the claimed person
+        assert sample_active_entry.is_registered
+        assert sample_active_entry.registry_person == active_person
+
+    def test_active_person_follows_unclaimed_flow(
+        self, mock_environment, collector, sample_active_entry
+    ):
+        """Test that active (non-suspended) unclaimed persons follow the
+        existing unclaimed flow."""
+        unclaimed_person = self._make_active_person("NACC-003", claimed=False)
+        unclaimed_person.is_claimed.return_value = False
+        mock_environment.user_registry.get.return_value = [unclaimed_person]
+        mock_environment.user_registry.has_bad_claim.return_value = False
+
+        process = ActiveUserProcess(mock_environment, collector)
+        process.visit(sample_active_entry)
+
+        # re_enable should NOT be called for active persons
+        mock_environment.user_registry.re_enable.assert_not_called()
+        # add should NOT be called (person exists)
+        mock_environment.user_registry.add.assert_not_called()
+
+    def test_multiple_suspended_persons_all_re_enabled(
+        self, mock_environment, collector, sample_active_entry
+    ):
+        """Test that multiple suspended persons are all re-enabled."""
+        suspended_1 = self._make_suspended_person("NACC-001")
+        suspended_2 = self._make_suspended_person("NACC-002")
+        mock_environment.user_registry.get.return_value = [
+            suspended_1,
+            suspended_2,
+        ]
+
+        process = ActiveUserProcess(mock_environment, collector)
+        process.visit(sample_active_entry)
+
+        assert mock_environment.user_registry.re_enable.call_count == 2
+        mock_environment.user_registry.re_enable.assert_any_call("NACC-001")
+        mock_environment.user_registry.re_enable.assert_any_call("NACC-002")
+
+        successes = collector.get_successes()
+        assert len(successes) == 2
+
+    def test_suspended_person_without_registry_id_skipped(
+        self, mock_environment, collector, sample_active_entry
+    ):
+        """Test that a suspended person without a registry ID is skipped."""
+        suspended_no_id = self._make_suspended_person(registry_id=None)
+        mock_environment.user_registry.get.return_value = [suspended_no_id]
+
+        process = ActiveUserProcess(mock_environment, collector)
+        process.visit(sample_active_entry)
+
+        mock_environment.user_registry.re_enable.assert_not_called()

--- a/common/test/python/user_test/test_flywheel_proxy_disable.py
+++ b/common/test/python/user_test/test_flywheel_proxy_disable.py
@@ -1,0 +1,91 @@
+"""Property tests for FlywheelProxy disable-related methods.
+
+Tests Properties 3 and 4 from the disable-inactive-users design
+document.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+from flywheel.models.user import User
+from flywheel.rest import ApiException
+from flywheel_adaptor.flywheel_proxy import FlywheelError, FlywheelProxy
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+
+@st.composite
+def mock_user_strategy(draw):
+    """Generate mock Flywheel User objects with random IDs and emails."""
+    user_id = draw(
+        st.text(
+            min_size=1,
+            max_size=30,
+            alphabet=st.characters(whitelist_categories=("Lu", "Ll", "Nd")),
+        )
+    )
+    email = draw(st.emails())
+    user = Mock(spec=User)
+    user.id = user_id
+    user.email = email
+    return user
+
+
+def _build_proxy(mock_client: Mock, dry_run: bool) -> FlywheelProxy:
+    """Build a FlywheelProxy with a mock client and dry_run setting."""
+    proxy = FlywheelProxy.__new__(FlywheelProxy)
+    # Access the name-mangled attributes directly
+    object.__setattr__(proxy, "_FlywheelProxy__fw", mock_client)
+    object.__setattr__(proxy, "_FlywheelProxy__dry_run", dry_run)
+    return proxy
+
+
+class TestDisableUserDryRunProperty:
+    """Property 3: Disable user calls SDK if and only if not in dry-run mode.
+
+    Feature: disable-inactive-users, Property 3: Disable user calls SDK
+    if and only if not in dry-run mode.
+    """
+
+    @given(user=mock_user_strategy(), dry_run=st.booleans())
+    @settings(max_examples=100)
+    def test_disable_user_calls_sdk_iff_not_dry_run(
+        self, user: Mock, dry_run: bool
+    ) -> None:
+        """For any User and any dry-run setting, modify_user is called exactly
+        when dry_run is False."""
+        mock_client = Mock()
+        proxy = _build_proxy(mock_client, dry_run)
+
+        proxy.disable_user(user)
+
+        if dry_run:
+            mock_client.modify_user.assert_not_called()
+        else:
+            mock_client.modify_user.assert_called_once_with(
+                user.id, {"disabled": True}, clear_permissions=True
+            )
+
+
+class TestDisableUserErrorWrappingProperty:
+    """Property 4: Disable user wraps SDK errors in FlywheelError.
+
+    Feature: disable-inactive-users, Property 4: Disable user wraps SDK
+    errors in FlywheelError.
+    """
+
+    @given(user=mock_user_strategy())
+    @settings(max_examples=100)
+    def test_disable_user_wraps_api_exception_in_flywheel_error(
+        self, user: Mock
+    ) -> None:
+        """For any User, if modify_user raises ApiException, then disable_user
+        raises FlywheelError with a descriptive message."""
+        mock_client = Mock()
+        mock_client.modify_user.side_effect = ApiException(
+            status=500, reason="Internal Server Error"
+        )
+        proxy = _build_proxy(mock_client, dry_run=False)
+
+        with pytest.raises(FlywheelError, match=f"Failed to disable user {user.id}"):
+            proxy.disable_user(user)

--- a/common/test/python/user_test/test_flywheel_proxy_disable.py
+++ b/common/test/python/user_test/test_flywheel_proxy_disable.py
@@ -13,6 +13,22 @@ from flywheel_adaptor.flywheel_proxy import FlywheelError, FlywheelProxy
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
+# Fast email strategy: avoids the slow st.emails() for property tests
+# where the actual email content doesn't matter, only its presence.
+_fast_email = st.builds(
+    lambda user, domain: f"{user}@{domain}.com",
+    st.text(
+        alphabet=st.characters(whitelist_categories=["Ll"]),
+        min_size=1,
+        max_size=8,
+    ),
+    st.text(
+        alphabet=st.characters(whitelist_categories=["Ll"]),
+        min_size=1,
+        max_size=8,
+    ),
+)
+
 
 @st.composite
 def mock_user_strategy(draw):
@@ -24,7 +40,7 @@ def mock_user_strategy(draw):
             alphabet=st.characters(whitelist_categories=("Lu", "Ll", "Nd")),
         )
     )
-    email = draw(st.emails())
+    email = draw(_fast_email)
     user = Mock(spec=User)
     user.id = user_id
     user.email = email
@@ -33,11 +49,7 @@ def mock_user_strategy(draw):
 
 def _build_proxy(mock_client: Mock, dry_run: bool) -> FlywheelProxy:
     """Build a FlywheelProxy with a mock client and dry_run setting."""
-    proxy = FlywheelProxy.__new__(FlywheelProxy)
-    # Access the name-mangled attributes directly
-    object.__setattr__(proxy, "_FlywheelProxy__fw", mock_client)
-    object.__setattr__(proxy, "_FlywheelProxy__dry_run", dry_run)
-    return proxy
+    return FlywheelProxy(client=mock_client, dry_run=dry_run)
 
 
 class TestDisableUserDryRunProperty:

--- a/common/test/python/user_test/test_inactive_user_process.py
+++ b/common/test/python/user_test/test_inactive_user_process.py
@@ -6,6 +6,7 @@ unit tests for COmanage suspension behavior.
 
 from unittest.mock import Mock, call
 
+from centers.center_info import CenterMapInfo
 from flywheel.models.user import User
 from flywheel_adaptor.flywheel_proxy import FlywheelError, FlywheelProxy
 from hypothesis import given, settings
@@ -89,7 +90,9 @@ class TestInactiveEntryProcessingProperty:
         mock_proxy = Mock(spec=FlywheelProxy)
         mock_proxy.find_user_by_email.return_value = fw_users
         mock_env.proxy = mock_proxy
+        mock_env.proxy.dry_run = False
         mock_env.user_registry.get.return_value = []
+        mock_env.admin_group.get_center_map.return_value = CenterMapInfo(centers={})
 
         collector = UserEventCollector()
         process = InactiveUserProcess(mock_env, collector)
@@ -125,8 +128,10 @@ def _build_mock_env() -> Mock:
     mock_env = Mock(spec=UserProcessEnvironment)
     mock_env.proxy = Mock(spec=FlywheelProxy)
     mock_env.proxy.find_user_by_email.return_value = []
+    mock_env.proxy.dry_run = False
     mock_env.user_registry = Mock(spec=UserRegistry)
     mock_env.user_registry.get.return_value = []
+    mock_env.admin_group.get_center_map.return_value = CenterMapInfo(centers={})
     return mock_env
 
 
@@ -236,7 +241,7 @@ class TestInactiveUserComanageSuspension:
 
         event = comanage_successes[0]
         assert event.message == "User NACC-003 suspended in COmanage"
-        assert event.category == EventCategory.USER_DISABLED.value
+        assert event.category == EventCategory.COMANAGE_USER_SUSPENDED.value
         assert event.event_type == EventType.SUCCESS.value
 
     def test_error_event_collected_when_comanage_suspend_fails(self) -> None:
@@ -263,7 +268,7 @@ class TestInactiveUserComanageSuspension:
         event = comanage_errors[0]
         assert "NACC-004" in event.message
         assert "COmanage" in event.message
-        assert event.category == EventCategory.USER_DISABLED.value
+        assert event.category == EventCategory.COMANAGE_USER_SUSPENDED.value
         assert event.event_type == EventType.ERROR.value
 
     def test_already_suspended_person_is_skipped(self) -> None:

--- a/common/test/python/user_test/test_inactive_user_process.py
+++ b/common/test/python/user_test/test_inactive_user_process.py
@@ -1,0 +1,103 @@
+"""Property tests for InactiveUserProcess.
+
+Tests Property 1 from the disable-inactive-users design document.
+"""
+
+from unittest.mock import Mock, call
+
+from flywheel.models.user import User
+from flywheel_adaptor.flywheel_proxy import FlywheelProxy
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from users.event_models import UserEventCollector
+from users.user_entry import PersonName, UserEntry
+from users.user_process_environment import UserProcessEnvironment
+from users.user_processes import InactiveUserProcess
+
+
+@st.composite
+def inactive_user_entry_strategy(draw):
+    """Generate inactive UserEntry objects."""
+    first_name = draw(
+        st.text(
+            min_size=1,
+            max_size=20,
+            alphabet=st.characters(whitelist_categories=("Lu", "Ll")),
+        )
+    )
+    last_name = draw(
+        st.text(
+            min_size=1,
+            max_size=20,
+            alphabet=st.characters(whitelist_categories=("Lu", "Ll")),
+        )
+    )
+    email = draw(st.emails())
+    return UserEntry(
+        name=PersonName(first_name=first_name, last_name=last_name),
+        email=email,
+        active=False,
+        approved=draw(st.booleans()),
+    )
+
+
+@st.composite
+def mock_fw_user_list_strategy(draw):
+    """Generate a list of mock Flywheel User objects."""
+    count = draw(st.integers(min_value=0, max_value=5))
+    users = []
+    for _ in range(count):
+        user_id = draw(
+            st.text(
+                min_size=1,
+                max_size=30,
+                alphabet=st.characters(whitelist_categories=("Lu", "Ll", "Nd")),
+            )
+        )
+        email = draw(st.emails())
+        user = Mock(spec=User)
+        user.id = user_id
+        user.email = email
+        users.append(user)
+    return users
+
+
+class TestInactiveEntryProcessingProperty:
+    """Property 1: Inactive entry processing disables all matching Flywheel
+    users.
+
+    Feature: disable-inactive-users, Property 1: Inactive entry processing
+    disables all matching Flywheel users.
+    """
+
+    @given(
+        entry=inactive_user_entry_strategy(),
+        fw_users=mock_fw_user_list_strategy(),
+    )
+    @settings(max_examples=100)
+    def test_visit_disables_all_matching_users(
+        self, entry: UserEntry, fw_users: list
+    ) -> None:
+        """For any inactive UserEntry and any list of matching Flywheel users,
+        disable_user is called exactly once per match.
+
+        When the match list is empty, disable_user is not called.
+        """
+        mock_env = Mock(spec=UserProcessEnvironment)
+        mock_proxy = Mock(spec=FlywheelProxy)
+        mock_proxy.find_user_by_email.return_value = fw_users
+        mock_env.proxy = mock_proxy
+
+        collector = UserEventCollector()
+        process = InactiveUserProcess(mock_env, collector)
+
+        process.visit(entry)
+
+        mock_proxy.find_user_by_email.assert_called_once_with(entry.email)
+
+        if not fw_users:
+            mock_proxy.disable_user.assert_not_called()
+        else:
+            assert mock_proxy.disable_user.call_count == len(fw_users)
+            expected_calls = [call(user) for user in fw_users]
+            mock_proxy.disable_user.assert_has_calls(expected_calls, any_order=False)

--- a/common/test/python/user_test/test_inactive_user_process.py
+++ b/common/test/python/user_test/test_inactive_user_process.py
@@ -1,38 +1,46 @@
-"""Property tests for InactiveUserProcess.
+"""Property tests and unit tests for InactiveUserProcess.
 
-Tests Property 1 from the disable-inactive-users design document.
+Tests Property 1 from the disable-inactive-users design document, and
+unit tests for COmanage suspension behavior.
 """
 
 from unittest.mock import Mock, call
 
 from flywheel.models.user import User
-from flywheel_adaptor.flywheel_proxy import FlywheelProxy
+from flywheel_adaptor.flywheel_proxy import FlywheelError, FlywheelProxy
 from hypothesis import given, settings
 from hypothesis import strategies as st
-from users.event_models import UserEventCollector
+from users.event_models import EventCategory, EventType, UserEventCollector
 from users.user_entry import PersonName, UserEntry
 from users.user_process_environment import UserProcessEnvironment
 from users.user_processes import InactiveUserProcess
+from users.user_registry import RegistryError, RegistryPerson, UserRegistry
+
+# Fast email strategy: avoids the slow st.emails() for property tests
+# where the actual email content doesn't matter, only its presence.
+_fast_email = st.builds(
+    lambda user, domain: f"{user}@{domain}.com",
+    st.text(
+        alphabet=st.characters(whitelist_categories=["Ll"]),
+        min_size=1,
+        max_size=8,
+    ),
+    st.text(
+        alphabet=st.characters(whitelist_categories=["Ll"]),
+        min_size=1,
+        max_size=8,
+    ),
+)
+
+_letters = st.characters(whitelist_categories=("Lu", "Ll"))
 
 
 @st.composite
 def inactive_user_entry_strategy(draw):
     """Generate inactive UserEntry objects."""
-    first_name = draw(
-        st.text(
-            min_size=1,
-            max_size=20,
-            alphabet=st.characters(whitelist_categories=("Lu", "Ll")),
-        )
-    )
-    last_name = draw(
-        st.text(
-            min_size=1,
-            max_size=20,
-            alphabet=st.characters(whitelist_categories=("Lu", "Ll")),
-        )
-    )
-    email = draw(st.emails())
+    first_name = draw(st.text(min_size=1, max_size=20, alphabet=_letters))
+    last_name = draw(st.text(min_size=1, max_size=20, alphabet=_letters))
+    email = draw(_fast_email)
     return UserEntry(
         name=PersonName(first_name=first_name, last_name=last_name),
         email=email,
@@ -46,15 +54,9 @@ def mock_fw_user_list_strategy(draw):
     """Generate a list of mock Flywheel User objects."""
     count = draw(st.integers(min_value=0, max_value=5))
     users = []
-    for _ in range(count):
-        user_id = draw(
-            st.text(
-                min_size=1,
-                max_size=30,
-                alphabet=st.characters(whitelist_categories=("Lu", "Ll", "Nd")),
-            )
-        )
-        email = draw(st.emails())
+    for i in range(count):
+        user_id = f"fw-user-{i}-{draw(st.integers(min_value=100, max_value=999))}"
+        email = draw(_fast_email)
         user = Mock(spec=User)
         user.id = user_id
         user.email = email
@@ -87,6 +89,7 @@ class TestInactiveEntryProcessingProperty:
         mock_proxy = Mock(spec=FlywheelProxy)
         mock_proxy.find_user_by_email.return_value = fw_users
         mock_env.proxy = mock_proxy
+        mock_env.user_registry.get.return_value = []
 
         collector = UserEventCollector()
         process = InactiveUserProcess(mock_env, collector)
@@ -101,3 +104,198 @@ class TestInactiveEntryProcessingProperty:
             assert mock_proxy.disable_user.call_count == len(fw_users)
             expected_calls = [call(user) for user in fw_users]
             mock_proxy.disable_user.assert_has_calls(expected_calls, any_order=False)
+
+
+# --- Unit tests for COmanage suspension in InactiveUserProcess ---
+# Validates: Requirements 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7
+
+
+def _build_entry(email: str = "user@example.com") -> UserEntry:
+    """Build an inactive UserEntry for testing."""
+    return UserEntry(
+        name=PersonName(first_name="Test", last_name="User"),
+        email=email,
+        active=False,
+        approved=True,
+    )
+
+
+def _build_mock_env() -> Mock:
+    """Build a mock UserProcessEnvironment with sensible defaults."""
+    mock_env = Mock(spec=UserProcessEnvironment)
+    mock_env.proxy = Mock(spec=FlywheelProxy)
+    mock_env.proxy.find_user_by_email.return_value = []
+    mock_env.user_registry = Mock(spec=UserRegistry)
+    mock_env.user_registry.get.return_value = []
+    return mock_env
+
+
+def _build_fw_user(user_id: str = "fw-user-1") -> Mock:
+    """Build a mock Flywheel User."""
+    user = Mock(spec=User)
+    user.id = user_id
+    user.email = "user@example.com"
+    return user
+
+
+def _build_registry_person(
+    registry_id: str = "NACC-001",
+    suspended: bool = False,
+) -> Mock:
+    """Build a mock RegistryPerson with a registry ID."""
+    person = Mock(spec=RegistryPerson)
+    person.registry_id.return_value = registry_id
+    person.is_suspended.return_value = suspended
+    return person
+
+
+class TestInactiveUserComanageSuspension:
+    """Unit tests for COmanage suspension in InactiveUserProcess."""
+
+    def test_comanage_suspend_attempted_after_flywheel_disable(self) -> None:
+        """COmanage suspend is attempted after Flywheel disable succeeds."""
+        mock_env = _build_mock_env()
+        fw_user = _build_fw_user()
+        mock_env.proxy.find_user_by_email.return_value = [fw_user]
+
+        person = _build_registry_person("NACC-001")
+        mock_env.user_registry.get.return_value = [person]
+
+        collector = UserEventCollector()
+        process = InactiveUserProcess(mock_env, collector)
+        entry = _build_entry()
+
+        process.visit(entry)
+
+        # Flywheel disable was called
+        mock_env.proxy.disable_user.assert_called_once_with(fw_user)
+        # COmanage suspend was called
+        mock_env.user_registry.suspend.assert_called_once_with("NACC-001")
+
+    def test_comanage_suspend_attempted_when_flywheel_disable_fails(self) -> None:
+        """COmanage suspend is still attempted even when Flywheel disable
+        fails."""
+        mock_env = _build_mock_env()
+        fw_user = _build_fw_user()
+        mock_env.proxy.find_user_by_email.return_value = [fw_user]
+        mock_env.proxy.disable_user.side_effect = FlywheelError("Flywheel down")
+
+        person = _build_registry_person("NACC-002")
+        mock_env.user_registry.get.return_value = [person]
+
+        collector = UserEventCollector()
+        process = InactiveUserProcess(mock_env, collector)
+        entry = _build_entry()
+
+        process.visit(entry)
+
+        # Flywheel disable was attempted (and failed)
+        mock_env.proxy.disable_user.assert_called_once_with(fw_user)
+        # COmanage suspend was still attempted
+        mock_env.user_registry.suspend.assert_called_once_with("NACC-002")
+
+    def test_no_error_when_no_comanage_record_found(self) -> None:
+        """No error when no COmanage record found for user email."""
+        mock_env = _build_mock_env()
+        mock_env.proxy.find_user_by_email.return_value = []
+        mock_env.user_registry.get.return_value = []
+
+        collector = UserEventCollector()
+        process = InactiveUserProcess(mock_env, collector)
+        entry = _build_entry()
+
+        # Should not raise
+        process.visit(entry)
+
+        mock_env.user_registry.suspend.assert_not_called()
+        # No error events should be collected for missing COmanage records
+        errors = collector.get_errors()
+        comanage_errors = [
+            e for e in errors if "COmanage" in e.message or "comanage" in e.message
+        ]
+        assert len(comanage_errors) == 0
+
+    def test_success_event_collected_with_comanage_message(self) -> None:
+        """Success event is collected with COmanage-specific message on
+        suspend."""
+        mock_env = _build_mock_env()
+        mock_env.proxy.find_user_by_email.return_value = []
+
+        person = _build_registry_person("NACC-003")
+        mock_env.user_registry.get.return_value = [person]
+
+        collector = UserEventCollector()
+        process = InactiveUserProcess(mock_env, collector)
+        entry = _build_entry()
+
+        process.visit(entry)
+
+        successes = collector.get_successes()
+        comanage_successes = [e for e in successes if "COmanage" in e.message]
+        assert len(comanage_successes) == 1
+
+        event = comanage_successes[0]
+        assert event.message == "User NACC-003 suspended in COmanage"
+        assert event.category == EventCategory.USER_DISABLED.value
+        assert event.event_type == EventType.SUCCESS.value
+
+    def test_error_event_collected_when_comanage_suspend_fails(self) -> None:
+        """Error event is collected when COmanage suspend fails."""
+        mock_env = _build_mock_env()
+        mock_env.proxy.find_user_by_email.return_value = []
+
+        person = _build_registry_person("NACC-004")
+        mock_env.user_registry.get.return_value = [person]
+        mock_env.user_registry.suspend.side_effect = RegistryError(
+            "API update_co_person call failed: 500"
+        )
+
+        collector = UserEventCollector()
+        process = InactiveUserProcess(mock_env, collector)
+        entry = _build_entry()
+
+        process.visit(entry)
+
+        errors = collector.get_errors()
+        comanage_errors = [e for e in errors if "COmanage" in e.message]
+        assert len(comanage_errors) == 1
+
+        event = comanage_errors[0]
+        assert "NACC-004" in event.message
+        assert "COmanage" in event.message
+        assert event.category == EventCategory.USER_DISABLED.value
+        assert event.event_type == EventType.ERROR.value
+
+    def test_already_suspended_person_is_skipped(self) -> None:
+        """A person already suspended in COmanage is not suspended again."""
+        mock_env = _build_mock_env()
+        mock_env.proxy.find_user_by_email.return_value = []
+
+        person = _build_registry_person("NACC-005", suspended=True)
+        mock_env.user_registry.get.return_value = [person]
+
+        collector = UserEventCollector()
+        process = InactiveUserProcess(mock_env, collector)
+        entry = _build_entry()
+
+        process.visit(entry)
+
+        mock_env.user_registry.suspend.assert_not_called()
+
+    def test_mixed_suspended_and_active_persons(self) -> None:
+        """Only non-suspended persons are suspended; already-suspended ones are
+        skipped."""
+        mock_env = _build_mock_env()
+        mock_env.proxy.find_user_by_email.return_value = []
+
+        already_suspended = _build_registry_person("NACC-006", suspended=True)
+        active_person = _build_registry_person("NACC-007", suspended=False)
+        mock_env.user_registry.get.return_value = [already_suspended, active_person]
+
+        collector = UserEventCollector()
+        process = InactiveUserProcess(mock_env, collector)
+        entry = _build_entry()
+
+        process.visit(entry)
+
+        mock_env.user_registry.suspend.assert_called_once_with("NACC-007")

--- a/common/test/python/user_test/test_inactive_user_process_redcap.py
+++ b/common/test/python/user_test/test_inactive_user_process_redcap.py
@@ -1,0 +1,696 @@
+"""Unit tests for the REDCap disable step in InactiveUserProcess.
+
+Tests the REDCap role removal flow through the public visit() method,
+verifying auth email resolution, center iteration, dry-run mode,
+event collection, step independence, and four-step ordering.
+
+Requirements: 2.1, 2.2, 2.3, 2.4, 3.2, 3.4, 3.5, 3.6, 3.7,
+              4.2, 4.3, 4.4, 7.1, 7.2, 7.3
+"""
+
+from unittest.mock import Mock
+
+from centers.center_group import (
+    CenterMetadata,
+    CenterStudyMetadata,
+    FormIngestProjectMetadata,
+    REDCapFormProjectMetadata,
+)
+from centers.center_info import CenterInfo, CenterMapInfo
+from centers.nacc_group import NACCGroup
+from flywheel_adaptor.flywheel_proxy import FlywheelError, FlywheelProxy
+from redcap_api.redcap_connection import REDCapConnectionError
+from redcap_api.redcap_project import REDCapProject
+from users.event_models import (
+    EventCategory,
+    EventType,
+    UserEventCollector,
+)
+from users.user_entry import PersonName, UserEntry
+from users.user_process_environment import UserProcessEnvironment
+from users.user_processes import InactiveUserProcess
+from users.user_registry import RegistryPerson, UserRegistry
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_entry(
+    email: str = "user@example.com",
+    auth_email: str | None = None,
+) -> UserEntry:
+    """Build an inactive UserEntry for testing."""
+    return UserEntry(
+        name=PersonName(first_name="Test", last_name="User"),
+        email=email,
+        auth_email=auth_email,
+        active=False,
+        approved=True,
+    )
+
+
+def _build_mock_env(dry_run: bool = False) -> Mock:
+    """Build a mock UserProcessEnvironment with sensible defaults.
+
+    The admin_group mock is configured with an empty center map by
+    default.
+    """
+    mock_env = Mock(spec=UserProcessEnvironment)
+    mock_env.proxy = Mock(spec=FlywheelProxy)
+    mock_env.proxy.find_user_by_email.return_value = []
+    mock_env.proxy.dry_run = dry_run
+    mock_env.user_registry = Mock(spec=UserRegistry)
+    mock_env.user_registry.get.return_value = []
+    mock_env.admin_group = Mock(spec=NACCGroup)
+    mock_env.admin_group.get_center_map.return_value = CenterMapInfo(centers={})
+    mock_env.admin_group.get_center.return_value = None
+    return mock_env
+
+
+def _build_registry_person(
+    auth_email: str = "auth@university.edu",
+) -> Mock:
+    """Build a mock RegistryPerson with an email_address."""
+    person = Mock(spec=RegistryPerson)
+    email_addr = Mock()
+    email_addr.mail = auth_email
+    person.email_address = email_addr
+    person.registry_id.return_value = None
+    person.is_suspended.return_value = False
+    return person
+
+
+def _build_mock_redcap(title: str = "Test Project") -> Mock:
+    """Build a mock REDCapProject with a title."""
+    mock_redcap = Mock(spec=REDCapProject)
+    mock_redcap.title = title
+    return mock_redcap
+
+
+def _build_center_metadata_with_redcap(
+    pids: list[int] | None = None,
+) -> CenterMetadata:
+    """Build a CenterMetadata with form ingest projects containing REDCap
+    PIDs."""
+    if pids is None:
+        pids = [100]
+    redcap_projects = {
+        f"module-{pid}": REDCapFormProjectMetadata(
+            redcap_pid=pid,
+            label=f"module-{pid}",
+        )
+        for pid in pids
+    }
+    form_ingest = FormIngestProjectMetadata(
+        study_id="study-1",
+        project_id="proj-1",
+        project_label="ingest-form",
+        pipeline_adcid=1,
+        datatype="form",
+        redcap_projects=redcap_projects,
+    )
+    study = CenterStudyMetadata(
+        study_id="study-1",
+        study_name="Test Study",
+        ingest_projects={"ingest-form": form_ingest},
+    )
+    return CenterMetadata(adcid=1, active=True, studies={"study-1": study})
+
+
+def _build_center_metadata_no_form_ingest() -> CenterMetadata:
+    """Build a CenterMetadata with no form ingest projects."""
+    return CenterMetadata(adcid=2, active=True, studies={})
+
+
+def _setup_center_map_with_centers(
+    mock_env: Mock,
+    center_configs: list[dict],
+) -> dict[int, Mock]:
+    """Set up multiple centers in the environment.
+
+    Each config dict should have: adcid, metadata, redcap_project
+    (optional). Returns a dict mapping adcid -> mock_center_group.
+    """
+    center_groups: dict[int, Mock] = {}
+    center_map = CenterMapInfo(centers={})
+    mock_env.admin_group.get_center_map.return_value = center_map
+    mock_env.admin_group.get_center.side_effect = None
+    mock_env.admin_group.get_center.return_value = None
+
+    mapping: dict[int, Mock] = {}
+    for cfg in center_configs:
+        adcid = cfg["adcid"]
+        metadata = cfg["metadata"]
+        redcap_proj = cfg.get("redcap_project")
+
+        center_info = CenterInfo(
+            adcid=adcid, name=f"center-{adcid}", group=f"grp-{adcid}"
+        )
+        center_map.add(adcid, center_info)
+
+        mock_cg = Mock()
+        mock_cg.get_project_info.return_value = metadata
+        mock_cg.get_redcap_project.return_value = redcap_proj
+        mapping[adcid] = mock_cg
+        center_groups[adcid] = mock_cg
+
+    mock_env.admin_group.get_center.side_effect = lambda a: mapping.get(a)
+    return center_groups
+
+
+# ===========================================================================
+# Auth email resolution tests
+# Validates: Requirements 2.1, 2.2, 2.3, 2.4
+# ===========================================================================
+
+
+class TestAuthEmailResolution:
+    """Test REDCap username resolution priority."""
+
+    def test_entry_auth_email_used_directly(self) -> None:
+        """When entry has auth_email, it is used as the REDCap username and the
+        COmanage auth_email extraction is skipped.
+
+        Validates: Requirement 2.4
+        """
+        mock_env = _build_mock_env()
+        mock_redcap = _build_mock_redcap()
+        metadata = _build_center_metadata_with_redcap([100])
+        _setup_center_map_with_centers(
+            mock_env,
+            [{"adcid": 1, "metadata": metadata, "redcap_project": mock_redcap}],
+        )
+
+        # Set up a registry person that should NOT be used for auth_email
+        person = _build_registry_person(auth_email="should-not-use@uni.edu")
+        mock_env.user_registry.get.return_value = [person]
+
+        collector = UserEventCollector()
+        process = InactiveUserProcess(mock_env, collector)
+        entry = _build_entry(auth_email="entry-auth@uni.edu")
+
+        process.visit(entry)
+
+        # unassign_user_role should be called with the entry's auth_email
+        mock_redcap.assign_user_role.assert_called_once_with("entry-auth@uni.edu", "")
+
+    def test_comanage_auth_email_used_when_entry_has_none(self) -> None:
+        """When entry has no auth_email but COmanage lookup returns one, the
+        COmanage auth_email is used.
+
+        Validates: Requirements 2.1, 2.2
+        """
+        mock_env = _build_mock_env()
+        mock_redcap = _build_mock_redcap()
+        metadata = _build_center_metadata_with_redcap([100])
+        _setup_center_map_with_centers(
+            mock_env,
+            [{"adcid": 1, "metadata": metadata, "redcap_project": mock_redcap}],
+        )
+
+        person = _build_registry_person(auth_email="comanage-auth@uni.edu")
+        mock_env.user_registry.get.return_value = [person]
+
+        collector = UserEventCollector()
+        process = InactiveUserProcess(mock_env, collector)
+        entry = _build_entry()
+
+        process.visit(entry)
+
+        mock_redcap.assign_user_role.assert_called_once_with(
+            "comanage-auth@uni.edu", ""
+        )
+
+    def test_directory_email_fallback_when_no_registry_match(self) -> None:
+        """When no registry person is found and entry has no auth_email, the
+        directory email is used as fallback.
+
+        Validates: Requirement 2.3
+        """
+        mock_env = _build_mock_env()
+        mock_redcap = _build_mock_redcap()
+        metadata = _build_center_metadata_with_redcap([100])
+        _setup_center_map_with_centers(
+            mock_env,
+            [{"adcid": 1, "metadata": metadata, "redcap_project": mock_redcap}],
+        )
+
+        mock_env.user_registry.get.return_value = []
+
+        collector = UserEventCollector()
+        process = InactiveUserProcess(mock_env, collector)
+        entry = _build_entry(email="dir@example.com")
+
+        process.visit(entry)
+
+        mock_redcap.assign_user_role.assert_called_once_with("dir@example.com", "")
+
+
+# ===========================================================================
+# Center iteration tests
+# Validates: Requirements 3.2, 3.4, 3.5, 7.1, 7.2, 7.3
+# ===========================================================================
+
+
+class TestCenterIteration:
+    """Test iteration over centers and REDCap projects."""
+
+    def test_skips_center_with_no_form_ingest_projects(self) -> None:
+        """Centers with no form ingest projects are skipped without error.
+
+        Validates: Requirement 3.2
+        """
+        mock_env = _build_mock_env()
+        metadata_no_forms = _build_center_metadata_no_form_ingest()
+        _setup_center_map_with_centers(
+            mock_env,
+            [{"adcid": 1, "metadata": metadata_no_forms}],
+        )
+
+        collector = UserEventCollector()
+        process = InactiveUserProcess(mock_env, collector)
+        entry = _build_entry()
+
+        process.visit(entry)
+
+        # No events should be collected for REDCap
+        redcap_events = [
+            e
+            for e in collector.get_events()
+            if e.category == EventCategory.REDCAP_USER_DISABLED.value
+        ]
+        assert len(redcap_events) == 0
+
+    def test_skips_project_with_unavailable_credentials(self) -> None:
+        """Projects with unavailable REDCap credentials are skipped with an
+        error event.
+
+        Validates: Requirement 3.4
+        """
+        mock_env = _build_mock_env()
+        metadata = _build_center_metadata_with_redcap([100])
+        # get_redcap_project returns None -> credentials unavailable
+        _setup_center_map_with_centers(
+            mock_env,
+            [{"adcid": 1, "metadata": metadata, "redcap_project": None}],
+        )
+
+        collector = UserEventCollector()
+        process = InactiveUserProcess(mock_env, collector)
+        entry = _build_entry()
+
+        process.visit(entry)
+
+        errors = collector.get_errors()
+        redcap_errors = [
+            e for e in errors if e.category == EventCategory.REDCAP_USER_DISABLED.value
+        ]
+        assert len(redcap_errors) == 1
+        assert "unavailable" in redcap_errors[0].message.lower()
+
+    def test_continues_after_unassignment_failure(self) -> None:
+        """Processing continues to the next project after a failure.
+
+        Validates: Requirements 3.5, 7.1
+        """
+        mock_env = _build_mock_env()
+        metadata = _build_center_metadata_with_redcap([100, 200])
+
+        mock_redcap_100 = _build_mock_redcap(title="Project 100")
+        mock_redcap_100.assign_user_role.side_effect = REDCapConnectionError(
+            "connection failed"
+        )
+        mock_redcap_200 = _build_mock_redcap(title="Project 200")
+        mock_redcap_200.assign_user_role.return_value = 1
+
+        center_groups = _setup_center_map_with_centers(
+            mock_env,
+            [{"adcid": 1, "metadata": metadata}],
+        )
+        # Return different REDCap projects for different PIDs
+        center_groups[1].get_redcap_project.side_effect = (
+            lambda pid: mock_redcap_100 if pid == 100 else mock_redcap_200
+        )
+
+        collector = UserEventCollector()
+        process = InactiveUserProcess(mock_env, collector)
+        entry = _build_entry()
+
+        process.visit(entry)
+
+        # Both projects should have been attempted
+        mock_redcap_100.assign_user_role.assert_called_once()
+        mock_redcap_200.assign_user_role.assert_called_once()
+
+        # One error, one success
+        redcap_events = [
+            e
+            for e in collector.get_events()
+            if e.category == EventCategory.REDCAP_USER_DISABLED.value
+        ]
+        errors = [e for e in redcap_events if e.event_type == EventType.ERROR.value]
+        successes = [
+            e for e in redcap_events if e.event_type == EventType.SUCCESS.value
+        ]
+        assert len(errors) == 1
+        assert len(successes) == 1
+
+    def test_continues_after_center_retrieval_failure(self) -> None:
+        """Processing continues when a center group cannot be retrieved.
+
+        Validates: Requirement 7.2
+        """
+        mock_env = _build_mock_env()
+        metadata_good = _build_center_metadata_with_redcap([200])
+        mock_redcap = _build_mock_redcap()
+
+        center_map = CenterMapInfo(centers={})
+        mock_env.admin_group.get_center_map.return_value = center_map
+
+        # Center 1 cannot be retrieved, center 2 works
+        center_map.add(1, CenterInfo(adcid=1, name="c1", group="g1"))
+        center_map.add(2, CenterInfo(adcid=2, name="c2", group="g2"))
+
+        mock_cg_2 = Mock()
+        mock_cg_2.get_project_info.return_value = metadata_good
+        mock_cg_2.get_redcap_project.return_value = mock_redcap
+
+        mock_env.admin_group.get_center.side_effect = (
+            lambda a: None if a == 1 else mock_cg_2
+        )
+
+        collector = UserEventCollector()
+        process = InactiveUserProcess(mock_env, collector)
+        entry = _build_entry()
+
+        process.visit(entry)
+
+        # Center 2's project should still be processed
+        mock_redcap.assign_user_role.assert_called_once()
+
+
+# ===========================================================================
+# Dry-run mode tests
+# Validates: Requirement 3.7
+# ===========================================================================
+
+
+class TestDryRunMode:
+    """Test dry-run mode behavior."""
+
+    def test_dry_run_does_not_call_unassign(self) -> None:
+        """In dry-run mode, unassign_user_role is not called.
+
+        Validates: Requirement 3.7
+        """
+        mock_env = _build_mock_env(dry_run=True)
+        mock_redcap = _build_mock_redcap()
+        metadata = _build_center_metadata_with_redcap([100])
+        _setup_center_map_with_centers(
+            mock_env,
+            [{"adcid": 1, "metadata": metadata, "redcap_project": mock_redcap}],
+        )
+
+        collector = UserEventCollector()
+        process = InactiveUserProcess(mock_env, collector)
+        entry = _build_entry()
+
+        process.visit(entry)
+
+        # assign_user_role should NOT be called
+        mock_redcap.assign_user_role.assert_not_called()
+
+    def test_dry_run_collects_success_event(self) -> None:
+        """In dry-run mode, a success event is still collected.
+
+        Validates: Requirement 3.7
+        """
+        mock_env = _build_mock_env(dry_run=True)
+        mock_redcap = _build_mock_redcap()
+        metadata = _build_center_metadata_with_redcap([100])
+        _setup_center_map_with_centers(
+            mock_env,
+            [{"adcid": 1, "metadata": metadata, "redcap_project": mock_redcap}],
+        )
+
+        collector = UserEventCollector()
+        process = InactiveUserProcess(mock_env, collector)
+        entry = _build_entry()
+
+        process.visit(entry)
+
+        successes = collector.get_successes()
+        redcap_successes = [
+            e
+            for e in successes
+            if e.category == EventCategory.REDCAP_USER_DISABLED.value
+        ]
+        assert len(redcap_successes) == 1
+        assert "dry run" in redcap_successes[0].message.lower()
+
+
+# ===========================================================================
+# Event collection tests
+# Validates: Requirements 4.2, 4.3, 4.4
+# ===========================================================================
+
+
+class TestEventCollection:
+    """Test event collection for REDCap disable actions."""
+
+    def test_success_event_has_correct_category_and_pid(self) -> None:
+        """Success events have REDCAP_USER_DISABLED category with title and
+        PID.
+
+        Validates: Requirement 4.2
+        """
+        mock_env = _build_mock_env()
+        mock_redcap = _build_mock_redcap(title="UDS Forms")
+        metadata = _build_center_metadata_with_redcap([100])
+        _setup_center_map_with_centers(
+            mock_env,
+            [{"adcid": 1, "metadata": metadata, "redcap_project": mock_redcap}],
+        )
+
+        collector = UserEventCollector()
+        process = InactiveUserProcess(mock_env, collector)
+        entry = _build_entry()
+
+        process.visit(entry)
+
+        successes = collector.get_successes()
+        redcap_successes = [
+            e
+            for e in successes
+            if e.category == EventCategory.REDCAP_USER_DISABLED.value
+        ]
+        assert len(redcap_successes) == 1
+        event = redcap_successes[0]
+        assert "100" in event.message
+        assert "UDS Forms" in event.message
+
+    def test_error_event_has_correct_category_and_details(self) -> None:
+        """Error events have REDCAP_USER_DISABLED category with error details.
+
+        Validates: Requirement 4.3
+        """
+        mock_env = _build_mock_env()
+        mock_redcap = _build_mock_redcap(title="UDS Forms")
+        mock_redcap.assign_user_role.side_effect = REDCapConnectionError("timeout")
+        metadata = _build_center_metadata_with_redcap([100])
+        _setup_center_map_with_centers(
+            mock_env,
+            [{"adcid": 1, "metadata": metadata, "redcap_project": mock_redcap}],
+        )
+
+        collector = UserEventCollector()
+        process = InactiveUserProcess(mock_env, collector)
+        entry = _build_entry()
+
+        process.visit(entry)
+
+        errors = collector.get_errors()
+        redcap_errors = [
+            e for e in errors if e.category == EventCategory.REDCAP_USER_DISABLED.value
+        ]
+        assert len(redcap_errors) == 1
+        event = redcap_errors[0]
+        assert "100" in event.message
+        assert "UDS Forms" in event.message
+
+    def test_event_user_context_contains_email_and_name(self) -> None:
+        """Events include user email and name in the UserContext.
+
+        Validates: Requirement 4.4
+        """
+        mock_env = _build_mock_env()
+        mock_redcap = _build_mock_redcap()
+        metadata = _build_center_metadata_with_redcap([100])
+        _setup_center_map_with_centers(
+            mock_env,
+            [{"adcid": 1, "metadata": metadata, "redcap_project": mock_redcap}],
+        )
+
+        collector = UserEventCollector()
+        process = InactiveUserProcess(mock_env, collector)
+        entry = _build_entry(email="specific@example.com")
+
+        process.visit(entry)
+
+        successes = collector.get_successes()
+        redcap_successes = [
+            e
+            for e in successes
+            if e.category == EventCategory.REDCAP_USER_DISABLED.value
+        ]
+        assert len(redcap_successes) == 1
+        ctx = redcap_successes[0].user_context
+        assert ctx.email == "specific@example.com"
+        assert "Test" in ctx.name
+        assert "User" in ctx.name
+
+
+# ===========================================================================
+# Step independence tests
+# Validates: Requirement 3.6
+# ===========================================================================
+
+
+class TestStepIndependence:
+    """Test that steps are independent of each other."""
+
+    def test_redcap_step_runs_even_if_flywheel_disable_fails(self) -> None:
+        """REDCap step runs even when Flywheel disable raises a FlywheelError.
+
+        Validates: Requirement 3.6
+        """
+        mock_env = _build_mock_env()
+        mock_env.proxy.find_user_by_email.side_effect = FlywheelError(
+            "Flywheel failure"
+        )
+
+        mock_redcap = _build_mock_redcap()
+        metadata = _build_center_metadata_with_redcap([100])
+        _setup_center_map_with_centers(
+            mock_env,
+            [{"adcid": 1, "metadata": metadata, "redcap_project": mock_redcap}],
+        )
+
+        collector = UserEventCollector()
+        process = InactiveUserProcess(mock_env, collector)
+        entry = _build_entry()
+
+        process.visit(entry)
+
+        # REDCap unassignment was still attempted
+        mock_redcap.assign_user_role.assert_called_once()
+
+    def test_comanage_suspend_runs_even_if_redcap_step_fails(self) -> None:
+        """COmanage suspend runs even when the REDCap step raises.
+
+        Validates: Requirement 3.6
+        """
+        mock_env = _build_mock_env()
+
+        # Set up a registry person for COmanage suspend
+        person = _build_registry_person()
+        person.registry_id.return_value = "NACC-001"
+        mock_env.user_registry.get.return_value = [person]
+
+        # Make the admin_group.get_center_map raise to simulate REDCap step failure
+        mock_env.admin_group.get_center_map.side_effect = REDCapConnectionError(
+            "REDCap step failure"
+        )
+
+        collector = UserEventCollector()
+        process = InactiveUserProcess(mock_env, collector)
+        entry = _build_entry()
+
+        process.visit(entry)
+
+        # COmanage suspend was still attempted
+        mock_env.user_registry.suspend.assert_called_once_with("NACC-001")
+
+
+# ===========================================================================
+# Four-step ordering tests
+# Validates: Requirements 7.3
+# ===========================================================================
+
+
+class TestFourStepOrdering:
+    """Test that the four steps execute in the correct order."""
+
+    def test_comanage_lookup_happens_before_redcap_step(self) -> None:
+        """COmanage lookup (Step 2) provides auth_email to REDCap step (Step
+        3).
+
+        Validates: Requirement 7.3
+        """
+        mock_env = _build_mock_env()
+        mock_redcap = _build_mock_redcap()
+        metadata = _build_center_metadata_with_redcap([100])
+        _setup_center_map_with_centers(
+            mock_env,
+            [{"adcid": 1, "metadata": metadata, "redcap_project": mock_redcap}],
+        )
+
+        # COmanage lookup returns a person with auth_email
+        person = _build_registry_person(auth_email="looked-up@uni.edu")
+        mock_env.user_registry.get.return_value = [person]
+
+        collector = UserEventCollector()
+        process = InactiveUserProcess(mock_env, collector)
+        entry = _build_entry()  # no auth_email on entry
+
+        process.visit(entry)
+
+        # The REDCap step should use the auth_email from COmanage lookup
+        mock_redcap.assign_user_role.assert_called_once_with("looked-up@uni.edu", "")
+
+    def test_comanage_suspend_happens_after_redcap_step(self) -> None:
+        """COmanage suspend (Step 4) happens after REDCap step (Step 3).
+
+        Validates: Requirement 7.3
+        """
+        mock_env = _build_mock_env()
+        mock_redcap = _build_mock_redcap()
+        metadata = _build_center_metadata_with_redcap([100])
+        _setup_center_map_with_centers(
+            mock_env,
+            [{"adcid": 1, "metadata": metadata, "redcap_project": mock_redcap}],
+        )
+
+        person = _build_registry_person()
+        person.registry_id.return_value = "NACC-001"
+        mock_env.user_registry.get.return_value = [person]
+
+        call_order: list[str] = []
+        original_assign = mock_redcap.assign_user_role
+
+        def track_assign(*args, **kwargs):
+            call_order.append("redcap_unassign")
+            return original_assign.return_value
+
+        mock_redcap.assign_user_role.side_effect = track_assign
+
+        original_suspend = mock_env.user_registry.suspend
+
+        def track_suspend(*args, **kwargs):
+            call_order.append("comanage_suspend")
+            return original_suspend.return_value
+
+        mock_env.user_registry.suspend.side_effect = track_suspend
+
+        collector = UserEventCollector()
+        process = InactiveUserProcess(mock_env, collector)
+        entry = _build_entry()
+
+        process.visit(entry)
+
+        assert "redcap_unassign" in call_order
+        assert "comanage_suspend" in call_order
+        assert call_order.index("redcap_unassign") < call_order.index(
+            "comanage_suspend"
+        )

--- a/common/test/python/user_test/test_property_dry_run.py
+++ b/common/test/python/user_test/test_property_dry_run.py
@@ -1,0 +1,79 @@
+"""Property test for dry-run mode behavior.
+
+**Feature: disable-inactive-comanage-users, Property 4: Dry-run mode skips
+writes but performs reads**
+**Validates: Requirements 5.1, 5.2, 5.3**
+"""
+
+from unittest.mock import MagicMock
+
+from coreapi_client.api.default_api import DefaultApi
+from coreapi_client.models.co_person import CoPerson
+from coreapi_client.models.co_person_message import CoPersonMessage
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from users.user_registry import UserRegistry
+
+
+def _registry_id_strategy():
+    """Generate random non-empty registry ID strings."""
+    return st.text(
+        min_size=1,
+        max_size=20,
+        alphabet=st.characters(whitelist_categories=("Lu", "Ll", "Nd")),
+    ).filter(lambda s: len(s.strip()) > 0)
+
+
+def _target_status_strategy():
+    """Generate target status values: 'S' (suspend) or 'A' (re-enable)."""
+    return st.sampled_from(["S", "A"])
+
+
+@given(
+    registry_id=_registry_id_strategy(),
+    target_status=_target_status_strategy(),
+)
+@settings(max_examples=100)
+def test_dry_run_skips_writes_but_performs_reads(
+    registry_id: str,
+    target_status: str,
+):
+    """Property test: Dry-run mode calls GET but never calls PUT.
+
+    **Feature: disable-inactive-comanage-users, Property 4: Dry-run mode skips
+    writes but performs reads**
+    **Validates: Requirements 5.1, 5.2, 5.3**
+
+    For any valid registry ID and any target status ('S' or 'A'), when dry-run
+    mode is enabled, the UserRegistry SHALL call the GET endpoint to retrieve
+    the record but SHALL NOT call the PUT endpoint.
+    """
+    # Arrange: build a mock API and a dry-run registry
+    mock_api = MagicMock(spec=DefaultApi)
+
+    # Mock GET to return a valid CoPersonMessage
+    person_message = CoPersonMessage(
+        CoPerson=CoPerson(co_id=1, status="A", meta=None),
+    )
+    get_response = MagicMock()
+    get_response.var_0 = person_message
+    mock_api.get_co_person.return_value = get_response
+
+    registry = UserRegistry(
+        api_instance=mock_api,
+        coid=1,
+        name_normalizer=lambda s: " ".join(s.lower().split()),
+        dry_run=True,
+    )
+
+    # Act: call suspend or re_enable based on target_status
+    if target_status == "S":
+        registry.suspend(registry_id)
+    else:
+        registry.re_enable(registry_id)
+
+    # Assert: GET was called (read performed)
+    mock_api.get_co_person.assert_called_once_with(coid=1, identifier=registry_id)
+
+    # Assert: PUT was NOT called (write skipped)
+    mock_api.update_co_person.assert_not_called()

--- a/common/test/python/user_test/test_property_reenable_no_duplicate.py
+++ b/common/test/python/user_test/test_property_reenable_no_duplicate.py
@@ -1,0 +1,127 @@
+"""Property test for re-enable instead of duplicate creation.
+
+**Feature: disable-inactive-comanage-users, Property 3: Active process
+re-enables suspended users instead of creating duplicates**
+**Validates: Requirements 4.1, 4.2**
+"""
+
+from unittest.mock import Mock
+
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+from users.authorizations import Authorizations
+from users.event_models import UserEventCollector
+from users.user_entry import CenterUserEntry, PersonName
+from users.user_processes import ActiveUserProcess, UserProcessEnvironment
+from users.user_registry import RegistryPerson
+
+# --- Fast strategies ---
+
+_fast_name = st.text(
+    alphabet=st.characters(whitelist_categories=("Lu", "Ll")),
+    min_size=1,
+    max_size=15,
+)
+
+_fast_email = st.builds(
+    lambda user, domain: f"{user}@{domain}.com",
+    st.text(
+        alphabet=st.characters(whitelist_categories=["Ll"]),
+        min_size=1,
+        max_size=8,
+    ),
+    st.text(
+        alphabet=st.characters(whitelist_categories=["Ll"]),
+        min_size=1,
+        max_size=8,
+    ),
+)
+
+_registry_id = st.builds(
+    lambda n: f"NACC-{n:06d}",
+    st.integers(min_value=1, max_value=999999),
+)
+
+
+@st.composite
+def active_user_entry_strategy(draw):
+    """Generate random CenterUserEntry objects representing active users."""
+    first_name = draw(_fast_name)
+    last_name = draw(_fast_name)
+    email = draw(_fast_email)
+    auth_email = draw(_fast_email)
+    adcid = draw(st.integers(min_value=1, max_value=999))
+
+    return CenterUserEntry(
+        name=PersonName(first_name=first_name, last_name=last_name),
+        email=email,
+        auth_email=auth_email,
+        active=True,
+        approved=True,
+        org_name="Test Center",
+        adcid=adcid,
+        authorizations=Authorizations(),
+        study_authorizations=[],
+    )
+
+
+@st.composite
+def suspended_person_strategy(draw):
+    """Generate a mock suspended RegistryPerson with a random registry ID."""
+    reg_id = draw(_registry_id)
+    person = Mock(spec=RegistryPerson)
+    person.is_suspended.return_value = True
+    person.is_claimed.return_value = False
+    person.registry_id.return_value = reg_id
+    person.creation_date = None
+    return person
+
+
+@given(
+    entry=active_user_entry_strategy(),
+    suspended_persons=st.lists(suspended_person_strategy(), min_size=1, max_size=3),
+)
+@settings(max_examples=100, suppress_health_check=[HealthCheck.too_slow])
+def test_active_process_re_enables_suspended_instead_of_creating_duplicates(
+    entry: CenterUserEntry,
+    suspended_persons: list,
+):
+    """Property 3: Active process re-enables suspended users instead of
+    creating duplicates.
+
+    **Feature: disable-inactive-comanage-users, Property 3: Active process
+    re-enables suspended users instead of creating duplicates**
+    **Validates: Requirements 4.1, 4.2**
+
+    For any active user entry whose email matches suspended RegistryPerson
+    objects, the ActiveUserProcess calls re_enable for each and never calls
+    add.
+    """
+    # Arrange
+    mock_env = Mock(spec=UserProcessEnvironment)
+    mock_env.user_registry = Mock()
+    mock_env.notification_client = Mock()
+    mock_env.find_user = Mock(return_value=None)
+    mock_env.get_from_registry = Mock(
+        side_effect=lambda email: mock_env.user_registry.get(email=email)
+    )
+    mock_env.user_registry.get_by_parent_domain = Mock(return_value=[])
+    mock_env.user_registry.get_by_name = Mock(return_value=[])
+
+    # Registry lookup returns the suspended persons
+    mock_env.user_registry.get.return_value = suspended_persons
+
+    collector = UserEventCollector()
+    process = ActiveUserProcess(mock_env, collector)
+
+    # Act
+    process.visit(entry)
+
+    # Assert: re_enable called for each suspended person with a registry ID
+    expected_ids = [p.registry_id() for p in suspended_persons if p.registry_id()]
+    assert mock_env.user_registry.re_enable.call_count == len(expected_ids)
+    for reg_id in expected_ids:
+        mock_env.user_registry.re_enable.assert_any_call(reg_id)
+
+    # Assert: add is never called (no duplicate creation)
+    mock_env.user_registry.add.assert_not_called()

--- a/common/test/python/user_test/test_property_service_independence.py
+++ b/common/test/python/user_test/test_property_service_independence.py
@@ -1,0 +1,152 @@
+"""Property test for Flywheel/COmanage service independence.
+
+**Feature: disable-inactive-comanage-users, Property 2: Flywheel disable and
+COmanage suspend are independent**
+**Validates: Requirements 3.1, 3.3, 3.4**
+"""
+
+from unittest.mock import Mock
+
+from flywheel.models.user import User
+from flywheel_adaptor.flywheel_proxy import FlywheelError, FlywheelProxy
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from users.event_models import UserEventCollector
+from users.user_entry import PersonName, UserEntry
+from users.user_process_environment import UserProcessEnvironment
+from users.user_processes import InactiveUserProcess
+from users.user_registry import RegistryError, RegistryPerson, UserRegistry
+
+# --- Fast strategies ---
+
+_fast_email = st.builds(
+    lambda user, domain: f"{user}@{domain}.com",
+    st.text(
+        alphabet=st.characters(whitelist_categories=["Ll"]),
+        min_size=1,
+        max_size=8,
+    ),
+    st.text(
+        alphabet=st.characters(whitelist_categories=["Ll"]),
+        min_size=1,
+        max_size=8,
+    ),
+)
+
+_letters = st.characters(whitelist_categories=("Lu", "Ll"))
+
+
+@st.composite
+def _inactive_user_entry_strategy(draw):
+    """Generate inactive UserEntry objects."""
+    first_name = draw(st.text(min_size=1, max_size=20, alphabet=_letters))
+    last_name = draw(st.text(min_size=1, max_size=20, alphabet=_letters))
+    email = draw(_fast_email)
+    return UserEntry(
+        name=PersonName(first_name=first_name, last_name=last_name),
+        email=email,
+        active=False,
+        approved=draw(st.booleans()),
+    )
+
+
+@st.composite
+def _mock_fw_user_list_strategy(draw):
+    """Generate a list of mock Flywheel User objects (0 to 3)."""
+    count = draw(st.integers(min_value=0, max_value=3))
+    users = []
+    for i in range(count):
+        user_id = f"fw-user-{i}-{draw(st.integers(min_value=100, max_value=999))}"
+        user = Mock(spec=User)
+        user.id = user_id
+        user.email = f"user{i}@example.com"
+        users.append(user)
+    return users
+
+
+@st.composite
+def _mock_registry_person_list_strategy(draw):
+    """Generate a list of mock RegistryPerson objects (0 to 3)."""
+    count = draw(st.integers(min_value=0, max_value=3))
+    persons = []
+    for _ in range(count):
+        person = Mock(spec=RegistryPerson)
+        registry_id = f"NACC-{draw(st.integers(min_value=1000, max_value=9999))}"
+        person.registry_id.return_value = registry_id
+        person.is_suspended.return_value = False
+        persons.append(person)
+    return persons
+
+
+# --- Property test ---
+
+
+@given(
+    entry=_inactive_user_entry_strategy(),
+    fw_users=_mock_fw_user_list_strategy(),
+    registry_persons=_mock_registry_person_list_strategy(),
+    flywheel_fails=st.booleans(),
+    comanage_fails=st.booleans(),
+)
+@settings(max_examples=100)
+def test_flywheel_and_comanage_are_independent(
+    entry: UserEntry,
+    fw_users: list,
+    registry_persons: list,
+    flywheel_fails: bool,
+    comanage_fails: bool,
+):
+    """Property 2: Flywheel disable and COmanage suspend are independent.
+
+    **Feature: disable-inactive-comanage-users, Property 2: Flywheel disable
+    and COmanage suspend are independent**
+    **Validates: Requirements 3.1, 3.3, 3.4**
+
+    For any inactive user entry and any combination of Flywheel and COmanage
+    operation outcomes (success or failure), the failure of one service
+    operation does not prevent the other from being attempted.
+    """
+    # Arrange
+    mock_env = Mock(spec=UserProcessEnvironment)
+    mock_proxy = Mock(spec=FlywheelProxy)
+    mock_registry = Mock(spec=UserRegistry)
+
+    mock_proxy.find_user_by_email.return_value = fw_users
+    mock_registry.get.return_value = registry_persons
+
+    if flywheel_fails and fw_users:
+        mock_proxy.disable_user.side_effect = FlywheelError("Flywheel error")
+
+    if comanage_fails and registry_persons:
+        mock_registry.suspend.side_effect = RegistryError("COmanage error")
+
+    mock_env.proxy = mock_proxy
+    mock_env.user_registry = mock_registry
+
+    collector = UserEventCollector()
+    process = InactiveUserProcess(mock_env, collector)
+
+    # Act
+    process.visit(entry)
+
+    # Assert: Flywheel lookup always happens
+    mock_proxy.find_user_by_email.assert_called_once_with(entry.email)
+
+    # Assert: COmanage lookup always happens (regardless of Flywheel outcome)
+    mock_registry.get.assert_called_once_with(email=entry.email)
+
+    # Assert: Flywheel disable is attempted for each user
+    if fw_users:
+        assert mock_proxy.disable_user.call_count == len(fw_users)
+    else:
+        mock_proxy.disable_user.assert_not_called()
+
+    # Assert: COmanage suspend is attempted for each person with a registry ID
+    # (regardless of whether Flywheel succeeded or failed)
+    expected_suspend_count = sum(
+        1 for p in registry_persons if p.registry_id() is not None
+    )
+    if expected_suspend_count > 0:
+        assert mock_registry.suspend.call_count == expected_suspend_count
+    else:
+        mock_registry.suspend.assert_not_called()

--- a/common/test/python/user_test/test_property_service_independence.py
+++ b/common/test/python/user_test/test_property_service_independence.py
@@ -7,6 +7,7 @@ COmanage suspend are independent**
 
 from unittest.mock import Mock
 
+from centers.center_info import CenterMapInfo
 from flywheel.models.user import User
 from flywheel_adaptor.flywheel_proxy import FlywheelError, FlywheelProxy
 from hypothesis import given, settings
@@ -112,6 +113,7 @@ def test_flywheel_and_comanage_are_independent(
     mock_registry = Mock(spec=UserRegistry)
 
     mock_proxy.find_user_by_email.return_value = fw_users
+    mock_proxy.dry_run = False
     mock_registry.get.return_value = registry_persons
 
     if flywheel_fails and fw_users:
@@ -122,6 +124,7 @@ def test_flywheel_and_comanage_are_independent(
 
     mock_env.proxy = mock_proxy
     mock_env.user_registry = mock_registry
+    mock_env.admin_group.get_center_map.return_value = CenterMapInfo(centers={})
 
     collector = UserEventCollector()
     process = InactiveUserProcess(mock_env, collector)

--- a/common/test/python/user_test/test_property_status_roundtrip.py
+++ b/common/test/python/user_test/test_property_status_roundtrip.py
@@ -1,0 +1,212 @@
+"""Property test for status update round-trip preservation.
+
+**Feature: disable-inactive-comanage-users, Property 1: Status update round-trip
+preserves all non-status fields**
+**Validates: Requirements 1.1, 1.2, 2.1, 2.2, 6.1, 6.2, 6.3, 6.4**
+"""
+
+from copy import deepcopy
+from unittest.mock import MagicMock
+
+from coreapi_client.api.default_api import DefaultApi
+from coreapi_client.models.co_person import CoPerson
+from coreapi_client.models.co_person_message import CoPersonMessage
+from coreapi_client.models.co_person_role import CoPersonRole
+from coreapi_client.models.email_address import EmailAddress
+from coreapi_client.models.identifier import Identifier
+from coreapi_client.models.name import Name
+from coreapi_client.models.org_identity import OrgIdentity
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+from users.user_registry import UserRegistry
+
+# --- Fast strategies to avoid slow st.emails() ---
+
+# Fast email strategy: avoids the slow st.emails() for property tests
+# where the actual email content doesn't matter, only its presence.
+_fast_email = st.builds(
+    lambda user, domain: f"{user}@{domain}.com",
+    st.text(
+        alphabet=st.characters(whitelist_categories=["Ll"]),
+        min_size=1,
+        max_size=8,
+    ),
+    st.text(
+        alphabet=st.characters(whitelist_categories=["Ll"]),
+        min_size=1,
+        max_size=8,
+    ),
+)
+
+
+# --- Hypothesis strategies for generating CoPersonMessage components ---
+
+
+@st.composite
+def _email_strategy(draw):
+    """Generate a random EmailAddress."""
+    mail = draw(_fast_email)
+    email_type = draw(st.sampled_from(["official", "personal", "work"]))
+    verified = draw(st.booleans())
+    return EmailAddress(mail=mail, type=email_type, verified=verified)
+
+
+@st.composite
+def _name_strategy(draw):
+    """Generate a random Name."""
+    letters = st.characters(whitelist_categories=("Lu", "Ll"))
+    given_name = draw(st.text(min_size=1, max_size=20, alphabet=letters))
+    family = draw(st.text(min_size=1, max_size=20, alphabet=letters))
+    primary = draw(st.booleans())
+    return Name(given=given_name, family=family, type="official", primary_name=primary)
+
+
+@st.composite
+def _identifier_strategy(draw):
+    """Generate a random Identifier."""
+    id_type = draw(st.sampled_from(["naccid", "oidcsub", "eppn"]))
+    # Identifier model only accepts "A" or "S" for status
+    status = draw(st.sampled_from(["A", "S"]))
+    id_value = f"{id_type}-{draw(st.integers(min_value=1000, max_value=9999))}"
+    login = draw(st.booleans()) if id_type == "oidcsub" else None
+    return Identifier(identifier=id_value, type=id_type, status=status, login=login)
+
+
+@st.composite
+def _role_strategy(draw):
+    """Generate a random CoPersonRole."""
+    affiliation = draw(st.sampled_from(["member", "staff", "faculty"]))
+    status = draw(st.sampled_from(["A", "D"]))
+    return CoPersonRole(cou_id=None, affiliation=affiliation, status=status)
+
+
+@st.composite
+def _org_identity_strategy(draw):
+    """Generate a random OrgIdentity with optional emails and identifiers."""
+    has_emails = draw(st.booleans())
+    has_identifiers = draw(st.booleans())
+    emails = (
+        draw(st.lists(_email_strategy(), min_size=1, max_size=2))
+        if has_emails
+        else None
+    )
+    identifiers = (
+        draw(st.lists(_identifier_strategy(), min_size=1, max_size=2))
+        if has_identifiers
+        else None
+    )
+    return OrgIdentity(email_address=emails, identifier=identifiers)
+
+
+@st.composite
+def _coperson_message_strategy(draw):
+    """Generate a CoPersonMessage with random related models.
+
+    Uses status 'A' as the initial status since the test will exercise
+    both suspend (-> 'S') and re-enable (-> 'A') paths.
+    """
+    coperson = CoPerson(co_id=1, status="A", meta=None)
+
+    emails = draw(st.lists(_email_strategy(), min_size=0, max_size=5))
+    names = draw(st.lists(_name_strategy(), min_size=0, max_size=3))
+    identifiers = draw(st.lists(_identifier_strategy(), min_size=0, max_size=3))
+    roles = draw(st.lists(_role_strategy(), min_size=0, max_size=2))
+    org_ids = draw(st.lists(_org_identity_strategy(), min_size=0, max_size=2))
+
+    return CoPersonMessage(
+        CoPerson=coperson,
+        EmailAddress=emails if emails else None,
+        Name=names if names else None,
+        Identifier=identifiers if identifiers else None,
+        CoPersonRole=roles if roles else None,
+        OrgIdentity=org_ids if org_ids else None,
+        CoGroupMember=None,
+        SshKey=None,
+        Url=None,
+    )
+
+
+# --- Helpers ---
+
+
+def _build_get_response(person_message: CoPersonMessage) -> MagicMock:
+    """Build a mock GetCoPerson200Response with var_0 holding the message."""
+    response = MagicMock()
+    response.var_0 = person_message
+    return response
+
+
+def _build_registry(mock_api: MagicMock) -> UserRegistry:
+    """Build a UserRegistry with a mock API (dry_run=False)."""
+    return UserRegistry(
+        api_instance=mock_api,
+        coid=1,
+        name_normalizer=lambda s: " ".join(s.lower().split()),
+        dry_run=False,
+    )
+
+
+# --- Property test ---
+
+
+@given(
+    original_message=_coperson_message_strategy(),
+    use_suspend=st.booleans(),
+)
+@settings(max_examples=100, suppress_health_check=[HealthCheck.too_slow])
+def test_status_update_roundtrip_preserves_non_status_fields(
+    original_message: CoPersonMessage,
+    use_suspend: bool,
+):
+    """Property 1: Status update round-trip preserves all non-status fields.
+
+    **Feature: disable-inactive-comanage-users, Property 1: Status update
+    round-trip preserves all non-status fields**
+    **Validates: Requirements 1.1, 1.2, 2.1, 2.2, 6.1, 6.2, 6.3, 6.4**
+
+    For any valid CoPersonMessage, performing a status update (GET -> modify
+    status -> PUT) preserves all non-status fields and all related models
+    unchanged. Only the CoPerson.status field differs.
+    """
+    # Arrange: snapshot the original state before mutation
+    snapshot = deepcopy(original_message)
+
+    mock_api = MagicMock(spec=DefaultApi)
+    mock_api.get_co_person.return_value = _build_get_response(original_message)
+
+    registry = _build_registry(mock_api)
+    registry_id = "NACC-TEST-001"
+
+    # Act: call suspend or re_enable
+    if use_suspend:
+        registry.suspend(registry_id)
+        expected_status = "S"
+    else:
+        registry.re_enable(registry_id)
+        expected_status = "A"
+
+    # Assert: update_co_person was called with the message
+    mock_api.update_co_person.assert_called_once()
+    call_kwargs = mock_api.update_co_person.call_args.kwargs
+    updated_message: CoPersonMessage = call_kwargs["co_person_message"]
+
+    # Assert: CoPerson.status is the target status
+    assert updated_message.co_person is not None
+    assert updated_message.co_person.status == expected_status
+
+    # Assert: all CoPerson fields except status are preserved
+    assert snapshot.co_person is not None
+    assert updated_message.co_person.co_id == snapshot.co_person.co_id
+    assert updated_message.co_person.meta == snapshot.co_person.meta
+    assert updated_message.co_person.date_of_birth == snapshot.co_person.date_of_birth
+    assert updated_message.co_person.timezone == snapshot.co_person.timezone
+
+    # Assert: all related models are identical to the original
+    assert updated_message.email_address == snapshot.email_address
+    assert updated_message.name == snapshot.name
+    assert updated_message.identifier == snapshot.identifier
+    assert updated_message.org_identity == snapshot.org_identity
+    assert updated_message.co_person_role == snapshot.co_person_role
+    assert updated_message.co_group_member == snapshot.co_group_member
+    assert updated_message.ssh_key == snapshot.ssh_key
+    assert updated_message.url == snapshot.url

--- a/common/test/python/user_test/test_redcap_disable_visitor.py
+++ b/common/test/python/user_test/test_redcap_disable_visitor.py
@@ -1,0 +1,234 @@
+"""Tests for REDCapDisableVisitor."""
+
+import pytest
+from centers.center_group import (
+    CenterMetadata,
+    CenterStudyMetadata,
+    DistributionProjectMetadata,
+    FormIngestProjectMetadata,
+    IngestProjectMetadata,
+    REDCapFormProjectMetadata,
+)
+from users.redcap_disable_visitor import REDCapDisableVisitor
+
+
+class TestREDCapDisableVisitor:
+    """Tests for REDCapDisableVisitor.
+
+    Validates: Requirements 3.1, 3.2
+    """
+
+    @pytest.fixture
+    def visitor(self) -> REDCapDisableVisitor:
+        """Create a fresh visitor instance."""
+        return REDCapDisableVisitor()
+
+    def test_collects_pids_from_form_ingest_project(
+        self, visitor: REDCapDisableVisitor
+    ) -> None:
+        """Test visitor collects PIDs from FormIngestProjectMetadata with
+        redcap_projects.
+
+        Validates: Requirements 3.1
+        """
+        redcap_project = REDCapFormProjectMetadata(
+            redcap_pid=100,
+            label="module-a",
+        )
+        form_ingest = FormIngestProjectMetadata(
+            study_id="study-1",
+            project_id="proj-1",
+            project_label="form-ingest-1",
+            pipeline_adcid=1,
+            datatype="form",
+            redcap_projects={"module-a": redcap_project},
+        )
+        study = CenterStudyMetadata(
+            study_id="study-1",
+            study_name="Study One",
+            ingest_projects={"form-ingest-1": form_ingest},
+        )
+        center = CenterMetadata(
+            adcid=1,
+            active=True,
+            studies={"study-1": study},
+        )
+
+        center.apply(visitor)
+
+        assert visitor.redcap_pids == [100]
+
+    def test_returns_empty_list_when_no_form_ingest_projects(
+        self, visitor: REDCapDisableVisitor
+    ) -> None:
+        """Test visitor returns empty list when no form ingest projects exist.
+
+        Validates: Requirements 3.2
+        """
+        center = CenterMetadata(
+            adcid=2,
+            active=True,
+            studies={},
+        )
+
+        center.apply(visitor)
+
+        assert visitor.redcap_pids == []
+
+    def test_skips_plain_ingest_projects(self, visitor: REDCapDisableVisitor) -> None:
+        """Test visitor skips non-form ingest projects (IngestProjectMetadata).
+
+        Validates: Requirements 3.2
+        """
+        ingest = IngestProjectMetadata(
+            study_id="study-1",
+            project_id="proj-ingest",
+            project_label="ingest-project",
+            pipeline_adcid=1,
+            datatype="dicom",
+        )
+        study = CenterStudyMetadata(
+            study_id="study-1",
+            study_name="Study One",
+            ingest_projects={"ingest-project": ingest},
+        )
+        center = CenterMetadata(
+            adcid=3,
+            active=True,
+            studies={"study-1": study},
+        )
+
+        center.apply(visitor)
+
+        assert visitor.redcap_pids == []
+
+    def test_skips_distribution_projects(self, visitor: REDCapDisableVisitor) -> None:
+        """Test visitor skips DistributionProjectMetadata.
+
+        Validates: Requirements 3.2
+        """
+        dist = DistributionProjectMetadata(
+            study_id="study-1",
+            project_id="proj-dist",
+            project_label="dist-project",
+            datatype="form",
+        )
+        study = CenterStudyMetadata(
+            study_id="study-1",
+            study_name="Study One",
+            distribution_projects={"dist-project": dist},
+        )
+        center = CenterMetadata(
+            adcid=4,
+            active=True,
+            studies={"study-1": study},
+        )
+
+        center.apply(visitor)
+
+        assert visitor.redcap_pids == []
+
+    def test_collects_pids_across_multiple_studies_and_projects(
+        self, visitor: REDCapDisableVisitor
+    ) -> None:
+        """Test visitor collects PIDs across multiple studies and multiple form
+        ingest projects.
+
+        Validates: Requirements 3.1, 3.2
+        """
+        # Study 1 with two form ingest projects, each with REDCap projects
+        redcap_a = REDCapFormProjectMetadata(redcap_pid=10, label="mod-a")
+        redcap_b = REDCapFormProjectMetadata(redcap_pid=20, label="mod-b")
+        form_ingest_1 = FormIngestProjectMetadata(
+            study_id="study-1",
+            project_id="proj-1",
+            project_label="form-ingest-1",
+            pipeline_adcid=1,
+            datatype="form",
+            redcap_projects={"mod-a": redcap_a},
+        )
+        form_ingest_2 = FormIngestProjectMetadata(
+            study_id="study-1",
+            project_id="proj-2",
+            project_label="form-ingest-2",
+            pipeline_adcid=1,
+            datatype="form",
+            redcap_projects={"mod-b": redcap_b},
+        )
+        study_1 = CenterStudyMetadata(
+            study_id="study-1",
+            study_name="Study One",
+            ingest_projects={
+                "form-ingest-1": form_ingest_1,
+                "form-ingest-2": form_ingest_2,
+            },
+        )
+
+        # Study 2 with one form ingest project with multiple REDCap projects
+        redcap_c = REDCapFormProjectMetadata(redcap_pid=30, label="mod-c")
+        redcap_d = REDCapFormProjectMetadata(redcap_pid=40, label="mod-d")
+        form_ingest_3 = FormIngestProjectMetadata(
+            study_id="study-2",
+            project_id="proj-3",
+            project_label="form-ingest-3",
+            pipeline_adcid=2,
+            datatype="form",
+            redcap_projects={"mod-c": redcap_c, "mod-d": redcap_d},
+        )
+        study_2 = CenterStudyMetadata(
+            study_id="study-2",
+            study_name="Study Two",
+            ingest_projects={"form-ingest-3": form_ingest_3},
+        )
+
+        center = CenterMetadata(
+            adcid=5,
+            active=True,
+            studies={"study-1": study_1, "study-2": study_2},
+        )
+
+        center.apply(visitor)
+
+        assert sorted(visitor.redcap_pids) == [10, 20, 30, 40]
+
+    def test_mixed_ingest_types_only_collects_form_ingest_pids(
+        self, visitor: REDCapDisableVisitor
+    ) -> None:
+        """Test visitor collects PIDs only from FormIngestProjectMetadata when
+        mixed with plain IngestProjectMetadata in the same study.
+
+        Validates: Requirements 3.1, 3.2
+        """
+        redcap_proj = REDCapFormProjectMetadata(redcap_pid=55, label="mod-x")
+        form_ingest = FormIngestProjectMetadata(
+            study_id="study-1",
+            project_id="proj-form",
+            project_label="form-ingest",
+            pipeline_adcid=1,
+            datatype="form",
+            redcap_projects={"mod-x": redcap_proj},
+        )
+        plain_ingest = IngestProjectMetadata(
+            study_id="study-1",
+            project_id="proj-plain",
+            project_label="plain-ingest",
+            pipeline_adcid=1,
+            datatype="dicom",
+        )
+        study = CenterStudyMetadata(
+            study_id="study-1",
+            study_name="Study One",
+            ingest_projects={
+                "form-ingest": form_ingest,
+                "plain-ingest": plain_ingest,
+            },
+        )
+        center = CenterMetadata(
+            adcid=6,
+            active=True,
+            studies={"study-1": study},
+        )
+
+        center.apply(visitor)
+
+        assert visitor.redcap_pids == [55]

--- a/common/test/python/user_test/test_redcap_user_operations.py
+++ b/common/test/python/user_test/test_redcap_user_operations.py
@@ -1,0 +1,43 @@
+"""Tests for REDCap user operations helper functions."""
+
+from unittest.mock import Mock
+
+import pytest
+from redcap_api.redcap_connection import REDCapConnectionError
+from redcap_api.redcap_project import REDCapProject
+from users.redcap_user_operations import unassign_user_role
+
+
+class TestUnassignUserRole:
+    """Tests for unassign_user_role helper function."""
+
+    def test_calls_assign_user_role_with_empty_role(self):
+        """Test that unassign_user_role calls assign_user_role with the
+        username and an empty string for the role."""
+        mock_project = Mock(spec=REDCapProject)
+        mock_project.assign_user_role.return_value = 1
+
+        unassign_user_role(mock_project, "user@example.com")
+
+        mock_project.assign_user_role.assert_called_once_with("user@example.com", "")
+
+    def test_returns_count_from_assign_user_role(self):
+        """Test that unassign_user_role returns the count from
+        assign_user_role."""
+        mock_project = Mock(spec=REDCapProject)
+        mock_project.assign_user_role.return_value = 3
+
+        result = unassign_user_role(mock_project, "user@example.com")
+
+        assert result == 3
+
+    def test_propagates_redcap_connection_error(self):
+        """Test that REDCapConnectionError from assign_user_role propagates to
+        the caller."""
+        mock_project = Mock(spec=REDCapProject)
+        mock_project.assign_user_role.side_effect = REDCapConnectionError(
+            "Connection failed"
+        )
+
+        with pytest.raises(REDCapConnectionError):
+            unassign_user_role(mock_project, "user@example.com")

--- a/common/test/python/user_test/test_registry_person_status.py
+++ b/common/test/python/user_test/test_registry_person_status.py
@@ -952,3 +952,82 @@ class TestClaimStateTrichotomy:
         ]
         assert sum(states) == 1
         assert person.is_unclaimed() is True
+
+
+class TestIsSuspendedMethod:
+    """Tests for is_suspended method.
+
+    Tests Requirement 4.1:
+    - Returns True when CoPerson status is "S" (Suspended)
+    - Returns False for status "A" (Active), "D" (Deleted), and None
+    """
+
+    def test_returns_true_for_suspended_status(
+        self,
+        build_email_address,
+        build_co_person,
+        build_coperson_message,
+    ):
+        """Test that is_suspended returns True when status is "S"."""
+        email = build_email_address(mail="user@example.com")
+        coperson = build_co_person(status="S")
+
+        coperson_msg = build_coperson_message(
+            co_person=coperson,
+            email_addresses=[email],
+        )
+
+        person = RegistryPerson(coperson_msg)
+        assert person.is_suspended() is True
+
+    def test_returns_false_for_active_status(
+        self,
+        build_email_address,
+        build_co_person,
+        build_coperson_message,
+    ):
+        """Test that is_suspended returns False when status is "A"."""
+        email = build_email_address(mail="user@example.com")
+        coperson = build_co_person(status="A")
+
+        coperson_msg = build_coperson_message(
+            co_person=coperson,
+            email_addresses=[email],
+        )
+
+        person = RegistryPerson(coperson_msg)
+        assert person.is_suspended() is False
+
+    def test_returns_false_for_deleted_status(
+        self,
+        build_email_address,
+        build_co_person,
+        build_coperson_message,
+    ):
+        """Test that is_suspended returns False when status is "D"."""
+        email = build_email_address(mail="user@example.com")
+        coperson = build_co_person(status="D")
+
+        coperson_msg = build_coperson_message(
+            co_person=coperson,
+            email_addresses=[email],
+        )
+
+        person = RegistryPerson(coperson_msg)
+        assert person.is_suspended() is False
+
+    def test_returns_false_when_coperson_is_none(
+        self,
+        build_email_address,
+        build_coperson_message,
+    ):
+        """Test that is_suspended returns False when CoPerson is None."""
+        email = build_email_address(mail="user@example.com")
+
+        coperson_msg = build_coperson_message(
+            co_person=None,
+            email_addresses=[email],
+        )
+
+        person = RegistryPerson(coperson_msg)
+        assert person.is_suspended() is False

--- a/common/test/python/user_test/test_user_process_integration.py
+++ b/common/test/python/user_test/test_user_process_integration.py
@@ -81,6 +81,7 @@ class TestActiveUserProcessIntegration:
         mock_person.creation_date = "2024-01-01"
         mock_person.is_claimed.return_value = True
         mock_person.registry_id.return_value = "reg123"
+        mock_person.is_suspended.return_value = False
 
         mock_environment.user_registry.get.return_value = [mock_person]
         mock_environment.user_registry.has_bad_claim.return_value = False
@@ -183,6 +184,7 @@ class TestActiveUserProcessIntegration:
         # Setup mocks for missing creation date scenario
         mock_person = Mock(spec=RegistryPerson)
         mock_person.creation_date = None  # No creation date
+        mock_person.is_suspended.return_value = False
 
         mock_environment.user_registry.get.return_value = [mock_person]
         mock_environment.user_registry.has_bad_claim.return_value = False
@@ -212,6 +214,7 @@ class TestActiveUserProcessIntegration:
         mock_person.creation_date = "2024-01-01"
         mock_person.is_claimed.return_value = True
         mock_person.registry_id.return_value = "reg123"
+        mock_person.is_suspended.return_value = False
 
         mock_environment.user_registry.get.return_value = [mock_person]
         mock_environment.user_registry.has_bad_claim.return_value = False

--- a/common/test/python/user_test/test_user_registry_update.py
+++ b/common/test/python/user_test/test_user_registry_update.py
@@ -1,0 +1,270 @@
+"""Unit tests for UserRegistry.suspend and re_enable methods.
+
+Tests cover:
+- suspend with valid registry ID calls GET then PUT with status "S"
+- re_enable with valid registry ID calls GET then PUT with status "A"
+- suspend with no registry ID raises RegistryError
+- suspend when GET returns no record raises RegistryError
+- suspend when PUT fails raises RegistryError with API error details
+- re_enable when GET fails raises RegistryError
+- dry-run mode logs but does not call PUT
+"""
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+from coreapi_client.api.default_api import DefaultApi
+from coreapi_client.exceptions import ApiException
+from coreapi_client.models.co_person import CoPerson
+from coreapi_client.models.co_person_message import CoPersonMessage
+from coreapi_client.models.co_person_role import CoPersonRole
+from coreapi_client.models.email_address import EmailAddress
+from coreapi_client.models.identifier import Identifier
+from coreapi_client.models.name import Name
+from users.user_registry import RegistryError, UserRegistry
+
+
+def _build_person_message(
+    status: str = "A",
+    registry_id: str = "NACC-001",
+) -> CoPersonMessage:
+    """Build a CoPersonMessage with related models for testing."""
+    return CoPersonMessage(
+        CoPerson=CoPerson(co_id=1, status=status, meta=None),
+        EmailAddress=[
+            EmailAddress(mail="test@example.com", type="official", verified=True)
+        ],
+        Name=[Name(given="John", family="Doe", type="official", primary_name=True)],
+        Identifier=[Identifier(identifier=registry_id, type="naccid", status="A")],
+        CoPersonRole=[CoPersonRole(cou_id=None, affiliation="member", status="A")],
+    )
+
+
+def _build_get_response(person_message: CoPersonMessage) -> MagicMock:
+    """Build a mock GetCoPerson200Response."""
+    response = MagicMock()
+    response.var_0 = person_message
+    response.additional_properties = None
+    return response
+
+
+def _build_empty_response() -> MagicMock:
+    """Build a mock GetCoPerson200Response with no record."""
+    response = MagicMock()
+    response.var_0 = None
+    response.additional_properties = None
+    return response
+
+
+def _build_registry(
+    mock_api: MagicMock,
+    dry_run: bool = False,
+) -> UserRegistry:
+    """Build a UserRegistry with a mock API."""
+    return UserRegistry(
+        api_instance=mock_api,
+        coid=1,
+        name_normalizer=lambda s: " ".join(s.lower().split()),
+        dry_run=dry_run,
+    )
+
+
+class TestSuspend:
+    """Tests for UserRegistry.suspend method."""
+
+    def test_suspend_calls_get_then_put_with_status_s(self):
+        """Suspend retrieves the full record and PUTs it back with status S."""
+        mock_api = MagicMock(spec=DefaultApi)
+        person_message = _build_person_message(status="A")
+        mock_api.get_co_person.return_value = _build_get_response(person_message)
+
+        registry = _build_registry(mock_api)
+        registry.suspend("NACC-001")
+
+        mock_api.get_co_person.assert_called_once_with(coid=1, identifier="NACC-001")
+        mock_api.update_co_person.assert_called_once_with(
+            coid=1,
+            identifier="NACC-001",
+            co_person_message=person_message,
+        )
+        assert person_message.co_person is not None
+        assert person_message.co_person.status == "S"
+
+    def test_suspend_with_none_registry_id_raises_error(self):
+        """Suspend with None registry ID raises RegistryError."""
+        mock_api = MagicMock(spec=DefaultApi)
+        registry = _build_registry(mock_api)
+
+        with pytest.raises(RegistryError, match="Cannot update person: no registry ID"):
+            registry.suspend(None)  # type: ignore[arg-type]
+
+    def test_suspend_with_empty_registry_id_raises_error(self):
+        """Suspend with empty string registry ID raises RegistryError."""
+        mock_api = MagicMock(spec=DefaultApi)
+        registry = _build_registry(mock_api)
+
+        with pytest.raises(RegistryError, match="Cannot update person: no registry ID"):
+            registry.suspend("")
+
+    def test_suspend_when_get_returns_no_record_raises_error(self):
+        """Suspend raises RegistryError when GET returns no matching record."""
+        mock_api = MagicMock(spec=DefaultApi)
+        mock_api.get_co_person.return_value = _build_empty_response()
+
+        registry = _build_registry(mock_api)
+
+        with pytest.raises(
+            RegistryError,
+            match="No COmanage record found for registry ID NACC-001",
+        ):
+            registry.suspend("NACC-001")
+
+    def test_suspend_when_get_fails_raises_error(self):
+        """Suspend raises RegistryError when GET API call fails."""
+        mock_api = MagicMock(spec=DefaultApi)
+        mock_api.get_co_person.side_effect = ApiException(
+            status=500, reason="Server Error"
+        )
+
+        registry = _build_registry(mock_api)
+
+        with pytest.raises(RegistryError, match="API get_co_person call failed"):
+            registry.suspend("NACC-001")
+
+    def test_suspend_when_put_fails_raises_error(self):
+        """Suspend raises RegistryError with API error details when PUT
+        fails."""
+        mock_api = MagicMock(spec=DefaultApi)
+        person_message = _build_person_message(status="A")
+        mock_api.get_co_person.return_value = _build_get_response(person_message)
+        mock_api.update_co_person.side_effect = ApiException(
+            status=400, reason="Bad Request"
+        )
+
+        registry = _build_registry(mock_api)
+
+        with pytest.raises(RegistryError, match="API update_co_person call failed"):
+            registry.suspend("NACC-001")
+
+    def test_suspend_preserves_related_models(self):
+        """Suspend preserves all related models in the PUT request."""
+        mock_api = MagicMock(spec=DefaultApi)
+        person_message = _build_person_message(status="A")
+        mock_api.get_co_person.return_value = _build_get_response(person_message)
+
+        registry = _build_registry(mock_api)
+        registry.suspend("NACC-001")
+
+        put_message = mock_api.update_co_person.call_args.kwargs["co_person_message"]
+        assert put_message.email_address is not None
+        assert len(put_message.email_address) == 1
+        assert put_message.name is not None
+        assert len(put_message.name) == 1
+        assert put_message.identifier is not None
+        assert put_message.co_person_role is not None
+
+
+class TestReEnable:
+    """Tests for UserRegistry.re_enable method."""
+
+    def test_re_enable_calls_get_then_put_with_status_a(self):
+        """Re-enable retrieves the full record and PUTs it back with status
+        A."""
+        mock_api = MagicMock(spec=DefaultApi)
+        person_message = _build_person_message(status="S")
+        mock_api.get_co_person.return_value = _build_get_response(person_message)
+
+        registry = _build_registry(mock_api)
+        registry.re_enable("NACC-001")
+
+        mock_api.get_co_person.assert_called_once_with(coid=1, identifier="NACC-001")
+        mock_api.update_co_person.assert_called_once_with(
+            coid=1,
+            identifier="NACC-001",
+            co_person_message=person_message,
+        )
+        assert person_message.co_person is not None
+        assert person_message.co_person.status == "A"
+
+    def test_re_enable_with_no_registry_id_raises_error(self):
+        """Re-enable with None registry ID raises RegistryError."""
+        mock_api = MagicMock(spec=DefaultApi)
+        registry = _build_registry(mock_api)
+
+        with pytest.raises(RegistryError, match="Cannot update person: no registry ID"):
+            registry.re_enable(None)  # type: ignore[arg-type]
+
+    def test_re_enable_when_get_fails_raises_error(self):
+        """Re-enable raises RegistryError when GET API call fails."""
+        mock_api = MagicMock(spec=DefaultApi)
+        mock_api.get_co_person.side_effect = ApiException(
+            status=500, reason="Server Error"
+        )
+
+        registry = _build_registry(mock_api)
+
+        with pytest.raises(RegistryError, match="API get_co_person call failed"):
+            registry.re_enable("NACC-001")
+
+
+class TestDryRunMode:
+    """Tests for dry-run mode behavior in status update methods."""
+
+    def test_suspend_dry_run_logs_but_does_not_put(self, caplog):
+        """In dry-run mode, suspend logs the intended action without calling
+        PUT."""
+        mock_api = MagicMock(spec=DefaultApi)
+        person_message = _build_person_message(status="A")
+        mock_api.get_co_person.return_value = _build_get_response(person_message)
+
+        registry = _build_registry(mock_api, dry_run=True)
+
+        with caplog.at_level(logging.INFO):
+            registry.suspend("NACC-001")
+
+        mock_api.get_co_person.assert_called_once()
+        mock_api.update_co_person.assert_not_called()
+        assert "DRY RUN" in caplog.text
+        assert "NACC-001" in caplog.text
+        assert "S" in caplog.text
+
+    def test_re_enable_dry_run_logs_but_does_not_put(self, caplog):
+        """In dry-run mode, re_enable logs the intended action without calling
+        PUT."""
+        mock_api = MagicMock(spec=DefaultApi)
+        person_message = _build_person_message(status="S")
+        mock_api.get_co_person.return_value = _build_get_response(person_message)
+
+        registry = _build_registry(mock_api, dry_run=True)
+
+        with caplog.at_level(logging.INFO):
+            registry.re_enable("NACC-001")
+
+        mock_api.get_co_person.assert_called_once()
+        mock_api.update_co_person.assert_not_called()
+        assert "DRY RUN" in caplog.text
+        assert "NACC-001" in caplog.text
+        assert "A" in caplog.text
+
+    def test_dry_run_still_performs_get(self):
+        """In dry-run mode, GET is still called to validate the record
+        exists."""
+        mock_api = MagicMock(spec=DefaultApi)
+        person_message = _build_person_message(status="A")
+        mock_api.get_co_person.return_value = _build_get_response(person_message)
+
+        registry = _build_registry(mock_api, dry_run=True)
+        registry.suspend("NACC-001")
+
+        mock_api.get_co_person.assert_called_once_with(coid=1, identifier="NACC-001")
+
+    def test_dry_run_property(self):
+        """The dry_run property reflects the constructor parameter."""
+        mock_api = MagicMock(spec=DefaultApi)
+
+        registry_normal = _build_registry(mock_api, dry_run=False)
+        assert registry_normal.dry_run is False
+
+        registry_dry = _build_registry(mock_api, dry_run=True)
+        assert registry_dry.dry_run is True

--- a/docs/user_management/CHANGELOG.md
+++ b/docs/user_management/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this gear are documented in this file.
 
+## 4.3.0
+
+* Adds inactive user disable flow across Flywheel, COmanage, and REDCap
+  * Disables matching Flywheel users when a directory entry is marked inactive
+  * Suspends matching COmanage registry persons with dry-run support
+  * Removes REDCap role assignments from all REDCap projects across all centers
+  * Each step is independent — failure of one does not block the others
+* Adds automatic re-enable of previously suspended COmanage users when they reappear as active in the directory
+* Adds summary notification email to support staff listing REDCap projects that need manual user suspension
+* Adds service-specific event categories for disable actions: Flywheel User Disabled, COmanage User Suspended, REDCap User Disabled
+* Adds `find_user_by_email` and `disable_user` to `FlywheelProxy`
+* Adds `suspend` and `re_enable` to `UserRegistry` with dry-run support
+
 ## 4.2.2
 
 * Rebuilt for updated common libraries (adds `data-freeze` datatype, relaxes primary study mode restriction)

--- a/gear/image_identifier_lookup/test/python/image_identifier_lookup_test/test_processor.py
+++ b/gear/image_identifier_lookup/test/python/image_identifier_lookup_test/test_processor.py
@@ -265,7 +265,7 @@ class TestImageIdentifierLookupProcessor:
         mock_repository.get.return_value = identifier
 
         # Mock subject update failure
-        mock_subject.update.side_effect = ApiException("Internal Server Error")
+        mock_subject.update.side_effect = ApiException(reason="Internal Server Error")
 
         # Act & Assert
         with pytest.raises(ApiException) as exc_info:

--- a/gear/transactional_event_scraper/test/python/transactional_event_scraper_tests/test_main.py
+++ b/gear/transactional_event_scraper/test/python/transactional_event_scraper_tests/test_main.py
@@ -48,7 +48,7 @@ def test_run_api_exception(mock_scraper):
     from flywheel.rest import ApiException
 
     # Make scraper raise an ApiException
-    mock_scraper.scrape_events.side_effect = ApiException("API error")
+    mock_scraper.scrape_events.side_effect = ApiException(reason="API error")
 
     with pytest.raises(ApiException, match="API error"):
         run(scraper=mock_scraper)

--- a/gear/user_management/src/docker/BUILD
+++ b/gear/user_management/src/docker/BUILD
@@ -4,5 +4,5 @@ docker_image(
     name="user-management",
     source="Dockerfile",
     dependencies=[":manifest", "gear/user_management/src/python/user_app:bin"],
-    image_tags=["4.2.2", "latest"],
+    image_tags=["4.3.0", "latest"],
 )

--- a/gear/user_management/src/docker/manifest.json
+++ b/gear/user_management/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "user-management",
     "label": "User Management",
     "description": "Creates and updates user and user roles",
-    "version": "4.2.2",
+    "version": "4.3.0",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/user-management:4.2.2"
+            "image": "naccdata/user-management:4.3.0"
         },
         "flywheel": {
             "suite": "NACC Admin Gears",

--- a/gear/user_management/src/python/user_app/run.py
+++ b/gear/user_management/src/python/user_app/run.py
@@ -21,7 +21,7 @@ from inputs.parameter_store import (
     ParameterStore,
 )
 from inputs.yaml import YAMLReadError, load_from_stream
-from notifications.email import EmailClient, create_ses_client
+from notifications.email import EmailClient, EmailSendError, create_ses_client
 from pydantic import ValidationError
 from redcap_api.redcap_repository import REDCapParametersRepository
 from users.authorizations import AuthMap
@@ -31,7 +31,7 @@ from users.domain_config import (
     IdPDomainConfig,
     normalize_person_name,
 )
-from users.event_models import UserEventCollector
+from users.event_models import EventCategory, UserEventCollector
 from users.user_entry import UserEntry, UserEntryList
 from users.user_process_environment import NotificationModeType
 from users.user_processes import (
@@ -291,6 +291,11 @@ class UserManagementVisitor(GearExecutionEnvironment):
                     "wrong-IdP detection will be disabled"
                 )
 
+            email_client = EmailClient(
+                client=create_ses_client(),
+                source=self.__email_source,
+            )
+
             try:
                 run(
                     user_queue=self.__get_user_queue(self.__user_filepath),
@@ -300,10 +305,7 @@ class UserManagementVisitor(GearExecutionEnvironment):
                             authorization_map=self.__get_auth_map(self.__auth_filepath),
                             notification_client=NotificationClient(
                                 configuration_set_name="user-creation-claims",
-                                email_client=EmailClient(
-                                    client=create_ses_client(),
-                                    source=self.__email_source,
-                                ),
+                                email_client=email_client,
                                 portal_url=self.__portal_url,
                                 mode=self.__notification_mode,
                             ),
@@ -326,6 +328,12 @@ class UserManagementVisitor(GearExecutionEnvironment):
                 raise GearExecutionError(
                     f"Critical service failure - User registry error: {error}"
                 ) from error
+
+        # Send REDCap disable notification if any roles were removed
+        self.__send_redcap_disable_notification(
+            collector=collector,
+            email_client=email_client,
+        )
 
         if not collector.has_errors():
             log.info("User management completed successfully with no errors")
@@ -364,13 +372,77 @@ class UserManagementVisitor(GearExecutionEnvironment):
             context=context,
             collector=collector,
             error_filename=error_filename,
+            email_client=email_client,
         )
+
+    def __send_redcap_disable_notification(
+        self,
+        collector: UserEventCollector,
+        email_client: EmailClient,
+    ) -> None:
+        """Send a summary notification for REDCap role removals.
+
+        Queries the collector for REDCAP_USER_DISABLED success events
+        and sends a single email listing all affected users and projects.
+
+        Args:
+            collector: The event collector with REDCap disable events
+            email_client: The email client for sending notifications
+        """
+        if not self.__support_emails:
+            return
+
+        redcap_successes = [
+            e
+            for e in collector.get_events_for_category(
+                EventCategory.REDCAP_USER_DISABLED
+            )
+            if e.is_success()
+        ]
+        if not redcap_successes:
+            return
+
+        # Group by user email
+        by_user: dict[str, list[str]] = {}
+        for event in redcap_successes:
+            user_email = event.user_context.email
+            if user_email not in by_user:
+                by_user[user_email] = []
+            by_user[user_email].append(event.message)
+
+        # Build summary body
+        sections = []
+        for user_email, messages in by_user.items():
+            project_lines = "\n".join(f"  - {msg}" for msg in messages)
+            sections.append(f"{user_email}:\n{project_lines}")
+
+        body = (
+            "The following REDCap role removals were performed "
+            "for inactive users:\n\n"
+            + "\n\n".join(sections)
+            + "\n\nPlease manually suspend these users' "
+            "REDCap accounts."
+        )
+
+        try:
+            email_client.send_raw(
+                destinations=self.__support_emails,
+                subject="[REDCap] inactive users to suspend",
+                body=body,
+            )
+            log.info("Sent REDCap disable notification for %d user(s)", len(by_user))
+        except (ClientError, EmailSendError) as error:
+            log.error(
+                "Failed to send REDCap disable notification: %s",
+                error,
+            )
 
     def __send_error_notification(
         self,
         context: GearContext,
         collector: UserEventCollector,
         error_filename: str,
+        email_client: EmailClient,
     ) -> None:
         """Send simple error notification email.
 
@@ -378,6 +450,7 @@ class UserManagementVisitor(GearExecutionEnvironment):
             context: The gear context
             collector: The collector containing errors
             error_filename: The name of the error CSV file
+            email_client: The email client for sending notifications
 
         Raises:
             GearExecutionError: If email sending fails
@@ -387,11 +460,6 @@ class UserManagementVisitor(GearExecutionEnvironment):
             collector.error_count(),
         )
         try:
-            email_client = EmailClient(
-                client=create_ses_client(),
-                source=self.__email_source,
-            )
-
             # Get destination information
             destination_id = context.config.destination.get("id", "unknown")
 

--- a/gear/user_management/src/python/user_app/run.py
+++ b/gear/user_management/src/python/user_app/run.py
@@ -313,6 +313,7 @@ class UserManagementVisitor(GearExecutionEnvironment):
                                 coid=self.__comanage_coid,
                                 name_normalizer=normalize_person_name,
                                 domain_config=domain_config,
+                                dry_run=self.proxy.dry_run,
                             ),
                             domain_config=domain_config,
                             idp_config=idp_config,

--- a/mypy-stubs/src/python/flywheel/client.pyi
+++ b/mypy-stubs/src/python/flywheel/client.pyi
@@ -87,7 +87,7 @@ class Client:
     def add_user(self, user: User) -> str:
         ...
 
-    def modify_user(self, user_id: str, body: Dict[str, str]) -> None:
+    def modify_user(self, user_id: str, body: Dict[str, str | bool], clear_permissions: bool = False) -> None:
         ...
 
     def get_views(self, view_id: str, filter: Optional[str]=None) -> List[DataView]:  # noqa: A002

--- a/mypy-stubs/src/python/flywheel/rest.pyi
+++ b/mypy-stubs/src/python/flywheel/rest.pyi
@@ -1,3 +1,16 @@
+from typing import Any, Optional
+
+
 class ApiException(Exception):
-    status: int
-    ...
+    status: Optional[int]
+    reason: Optional[str]
+    body: Optional[str]
+    detail: Optional[str]
+    headers: Optional[Any]
+
+    def __init__(
+        self,
+        status: Optional[int] = None,
+        reason: Optional[str] = None,
+        http_resp: Optional[Any] = None,
+    ) -> None: ...


### PR DESCRIPTION
**Disable flow for inactive users:**
- Disables matching Flywheel users when a directory entry is marked inactive
- Suspends matching COmanage registry persons (with dry-run support)
- Removes REDCap role assignments from all REDCap projects across all centers
- Sends a summary notification email to support staff listing REDCap projects that need manual user suspension
- Re-enables previously suspended COmanage users when they reappear as active in the directory
- Each step is independent — failure of one does not block the others

**Supporting changes:**
- Adds `find_user_by_email` and `disable_user` methods to `FlywheelProxy`
- Adds `suspend` and `re_enable` methods to `UserRegistry` with dry-run support
- Adds service-specific event categories: `Flywheel User Disabled`, `COmanage User Suspended`, `REDCap User Disabled`, `User Re-Enabled`
- Adds REDCap disable events to error CSV export and category breakdown in error notifications

Bumps user management to v4.3.0