### PR TITLE
Fix/identifier lookup docs mismatch

### DIFF
--- a/docs/identifier_lookup/CHANGELOG.md
+++ b/docs/identifier_lookup/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this gear are documented in this file.
 
+## 2.4.1
+
+* Fix multi-center identifier lookup (Scenario 2) when `form_configs_file` is provided with `single_center: false`
+* Guard QC logging and event capture behind single center mode to prevent errors in multi-center scenarios
+* Fix `preserve_case` code default to match manifest default (`true`)
+* Fix `form_configs_file` manifest description to reflect it is optional
+
 ## 2.4.0
 
 * Rebuilt for log file naming format update

--- a/docs/identifier_lookup/index.md
+++ b/docs/identifier_lookup/index.md
@@ -7,8 +7,6 @@ The identifier-lookup gear reads participant IDs from a tabular (CSV) input file
 
 The gear outputs a CSV file with the looked-up identifiers appended. If any rows fail lookup, an error file is produced listing the failures.
 
-
-
 ## Environment
 
 This gear uses the AWS SSM parameter store, and expects that AWS credentials are available in environment variables within the Flywheel runtime.
@@ -50,12 +48,12 @@ The gear supports three main usage scenarios:
 - Center validation is enforced (validates ADCID matches and PTID format)
 - Module-specific field validation is performed
 - QC status logs are created
-- Visit events are captured to S3 (if event capture is configured)
+- Visit events are captured to S3
 - Output includes `naccid` and `module` columns
 
 **Event Capture**:
 
-When event capture is configured (by providing `event_environment` and `event_bucket`), the gear will create submission events for each valid visit row. These events are captured to an S3 bucket for tracking data submissions in the NACC event system.
+In single center mode with `form_configs_file`, the gear captures submission events for each valid visit row. These events are stored in an S3 bucket for tracking data submissions in the NACC event system. The `event_environment` and `event_bucket` parameters are **required** in this scenario.
 
 Event capture behavior:
 
@@ -63,11 +61,6 @@ Event capture behavior:
 - Events include visit metadata such as center, project, visit date, and packet information
 - Event capture failures do not affect the primary identifier lookup functionality
 - Events are stored in the configured S3 bucket with environment-specific prefixes
-
-Event capture configuration parameters:
-
-- **`event_environment`** (string, required for event capture): Environment for event capture. Valid values are "prod" or "dev". This determines the environment prefix used when storing events in S3.
-- **`event_bucket`** (string, required for event capture): S3 bucket name where submission events will be stored. The gear must have write access to this bucket.
 
 **When to use**: Standard form data processing pipelines where data comes from a single center.
 
@@ -93,6 +86,7 @@ Event capture configuration parameters:
 
 - Rows can have different `adcid` values
 - No center validation is performed
+- No QC logging or event capture (these require single center mode)
 - If `form_configs_file` is provided, module field validation is still performed
 - Output includes `naccid` column (and `module` if configs provided)
 
@@ -129,8 +123,8 @@ Event capture configuration parameters:
   - `"center"`: Look up center identifiers from NACCIDs
 
 - **`single_center`** (boolean, default: true): Whether to enforce single-center validation
-  - `true`: All rows must have the same `adcid` matching the project's pipeline ADCID (only applies when `form_configs_file` is provided)
-  - `false`: Allows rows with different `adcid` values, disables center validation
+  - `true`: All rows must have the same `adcid` matching the project's pipeline ADCID (only applies when `form_configs_file` is provided). Enables QC logging and event capture.
+  - `false`: Allows rows with different `adcid` values, disables center validation, QC logging, and event capture
 
 - **`module`** (string, optional): Module name for form processing (e.g., "uds", "lbd")
   - Can be inferred from filename suffix (e.g., `data-uds.csv` → module "UDS")
@@ -140,6 +134,16 @@ Event capture configuration parameters:
 - **`preserve_case`** (boolean, default: true): Whether to preserve the case of header keys in the input file
 
 - **`database_mode`** (string, default: "prod"): Whether to lookup identifiers from "dev" or "prod" database
+
+- **`event_environment`** (string, optional): Environment for visit event capture. Valid values are "prod" or "dev". Required when using nacc direction with `form_configs_file` in single center mode.
+
+- **`event_bucket`** (string, optional): S3 bucket name for event capture. Required when using nacc direction with `form_configs_file` in single center mode. The gear must have write access to this bucket.
+
+- **`dry_run`** (boolean, default: false): Whether to do a dry run
+
+- **`admin_group`** (string, default: "nacc"): Name of the admin group
+
+- **`apikey_path_prefix`** (string, default: "/prod/flywheel/gearbot"): The instance-specific AWS parameter gearbot path prefix
 
 ## Input
 
@@ -155,6 +159,3 @@ The gear has two output files.
   The format of this file is determined by the FW interface for displaying errors.
 
 Note: Event capture, when enabled, does not produce additional output files. Events are captured directly to the configured S3 bucket and do not affect the standard CSV output files described above.
-
-
-

--- a/docs/identifier_lookup/index.md
+++ b/docs/identifier_lookup/index.md
@@ -151,11 +151,10 @@ The input is a single CSV file, which must have columns `adcid` and `ptid`.
 
 ## Output
 
-The gear has two output files.
+The gear produces up to two output files.
 
