### PR TITLE
Refactor/no users no failure

### DIFF
--- a/common/src/python/users/user_processes.py
+++ b/common/src/python/users/user_processes.py
@@ -77,6 +77,10 @@ class UserQueue(Generic[T]):
     def __init__(self) -> None:
         self.__queue: deque[T] = deque()
 
+    def __len__(self) -> int:
+        """Returns the number of entries in the queue."""
+        return len(self.__queue)
+
     def enqueue(self, user_entry: T) -> None:
         """Adds the user entry to the queue.
 

--- a/docs/user_management/CHANGELOG.md
+++ b/docs/user_management/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this gear are documented in this file.
 
+## 4.3.1
+
+* Handles empty user list gracefully instead of failing with an error
+  * Incremental pull-directory runs can produce empty user files, which is now expected
+  * Logs an informational message and exits successfully when no users are present
+  * Skips unnecessary infrastructure setup (COManage, SES, registry) for empty inputs
+* Adds `__len__` method to `UserQueue` for queue size checks
+
 ## 4.3.0
 
 * Adds inactive user disable flow across Flywheel, COmanage, and REDCap

--- a/gear/user_management/src/docker/BUILD
+++ b/gear/user_management/src/docker/BUILD
@@ -4,5 +4,5 @@ docker_image(
     name="user-management",
     source="Dockerfile",
     dependencies=[":manifest", "gear/user_management/src/python/user_app:bin"],
-    image_tags=["4.3.0", "latest"],
+    image_tags=["4.3.1", "latest"],
 )

--- a/gear/user_management/src/docker/manifest.json
+++ b/gear/user_management/src/docker/manifest.json
@@ -2,7 +2,7 @@
   "name": "user-management",
   "label": "User Management",
   "description": "Creates and updates user and user roles",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "author": "NACC",
   "maintainer": "NACC <nacchelp@uw.edu>",
   "cite": "",
@@ -15,7 +15,7 @@
   "custom": {
     "gear-builder": {
       "category": "utility",
-      "image": "naccdata/user-management:4.3.0"
+      "image": "naccdata/user-management:4.3.1"
     },
     "flywheel": {
       "suite": "NACC Admin Gears",

--- a/gear/user_management/src/python/user_app/run.py
+++ b/gear/user_management/src/python/user_app/run.py
@@ -273,6 +273,11 @@ class UserManagementVisitor(GearExecutionEnvironment):
         assert self.__admin_id, "Admin group ID required"
         assert self.__email_source, "Sender email address required"
 
+        user_queue = self.__get_user_queue(self.__user_filepath)
+        if len(user_queue) == 0:
+            log.info("User queue is empty - nothing to process")
+            return
+
         collector = UserEventCollector()
         with ApiClient(configuration=self.__comanage_config) as comanage_client:
             admin_group = self.admin_group(admin_id=self.__admin_id)
@@ -298,7 +303,7 @@ class UserManagementVisitor(GearExecutionEnvironment):
 
             try:
                 run(
-                    user_queue=self.__get_user_queue(self.__user_filepath),
+                    user_queue=user_queue,
                     user_process=UserProcess(
                         environment=UserProcessEnvironment(
                             admin_group=admin_group,
@@ -556,7 +561,8 @@ class UserManagementVisitor(GearExecutionEnvironment):
                 f"No users read from user file {user_file_path}: {error}"
             ) from error
         if not object_list:
-            raise GearExecutionError("No users found in user file")
+            log.info("No users found in user file - nothing to process")
+            return UserQueue()
 
         try:
             user_entry_list = UserEntryList.model_validate(object_list)


### PR DESCRIPTION
Changes user management so that user list input can be empty. This case was previously causing the gear to report a failure.