-- A CSV file consisting of the rows of the input file for which a NACCID was found, with an additional `naccid` column if the direction is `nacc` or additional `adcid` and `ptid` columns if the direction is `center`
+- **Identifier file**: `{input_basename}_identifiers.{ext}` — a CSV file consisting of the rows of the input file for which an identifier was found, with an additional `naccid` column if the direction is `nacc` or additional `adcid` and `ptid` columns if the direction is `center`. For example, an input file named `data-uds.csv` produces `data-uds_identifiers.csv`. This file is only written if at least one row has a successful lookup.
   - Unless the configuration value `preserve_case` is set to `True`, all header keys will also be forced to lower case and spaces replaced with `_`
-- A CSV file indicating errors, and specifically information about rows for which a NACCID was not found.
-  The format of this file is determined by the FW interface for displaying errors.
+- **Error file**: a CSV file indicating errors, and specifically information about rows for which an identifier was not found. The format and naming of this file is determined by the Flywheel error UI interface.
 
 Note: Event capture, when enabled, does not produce additional output files. Events are captured directly to the configured S3 bucket and do not affect the standard CSV output files described above.

--- a/gear/identifier_lookup/src/docker/BUILD
+++ b/gear/identifier_lookup/src/docker/BUILD
@@ -4,5 +4,5 @@ docker_image(
     name="identifier-lookup",
     source="Dockerfile",
     dependencies=[":manifest", "gear/identifier_lookup/src/python/identifier_app:bin"],
-    image_tags=["2.4.0", "latest"],
+    image_tags=["2.4.1", "latest"],
 )

--- a/gear/identifier_lookup/src/docker/manifest.json
+++ b/gear/identifier_lookup/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "identifier-lookup",
     "label": "Identifier Lookup",
     "description": "Gear to look up participant identifiers for incoming data and capture visit events when QC logging is enabled",
-    "version": "2.4.0",
+    "version": "2.4.1",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/identifier-lookup:2.4.0"
+            "image": "naccdata/identifier-lookup:2.4.1"
         },
         "flywheel": {
             "suite": "NACC Data Gears",

--- a/gear/identifier_lookup/src/docker/manifest.json
+++ b/gear/identifier_lookup/src/docker/manifest.json
@@ -36,7 +36,7 @@
             }
         },
         "form_configs_file": {
-            "description": "A JSON file with forms module configurations; required for the nacc direction",
+            "description": "A JSON file with forms module configurations; optional, enables field validation and QC logging",
             "base": "file",
             "optional": true,
             "type": {

--- a/gear/identifier_lookup/src/python/identifier_app/run.py
+++ b/gear/identifier_lookup/src/python/identifier_app/run.py
@@ -107,7 +107,7 @@ class IdentifierLookupVisitor(GearExecutionEnvironment):
         admin_id = options.get("admin_group", DefaultValues.NACC_GROUP_ID)
         mode = options.get("database_mode", "prod")
         direction = options.get("direction", "nacc")
-        preserve_case = options.get("preserve_case", False)
+        preserve_case = options.get("preserve_case", True)
         module = options.get("module")
         single_center = options.get("single_center", True)
         gear_name = GearExecutionEnvironment.get_gear_name(context, "identifer-lookup")
@@ -117,15 +117,15 @@ class IdentifierLookupVisitor(GearExecutionEnvironment):
 
         # Initialize visit event capture for nacc direction with QC logging
         event_capture = None
-        if direction == "nacc" and config_input is not None:
-            # Get visit event capture parameters - required when capture is enabled
+        if direction == "nacc" and config_input is not None and single_center:
+            # Get visit event capture parameters - required for single center
             event_environment = options.get("event_environment")
             event_bucket = options.get("event_bucket")
 
             if not event_environment or not event_bucket:
                 raise GearExecutionError(
                     "event_environment and event_bucket are required when using "
-                    "nacc direction with form configs for visit event capture"
+                    "nacc direction with form configs in single center mode"
                 )
 
             try:
@@ -237,8 +237,10 @@ class IdentifierLookupVisitor(GearExecutionEnvironment):
         # Start with just the identifier lookup visitor
         visitors: List[CSVVisitor] = [naccid_visitor]
 
-        # Add QC status log visitor if we have module configs
-        if module_configs:
+        # Add QC status log visitor if we have module configs and single center
+        # (QC logging requires a project context which is only available for
+        # single center mode)
+        if module_configs and self.__single_center:
             error_log_template = ErrorLogTemplate()
             visit_annotator = FileVisitAnnotator(project=project)
             qc_log_manager = QCStatusLogManager(
@@ -256,8 +258,9 @@ class IdentifierLookupVisitor(GearExecutionEnvironment):
             )
             visitors.append(qc_visitor)
 
-        # Add event capture visitor if we have both event capture and module configs
-        if self.__event_capture and module_configs:
+        # Add event capture visitor if we have event capture, module configs,
+        # and single center mode (event capture requires project context)
+        if self.__event_capture and module_configs and self.__single_center:
             # Extract center label and project label from project adaptor
             center_label = project.group  # Use group as center label
             project_label = project.label


### PR DESCRIPTION
## Fix identifier lookup multi-center scenario and update docs

Fixes multi-center identifier lookup when `form_configs_file` is provided with `single_center: false`. Previously this would error out because event capture params were required unconditionally, and QC logging referenced an unbound `project` variable.

- Guard event capture initialization and QC logging behind `single_center` flag
- Fix `preserve_case` code default to match manifest default (`true`)
- Fix `form_configs_file` manifest description to reflect it is optional
- Update docs: add missing config parameters, clarify event capture requirements, document output filenames

