### PR TITLE
Skip REDCap role unassignment for users without role assignments

### DIFF
--- a/.kiro/specs/redcap-role-unassignment-check/.config.kiro
+++ b/.kiro/specs/redcap-role-unassignment-check/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "b6a6206c-b157-4363-9d7a-d900b5c0d435", "workflowType": "requirements-first", "specType": "bugfix"}

--- a/.kiro/specs/redcap-role-unassignment-check/bugfix.md
+++ b/.kiro/specs/redcap-role-unassignment-check/bugfix.md
@@ -1,0 +1,41 @@
+# Bugfix Requirements Document
+
+## Introduction
+
+When disabling a user in REDCap, the `InactiveUserProcess.__disable_in_redcap` method iterates over all centers and all REDCap projects, calling `__unassign_redcap_project` for every project — even those where the user was never a member. This results in unnecessary REDCap API calls and misleading success events that suggest a role was unassigned when the user had no role in the project.
+
+The fix should check whether the user exists in a REDCap project before attempting to unassign their role. If the user is not found in the project, the unassignment should be skipped and no success event should be generated.
+
+## Bug Analysis
+
+### Current Behavior (Defect)
+
+1.1 WHEN a user is being disabled and the user does NOT exist in a REDCap project THEN the system calls `unassign_user_role` for that project anyway, making an unnecessary API call to REDCap
+
+1.2 WHEN a user is being disabled and the user does NOT exist in a REDCap project THEN the system emits a success event indicating the role was unassigned, even though the user had no role in that project
+
+1.3 WHEN a user is being disabled across multiple centers THEN the system attempts to unassign the user's role from every REDCap project across all centers without checking membership, resulting in potentially many unnecessary API calls
+
+### Expected Behavior (Correct)
+
+2.1 WHEN a user is being disabled and the user does NOT exist in a REDCap project THEN the system SHALL skip the unassignment for that project without making an API call to `assign_user_role`
+
+2.2 WHEN a user is being disabled and the user does NOT exist in a REDCap project THEN the system SHALL NOT emit a success event for that project
+
+2.3 WHEN a user is being disabled and the user DOES exist in a REDCap project THEN the system SHALL unassign the user's role and emit a success event as before
+
+2.4 WHEN checking whether a user has a role assignment in a REDCap project THEN the system SHALL query the project's user-role mappings (via the REDCap `userRoleMapping` export API) and check whether the username appears in the assignments
+
+### Unchanged Behavior (Regression Prevention)
+
+3.1 WHEN a user is being disabled and the user DOES exist in a REDCap project THEN the system SHALL CONTINUE TO call `unassign_user_role` and emit a success event with the project title and PID
+
+3.2 WHEN a user is being disabled and REDCap project credentials are unavailable THEN the system SHALL CONTINUE TO skip that project and emit an error event indicating credentials are unavailable
+
+3.3 WHEN a user is being disabled in dry-run mode THEN the system SHALL CONTINUE TO skip the actual `unassign_user_role` call and emit a dry-run success event
+
+3.4 WHEN `unassign_user_role` raises a `REDCapConnectionError` THEN the system SHALL CONTINUE TO catch the error, emit an error event, and continue processing the next project
+
+3.5 WHEN a center group cannot be retrieved THEN the system SHALL CONTINUE TO skip that center and continue processing remaining centers
+
+3.6 WHEN the user-role mapping export API call fails with a `REDCapConnectionError` THEN the system SHALL treat the failure gracefully (e.g., log an error event and skip the project) without crashing the disable flow

--- a/.kiro/specs/redcap-role-unassignment-check/design.md
+++ b/.kiro/specs/redcap-role-unassignment-check/design.md
@@ -1,0 +1,260 @@
+# REDCap Role Unassignment Check Bugfix Design
+
+## Overview
+
+The `InactiveUserProcess.__unassign_redcap_project` method currently calls `unassign_user_role` for every REDCap project across all centers, regardless of whether the user actually has a role assignment in that project. This produces unnecessary REDCap API calls and misleading success events.
+
+The fix adds a membership check before attempting role unassignment. A new `export_user_role_assignments()` method on `REDCapProject` (in the external `redcap_api` package) queries the REDCap `userRoleMapping` export API. A new helper function `user_has_role_assignment()` in `redcap_user_operations.py` uses this export to check whether a username appears in the project's user-role mappings. The `__unassign_redcap_project` method is then updated to skip unassignment (and skip event collection) when the user is not found.
+
+## Glossary
+
+- **Bug_Condition (C)**: The user does NOT have a role assignment in the REDCap project, yet `unassign_user_role` is called and a success event is emitted
+- **Property (P)**: When the user has no role assignment, the system skips unassignment and emits no success event; when the user does have a role assignment, the system unassigns and emits a success event as before
+- **Preservation**: All existing behavior for users who DO have role assignments, dry-run mode, credential unavailability, error handling, and center iteration must remain unchanged
+- **`__unassign_redcap_project`**: The private method in `InactiveUserProcess` (in `user_processes.py`) that attempts to unassign a user's role from a single REDCap project
+- **`unassign_user_role`**: The helper function in `redcap_user_operations.py` that calls `REDCapProject.assign_user_role(username, "")` to remove a user's role
+- **`export_user_role_assignments`**: A new method to be added to `REDCapProject` that exports user-role mappings via the REDCap API (`content: "userRoleMapping"`, `action: "export"`)
+- **`user_has_role_assignment`**: A new helper function in `redcap_user_operations.py` that checks whether a username appears in a project's user-role mapping export
+- **User-role mapping**: A REDCap record associating a username with a unique role name in a project
+
+## Bug Details
+
+### Bug Condition
+
+The bug manifests when `__unassign_redcap_project` is called for a REDCap project where the user has no role assignment. The method unconditionally calls `unassign_user_role` and emits a success event, even though the user was never assigned a role in that project.
+
+**Formal Specification:**
+```
+FUNCTION isBugCondition(input)
+  INPUT: input of type {redcap_project: REDCapProject, username: str}
+  OUTPUT: boolean
+
+  role_assignments := redcap_project.export_user_role_assignments()
+  user_in_project := ANY assignment IN role_assignments
+                     WHERE assignment["username"] == username
+
+  RETURN NOT user_in_project
+         AND unassign_user_role_is_called(redcap_project, username)
+END FUNCTION
+```
+
+### Examples
+
+- **User not in project**: User `alice@uni.edu` is being disabled. REDCap project PID 100 has role assignments for `bob@uni.edu` and `carol@uni.edu` only. Current behavior: `unassign_user_role` is called for `alice@uni.edu` in PID 100 and a success event is emitted. Expected: skip PID 100 entirely, no API call, no event.
+- **User in project**: User `alice@uni.edu` is being disabled. REDCap project PID 200 has a role assignment for `alice@uni.edu`. Current behavior: `unassign_user_role` is called. Expected: same — `unassign_user_role` is called and a success event is emitted.
+- **User not in any project across multiple centers**: User `dave@uni.edu` is being disabled across 3 centers with 5 REDCap projects total. `dave@uni.edu` has no role in any of them. Current behavior: 5 unnecessary API calls and 5 misleading success events. Expected: 0 API calls, 0 events.
+- **User in some projects but not others**: User `eve@uni.edu` is being disabled. She has a role in PID 100 and PID 300 but not in PID 200. Current behavior: 3 API calls, 3 success events. Expected: 2 API calls (PID 100 and 300), 2 success events, PID 200 skipped.
+
+## Expected Behavior
+
+### Preservation Requirements
+
+**Unchanged Behaviors:**
+- When a user DOES have a role assignment in a REDCap project, `unassign_user_role` must continue to be called and a success event emitted with the project title and PID
+- When REDCap project credentials are unavailable (`get_redcap_project` returns `None`), the project must continue to be skipped with an error event
+- When in dry-run mode, the actual `unassign_user_role` call must continue to be skipped and a dry-run success event emitted
+- When `unassign_user_role` raises `REDCapConnectionError`, the error must continue to be caught, an error event emitted, and processing must continue to the next project
+- When a center group cannot be retrieved, that center must continue to be skipped and remaining centers processed
+- Auth email resolution priority (entry.auth_email > COmanage auth_email > directory email) must remain unchanged
+- Step independence (Flywheel disable, COmanage lookup, REDCap role removal, COmanage suspend) must remain unchanged
+- Event `UserContext` must continue to contain the user's email, name, and center ID
+
+**Scope:**
+All inputs where the user DOES have a role assignment in the REDCap project should be completely unaffected by this fix. The only behavioral change is for inputs where the user does NOT have a role assignment — those now skip the unassignment call and event collection.
+
+## Hypothesized Root Cause
+
+Based on the bug description, the root cause is straightforward:
+
+1. **Missing membership check**: The `__unassign_redcap_project` method does not check whether the user has a role assignment in the project before calling `unassign_user_role`. It unconditionally proceeds with the API call for every project discovered by the `REDCapDisableVisitor`.
+
+2. **No user-role mapping export capability**: The `REDCapProject` class in the `redcap_api` package does not currently have a method to export user-role mappings. It has `export_user_roles()` (which exports role definitions, not user-role assignments) and `assign_user_role()` (which imports/updates assignments), but no export for the `userRoleMapping` content type. This means there was no convenient way to check membership when the original code was written.
+
+3. **Unconditional success event emission**: The success event is emitted immediately after a successful `unassign_user_role` call, without verifying that the user actually had a role to unassign. The REDCap API does not error when unassigning a role from a user who has no role — it simply returns a count, making the bug silent.
+
+## Correctness Properties
+
+Property 1: Bug Condition - Skip Unassignment for Non-Member Users
+
+_For any_ input where the user does NOT have a role assignment in the REDCap project (isBugCondition returns true), the fixed `__unassign_redcap_project` method SHALL NOT call `unassign_user_role` and SHALL NOT emit a success event for that project.
+
+**Validates: Requirements 2.1, 2.2**
+
+Property 2: Preservation - Unassignment Behavior for Member Users
+
+_For any_ input where the user DOES have a role assignment in the REDCap project (isBugCondition returns false), the fixed `__unassign_redcap_project` method SHALL produce the same result as the original method — calling `unassign_user_role` and emitting a success event with the project title and PID, preserving all existing behavior for users who are members of the project.
+
+**Validates: Requirements 2.3, 3.1, 3.2, 3.3, 3.4, 3.5**
+
+## Fix Implementation
+
+### Changes Required
+
+Assuming our root cause analysis is correct:
+
+**File**: `redcap_api` package — `redcap_api/redcap_project.py` (external)
+
+**Method**: New `export_user_role_assignments`
+
+**Specific Changes**:
+1. **Add `export_user_role_assignments()` method to `REDCapProject`**: This method calls the REDCap API with `content: "userRoleMapping"` and `action: "export"` to retrieve the list of user-role assignments. Returns `List[Dict[str, Any]]` where each dict has `username` and `unique_role_name` keys. Raises `REDCapConnectionError` on failure.
+
+---
+
+**File**: `common/src/python/users/redcap_user_operations.py`
+
+**Function**: New `user_has_role_assignment`
+
+**Specific Changes**:
+2. **Add `user_has_role_assignment(redcap_project, username)` helper function**: Calls `redcap_project.export_user_role_assignments()` and checks whether any returned mapping has a `username` field matching the given username. Returns `bool`. Lets `REDCapConnectionError` propagate to the caller.
+
+---
+
+**File**: `common/src/python/users/user_processes.py`
+
+**Method**: `InactiveUserProcess.__unassign_redcap_project`
+
+**Specific Changes**:
+3. **Add membership check before unassignment**: After obtaining the `redcap_project` and its title, but before the dry-run check, call `user_has_role_assignment(redcap_project, username)`. If the user is not a member, log an info message and return early without calling `unassign_user_role` and without emitting any event.
+
+4. **Handle `REDCapConnectionError` from membership check**: If `export_user_role_assignments()` fails, catch the `REDCapConnectionError`, log an error, emit an error event with `REDCAP_USER_DISABLED` category, and return (skip the project gracefully).
+
+5. **Import `user_has_role_assignment`**: Add the import of the new helper function from `users.redcap_user_operations`.
+
+## External Dependency: `redcap_api` Package Change
+
+The `redcap_api` package is an external dependency (not in this repository). The new `export_user_role_assignments()` method must be added there first, before the changes in this repo can be implemented.
+
+### Prompt for `redcap_api` Repository
+
+Use the following prompt in the `redcap_api` workspace to implement the required change:
+
+---
+
+**Add `export_user_role_assignments()` method to `REDCapProject`**
+
+The `REDCapProject` class needs a new method to export user-role mappings from a project. This is the counterpart to the existing `assign_user_role()` method (which imports/updates mappings). The new method exports the current user-role assignments so callers can check which users have roles before modifying them.
+
+**Method signature:**
+
+```python
+def export_user_role_assignments(self) -> List[Dict[str, Any]]:
+```
+
+**Implementation pattern** — follow the same pattern as `export_user_roles()`:
+
+```python
+def export_user_role_assignments(self) -> List[Dict[str, Any]]:
+    """Export user-role assignments for the project.
+
+    Returns the mapping of users to roles in the project. Each entry
+    contains a ``username`` and ``unique_role_name`` key.
+
+    Returns:
+        List of user-role assignment dicts
+
+    Raises:
+        REDCapConnectionError if the response has an error
+    """
+    message = "exporting user-role assignments"
+    data = {"content": "userRoleMapping", "action": "export"}
+
+    return self.__redcap_con.request_json_value(data=data, message=message)
+```
+
+**Context:**
+- The REDCap API's `userRoleMapping` content type with `action: "export"` returns a JSON array of objects, each with `username` and `unique_role_name` keys
+- The existing `assign_user_role()` method already uses `content: "userRoleMapping"` with `action: "import"` — this is the export counterpart
+- The existing `export_user_roles()` method uses `content: "userRole"` which exports role definitions (not user-role assignments) — this is different
+- Follow the same error handling pattern: let `request_json_value` raise `REDCapConnectionError` on failure
+
+**Tests to add:**
+- Test that the method sends the correct data payload (`content: "userRoleMapping"`, `action: "export"`)
+- Test that it returns the parsed JSON response
+- Test that `REDCapConnectionError` propagates on failure
+
+---
+
+## Testing Strategy
+
+### Validation Approach
+
+The testing strategy follows a two-phase approach: first, surface counterexamples that demonstrate the bug on unfixed code, then verify the fix works correctly and preserves existing behavior.
+
+### Exploratory Bug Condition Checking
+
+**Goal**: Surface counterexamples that demonstrate the bug BEFORE implementing the fix. Confirm or refute the root cause analysis. If we refute, we will need to re-hypothesize.
+
+**Test Plan**: Write tests that mock `export_user_role_assignments()` to return mappings that do NOT include the target username, then verify that `unassign_user_role` is still called (demonstrating the bug on unfixed code). Run these tests on the UNFIXED code to observe failures and understand the root cause.
+
+**Test Cases**:
+1. **Non-member unassignment test**: Mock a REDCap project where `export_user_role_assignments()` returns mappings for other users only. Call `visit()` on an inactive user entry. Assert that `assign_user_role` is NOT called for that project (will fail on unfixed code because it IS called).
+2. **Non-member event test**: Same setup as above. Assert that no success event is emitted for the project (will fail on unfixed code because a success event IS emitted).
+3. **Multiple projects mixed membership test**: Set up 3 projects — user is a member of 1, not a member of 2. Assert that `assign_user_role` is called only for the 1 project where the user is a member (will fail on unfixed code because all 3 are called).
+4. **No membership in any project test**: User has no role in any of 3 projects across 2 centers. Assert zero `assign_user_role` calls (will fail on unfixed code).
+
+**Expected Counterexamples**:
+- `assign_user_role` is called even when the user has no role assignment in the project
+- Success events are emitted for projects where the user was never a member
+- Possible cause: no membership check exists in `__unassign_redcap_project`
+
+### Fix Checking
+
+**Goal**: Verify that for all inputs where the bug condition holds, the fixed function produces the expected behavior.
+
+**Pseudocode:**
+```
+FOR ALL input WHERE isBugCondition(input) DO
+  result := __unassign_redcap_project_fixed(input)
+  ASSERT unassign_user_role NOT called
+  ASSERT no success event emitted
+END FOR
+```
+
+### Preservation Checking
+
+**Goal**: Verify that for all inputs where the bug condition does NOT hold, the fixed function produces the same result as the original function.
+
+**Pseudocode:**
+```
+FOR ALL input WHERE NOT isBugCondition(input) DO
+  ASSERT __unassign_redcap_project_original(input) = __unassign_redcap_project_fixed(input)
+END FOR
+```
+
+**Testing Approach**: Property-based testing is recommended for preservation checking because:
+- It generates many test cases automatically across the input domain
+- It catches edge cases that manual unit tests might miss (e.g., username case sensitivity, empty role mappings)
+- It provides strong guarantees that behavior is unchanged for all users who ARE members
+
+**Test Plan**: Observe behavior on UNFIXED code first for users who DO have role assignments, then write property-based tests capturing that behavior.
+
+**Test Cases**:
+1. **Member unassignment preservation**: Observe that `unassign_user_role` is called for users who have role assignments on unfixed code, then write test to verify this continues after fix
+2. **Dry-run preservation**: Observe that dry-run mode skips the API call and emits a dry-run event on unfixed code, then write test to verify this continues after fix
+3. **Error handling preservation**: Observe that `REDCapConnectionError` from `unassign_user_role` is caught and an error event emitted on unfixed code, then write test to verify this continues after fix
+4. **Credential unavailability preservation**: Observe that projects with unavailable credentials are skipped on unfixed code, then write test to verify this continues after fix
+
+### Unit Tests
+
+- Test `export_user_role_assignments()` on `REDCapProject` calls the correct API endpoint (`content: "userRoleMapping"`, `action: "export"`)
+- Test `user_has_role_assignment()` returns `True` when username is in the mapping list
+- Test `user_has_role_assignment()` returns `False` when username is not in the mapping list
+- Test `user_has_role_assignment()` returns `False` when the mapping list is empty
+- Test `user_has_role_assignment()` propagates `REDCapConnectionError`
+- Test `__unassign_redcap_project` skips unassignment when user is not a member
+- Test `__unassign_redcap_project` proceeds with unassignment when user is a member
+- Test `__unassign_redcap_project` handles `REDCapConnectionError` from membership check gracefully
+- Test dry-run mode still checks membership (or skips check — design decision to be confirmed)
+
+### Property-Based Tests
+
+- Generate random sets of usernames and role mappings, verify `user_has_role_assignment` correctly identifies membership for any username
+- Generate random project configurations (user in some projects, not in others), verify that `unassign_user_role` is called only for projects where the user has a role assignment
+- Generate random inputs where the user IS a member, verify the fixed code produces the same events and API calls as the original code
+
+### Integration Tests
+
+- Test full `visit()` flow with a mix of projects where the user is and is not a member, verifying correct API calls and events
+- Test that the membership check failure (REDCapConnectionError) does not block processing of subsequent projects
+- Test that step independence is maintained — membership check failure in REDCap step does not affect Flywheel or COmanage steps

--- a/.kiro/specs/redcap-role-unassignment-check/tasks.md
+++ b/.kiro/specs/redcap-role-unassignment-check/tasks.md
@@ -1,0 +1,90 @@
+# Implementation Plan
+
+- [x] 1. Write bug condition exploration test
+  - **Property 1: Bug Condition** - Non-Member User Still Gets Unassigned
+  - **CRITICAL**: This test MUST FAIL on unfixed code — failure confirms the bug exists
+  - **DO NOT attempt to fix the test or the code when it fails**
+  - **NOTE**: This test encodes the expected behavior — it will validate the fix when it passes after implementation
+  - **GOAL**: Surface counterexamples that demonstrate the bug exists
+  - **Scoped PBT Approach**: Scope the property to concrete failing cases where `export_user_role_assignments()` returns mappings that do NOT include the target username
+  - Add a new test class `TestBugConditionExploration` in `common/test/python/user_test/test_inactive_user_process_redcap.py`
+  - Mock `export_user_role_assignments()` on the mock REDCap project to return a list of mappings for OTHER users only (e.g., `[{"username": "other@uni.edu", "unique_role_name": "U-role1"}]`)
+  - Set up a single center with one REDCap project (PID 100) using existing `_build_center_metadata_with_redcap` and `_setup_center_map_with_centers` helpers
+  - Call `process.visit(entry)` on an inactive user entry (e.g., `user@example.com`)
+  - Assert that `assign_user_role` is NOT called for that project (bug condition: it IS called on unfixed code)
+  - Assert that no success event with category `REDCAP_USER_DISABLED` is emitted (bug condition: one IS emitted on unfixed code)
+  - Also test the multi-project mixed membership case: set up 3 projects where user is a member of PID 100 only (mapping includes username), not PID 200 or PID 300. Assert `assign_user_role` is called exactly once (for PID 100 only)
+  - Run test on UNFIXED code
+  - **EXPECTED OUTCOME**: Test FAILS (this is correct — it proves the bug exists because `assign_user_role` is called unconditionally)
+  - Document counterexamples found: `assign_user_role` called with `("user@example.com", "")` even though `export_user_role_assignments()` shows user has no role
+  - Mark task complete when test is written, run, and failure is documented
+  - _Requirements: 1.1, 1.2, 1.3, 2.1, 2.2_
+
+- [x] 2. Write preservation property tests (BEFORE implementing fix)
+  - **Property 2: Preservation** - Member User Unassignment and Existing Behaviors Unchanged
+  - **IMPORTANT**: Follow observation-first methodology
+  - Add a new test class `TestPreservationProperties` in `common/test/python/user_test/test_inactive_user_process_redcap.py`
+  - **Observe on UNFIXED code first**, then write tests capturing observed behavior:
+  - Observe: When user IS a member (mapping includes username), `assign_user_role(username, "")` is called and a success event with `REDCAP_USER_DISABLED` category is emitted — verify this on unfixed code
+  - Observe: When in dry-run mode with a member user, `assign_user_role` is NOT called but a dry-run success event IS emitted — verify this on unfixed code
+  - Observe: When `assign_user_role` raises `REDCapConnectionError` for a member user, an error event with `REDCAP_USER_DISABLED` category is emitted and processing continues — verify this on unfixed code
+  - Observe: When `get_redcap_project` returns `None` (credentials unavailable), the project is skipped with an error event — verify this on unfixed code
+  - Mock `export_user_role_assignments()` to return mappings that INCLUDE the target username (e.g., `[{"username": "user@example.com", "unique_role_name": "U-role1"}]`) for member-user tests
+  - Write property-based style tests (parameterized across multiple username/mapping combinations) asserting the observed behaviors are preserved
+  - Run tests on UNFIXED code
+  - **EXPECTED OUTCOME**: Tests PASS (this confirms baseline behavior to preserve)
+  - Mark task complete when tests are written, run, and passing on unfixed code
+  - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5_
+
+- [x] 3. Fix for REDCap role unassignment without membership check
+
+  - [x] 3.1 Add `user_has_role_assignment` helper to `redcap_user_operations.py`
+    - Add a new function `user_has_role_assignment(redcap_project: REDCapProject, username: str) -> bool` in `common/src/python/users/redcap_user_operations.py`
+    - Call `redcap_project.export_user_role_assignments()` to get the list of user-role mappings
+    - Return `True` if any mapping has `assignment["username"] == username`, `False` otherwise
+    - Let `REDCapConnectionError` propagate to the caller (do not catch it)
+    - Add unit tests in `common/test/python/user_test/test_redcap_user_operations.py`:
+      - Test returns `True` when username is in the mapping list
+      - Test returns `False` when username is not in the mapping list
+      - Test returns `False` when the mapping list is empty
+      - Test propagates `REDCapConnectionError` from `export_user_role_assignments()`
+    - _Bug_Condition: isBugCondition(input) where user has no role assignment but unassign is called_
+    - _Expected_Behavior: user_has_role_assignment returns False for non-members, True for members_
+    - _Preservation: Existing unassign_user_role function unchanged_
+    - _Requirements: 2.4_
+
+  - [x] 3.2 Update `__unassign_redcap_project` in `user_processes.py` to check membership
+    - Import `user_has_role_assignment` from `users.redcap_user_operations` (add to existing import line)
+    - After obtaining `redcap_project` and its `title`, but BEFORE the dry-run check, add a membership check:
+      - Call `user_has_role_assignment(redcap_project, username)` wrapped in a try/except for `REDCapConnectionError`
+      - If user is NOT a member: log an info message (`"User %s has no role assignment in REDCap project %s (PID %s), skipping"`) and return early — no API call, no event
+      - If `REDCapConnectionError` is raised from the membership check: log an error, emit an error event with `EventCategory.REDCAP_USER_DISABLED`, and return (skip the project gracefully)
+    - If user IS a member: proceed with existing logic (dry-run check, unassign call, event collection) unchanged
+    - _Bug_Condition: isBugCondition(input) where NOT user_in_project AND unassign_user_role_is_called_
+    - _Expected_Behavior: When not a member, skip unassignment and emit no success event; when a member, proceed as before_
+    - _Preservation: All existing behavior for member users, dry-run, error handling, credential unavailability unchanged_
+    - _Requirements: 2.1, 2.2, 2.3, 2.4, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6_
+
+  - [x] 3.3 Verify bug condition exploration test now passes
+    - **Property 1: Expected Behavior** - Non-Member User Skipped Correctly
+    - **IMPORTANT**: Re-run the SAME test from task 1 — do NOT write a new test
+    - The test from task 1 encodes the expected behavior (no `assign_user_role` call, no success event for non-members)
+    - When this test passes, it confirms the expected behavior is satisfied
+    - Run bug condition exploration test from step 1
+    - **EXPECTED OUTCOME**: Test PASSES (confirms bug is fixed)
+    - _Requirements: 2.1, 2.2_
+
+  - [x] 3.4 Verify preservation tests still pass
+    - **Property 2: Preservation** - Member User Unassignment and Existing Behaviors Unchanged
+    - **IMPORTANT**: Re-run the SAME tests from task 2 — do NOT write new tests
+    - Run preservation property tests from step 2
+    - **EXPECTED OUTCOME**: Tests PASS (confirms no regressions)
+    - Confirm all preservation tests still pass after fix (no regressions)
+    - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5_
+
+- [x] 4. Checkpoint - Ensure all tests pass
+  - Run the full test suite for the affected test files:
+    - `common/test/python/user_test/test_inactive_user_process_redcap.py`
+    - `common/test/python/user_test/test_redcap_user_operations.py`
+  - Ensure ALL tests pass (both new and existing)
+  - Ask the user if questions arise

--- a/common/src/python/users/redcap_user_operations.py
+++ b/common/src/python/users/redcap_user_operations.py
@@ -20,3 +20,23 @@ def unassign_user_role(redcap_project: REDCapProject, username: str) -> int:
         REDCapConnectionError: If the underlying API call fails
     """
     return redcap_project.assign_user_role(username, "")
+
+
+def user_has_role_assignment(redcap_project: REDCapProject, username: str) -> bool:
+    """Check whether a user has a role assignment in a REDCap project.
+
+    Queries the project's user-role mappings and checks whether the
+    given username appears in any assignment.
+
+    Args:
+        redcap_project: The REDCap project instance
+        username: The REDCap username to look up
+
+    Returns:
+        True if the username has a role assignment, False otherwise
+
+    Raises:
+        REDCapConnectionError: If the underlying API call fails
+    """
+    assignments = redcap_project.export_user_role_assignments()
+    return any(assignment["username"] == username for assignment in assignments)

--- a/common/src/python/users/user_processes.py
+++ b/common/src/python/users/user_processes.py
@@ -201,7 +201,10 @@ class InactiveUserProcess(BaseUserProcess[UserEntry]):
             has_role = user_has_role_assignment(redcap_project, username)
         except REDCapConnectionError as error:
             log.error(
-                "failed to check role assignment for %s in REDCap project %s (PID %s): %s",
+                (
+                    "failed to check role assignment for %s in REDCap project %s "
+                    "(PID %s): %s"
+                ),
                 username,
                 title,
                 pid,
@@ -221,7 +224,10 @@ class InactiveUserProcess(BaseUserProcess[UserEntry]):
 
         if not has_role:
             log.info(
-                "User %s has no role assignment in REDCap project %s (PID %s), skipping",
+                (
+                    "User %s has no role assignment in REDCap project %s "
+                    "(PID %s), skipping"
+                ),
                 username,
                 title,
                 pid,

--- a/common/src/python/users/user_processes.py
+++ b/common/src/python/users/user_processes.py
@@ -9,6 +9,7 @@ from coreapi_client.models.identifier import Identifier
 from flywheel.models.user import User
 from flywheel_adaptor.flywheel_proxy import FlywheelError
 from redcap_api.redcap_connection import REDCapConnectionError
+
 from users.authorization_visitor import (
     CenterAuthorizationVisitor,
     GeneralAuthorizationVisitor,

--- a/common/src/python/users/user_processes.py
+++ b/common/src/python/users/user_processes.py
@@ -9,7 +9,6 @@ from coreapi_client.models.identifier import Identifier
 from flywheel.models.user import User
 from flywheel_adaptor.flywheel_proxy import FlywheelError
 from redcap_api.redcap_connection import REDCapConnectionError
-
 from users.authorization_visitor import (
     CenterAuthorizationVisitor,
     GeneralAuthorizationVisitor,
@@ -24,7 +23,7 @@ from users.event_models import (
 )
 from users.failure_analyzer import FailureAnalyzer
 from users.redcap_disable_visitor import REDCapDisableVisitor
-from users.redcap_user_operations import unassign_user_role
+from users.redcap_user_operations import unassign_user_role, user_has_role_assignment
 from users.user_entry import ActiveUserEntry, CenterUserEntry, UserEntry
 from users.user_process_environment import NotificationClient, UserProcessEnvironment
 from users.user_registry import DomainCandidate, RegistryError, RegistryPerson
@@ -196,6 +195,37 @@ class InactiveUserProcess(BaseUserProcess[UserEntry]):
             return
 
         title = redcap_project.title
+
+        try:
+            has_role = user_has_role_assignment(redcap_project, username)
+        except REDCapConnectionError as error:
+            log.error(
+                "failed to check role assignment for %s in REDCap project %s (PID %s): %s",
+                username,
+                title,
+                pid,
+                error,
+            )
+            error_event = UserProcessEvent(
+                event_type=EventType.ERROR,
+                category=EventCategory.REDCAP_USER_DISABLED,
+                user_context=user_context,
+                message=(
+                    f"Failed to check role assignment for {username} "
+                    f"in REDCap project {title} (PID {pid}): {error}"
+                ),
+            )
+            self.collector.collect(error_event)
+            return
+
+        if not has_role:
+            log.info(
+                "User %s has no role assignment in REDCap project %s (PID %s), skipping",
+                username,
+                title,
+                pid,
+            )
+            return
 
         if self.__env.proxy.dry_run:
             log.info(

--- a/common/test/python/user_test/test_clariti_roles.py
+++ b/common/test/python/user_test/test_clariti_roles.py
@@ -340,8 +340,16 @@ class TestCLARiTIPropertyTests:
 
         fast_email = st.builds(
             lambda user, domain: f"{user}@{domain}.edu",
-            st.from_regex(r"[a-z]{1,10}", fullmatch=True),
-            st.from_regex(r"[a-z]{1,10}", fullmatch=True),
+            st.text(
+                alphabet=st.characters(categories=("Ll",)),
+                min_size=1,
+                max_size=10,
+            ),
+            st.text(
+                alphabet=st.characters(categories=("Ll",)),
+                min_size=1,
+                max_size=10,
+            ),
         )
 
         @given(

--- a/common/test/python/user_test/test_clariti_roles.py
+++ b/common/test/python/user_test/test_clariti_roles.py
@@ -341,12 +341,12 @@ class TestCLARiTIPropertyTests:
         fast_email = st.builds(
             lambda user, domain: f"{user}@{domain}.edu",
             st.text(
-                alphabet=st.characters(categories=("Ll",)),
+                alphabet="abcdefghijklmnopqrstuvwxyz",
                 min_size=1,
                 max_size=10,
             ),
             st.text(
-                alphabet=st.characters(categories=("Ll",)),
+                alphabet="abcdefghijklmnopqrstuvwxyz",
                 min_size=1,
                 max_size=10,
             ),

--- a/common/test/python/user_test/test_inactive_user_process_redcap.py
+++ b/common/test/python/user_test/test_inactive_user_process_redcap.py
@@ -6,10 +6,13 @@ event collection, step independence, and four-step ordering.
 
 Requirements: 2.1, 2.2, 2.3, 2.4, 3.2, 3.4, 3.5, 3.6, 3.7,
               4.2, 4.3, 4.4, 7.1, 7.2, 7.3
+
+Preservation Properties: 3.1, 3.2, 3.3, 3.4, 3.5
 """
 
 from unittest.mock import Mock
 
+import pytest
 from centers.center_group import (
     CenterMetadata,
     CenterStudyMetadata,
@@ -81,10 +84,38 @@ def _build_registry_person(
     return person
 
 
-def _build_mock_redcap(title: str = "Test Project") -> Mock:
-    """Build a mock REDCapProject with a title."""
+def _build_mock_redcap(
+    title: str = "Test Project",
+    member_usernames: list[str] | None = None,
+) -> Mock:
+    """Build a mock REDCapProject with a title.
+
+    Args:
+        title: The project title.
+        member_usernames: Usernames to include in the role assignment
+            export.  When ``None`` (the default) the export returns a
+            mapping for every common test email so that existing tests
+            that do not care about membership continue to work.
+    """
     mock_redcap = Mock(spec=REDCapProject)
     mock_redcap.title = title
+    if member_usernames is None:
+        # Default: include common test emails so pre-existing tests
+        # that don't set export_user_role_assignments still pass the
+        # membership check.
+        member_usernames = [
+            "user@example.com",
+            "entry-auth@uni.edu",
+            "comanage-auth@uni.edu",
+            "dir@example.com",
+            "specific@example.com",
+            "looked-up@uni.edu",
+            "auth@university.edu",
+            "should-not-use@uni.edu",
+        ]
+    mock_redcap.export_user_role_assignments.return_value = [
+        {"username": u, "unique_role_name": "U-default"} for u in member_usernames
+    ]
     return mock_redcap
 
 
@@ -694,3 +725,467 @@ class TestFourStepOrdering:
         assert call_order.index("redcap_unassign") < call_order.index(
             "comanage_suspend"
         )
+
+
+# ===========================================================================
+# Bug condition exploration tests
+# Validates: Requirements 1.1, 1.2, 1.3, 2.1, 2.2
+# ===========================================================================
+
+
+class TestBugConditionExploration:
+    """Explore the bug condition where unassign_user_role is called for
+    projects where the user has no role assignment.
+
+    These tests encode the EXPECTED (correct) behavior. On unfixed code
+    they are expected to FAIL, which confirms the bug exists.
+
+    Bug condition: assign_user_role is called unconditionally for every
+    REDCap project, even when the user has no role assignment in that
+    project.
+    """
+
+    def test_non_member_user_should_not_be_unassigned(self) -> None:
+        """When a user has no role assignment in a REDCap project,
+        assign_user_role should NOT be called for that project.
+
+        Bug condition: on unfixed code assign_user_role IS called
+        unconditionally, so this assertion will fail.
+
+        Validates: Requirements 1.1, 2.1
+        """
+        mock_env = _build_mock_env()
+        mock_redcap = _build_mock_redcap(title="Test Project PID 100")
+        # Mock export_user_role_assignments to return OTHER users only
+        mock_redcap.export_user_role_assignments.return_value = [
+            {"username": "other@uni.edu", "unique_role_name": "U-role1"},
+        ]
+        metadata = _build_center_metadata_with_redcap([100])
+        _setup_center_map_with_centers(
+            mock_env,
+            [{"adcid": 1, "metadata": metadata, "redcap_project": mock_redcap}],
+        )
+
+        collector = UserEventCollector()
+        process = InactiveUserProcess(mock_env, collector)
+        entry = _build_entry(email="user@example.com")
+
+        process.visit(entry)
+
+        # Expected: assign_user_role should NOT be called because user
+        # has no role assignment in this project.
+        # Bug: on unfixed code it IS called with ("user@example.com", "")
+        mock_redcap.assign_user_role.assert_not_called()
+
+    def test_non_member_user_should_not_emit_success_event(self) -> None:
+        """When a user has no role assignment in a REDCap project, no success
+        event with REDCAP_USER_DISABLED should be emitted.
+
+        Bug condition: on unfixed code a success event IS emitted,
+        so this assertion will fail.
+
+        Validates: Requirements 1.2, 2.2
+        """
+        mock_env = _build_mock_env()
+        mock_redcap = _build_mock_redcap(title="Test Project PID 100")
+        mock_redcap.export_user_role_assignments.return_value = [
+            {"username": "other@uni.edu", "unique_role_name": "U-role1"},
+        ]
+        metadata = _build_center_metadata_with_redcap([100])
+        _setup_center_map_with_centers(
+            mock_env,
+            [{"adcid": 1, "metadata": metadata, "redcap_project": mock_redcap}],
+        )
+
+        collector = UserEventCollector()
+        process = InactiveUserProcess(mock_env, collector)
+        entry = _build_entry(email="user@example.com")
+
+        process.visit(entry)
+
+        # Expected: no success event for REDCAP_USER_DISABLED
+        # Bug: on unfixed code a success event IS emitted
+        redcap_successes = [
+            e
+            for e in collector.get_successes()
+            if e.category == EventCategory.REDCAP_USER_DISABLED.value
+        ]
+        assert len(redcap_successes) == 0, (
+            f"Expected no REDCAP_USER_DISABLED success events for non-member user, "
+            f"but got {len(redcap_successes)}: "
+            f"{[e.message for e in redcap_successes]}"
+        )
+
+    def test_mixed_membership_only_unassigns_member_projects(self) -> None:
+        """When a user is a member of PID 100 but NOT PID 200 or PID 300,
+        assign_user_role should be called exactly once (for PID 100 only).
+
+        Bug condition: on unfixed code assign_user_role is called for
+        all 3 projects, so the call count assertion will fail.
+
+        Validates: Requirements 1.3, 2.1, 2.2
+        """
+        mock_env = _build_mock_env()
+
+        # PID 100: user IS a member
+        mock_redcap_100 = _build_mock_redcap(title="Project 100")
+        mock_redcap_100.export_user_role_assignments.return_value = [
+            {"username": "user@example.com", "unique_role_name": "U-role1"},
+            {"username": "other@uni.edu", "unique_role_name": "U-role2"},
+        ]
+
+        # PID 200: user is NOT a member
+        mock_redcap_200 = _build_mock_redcap(title="Project 200")
+        mock_redcap_200.export_user_role_assignments.return_value = [
+            {"username": "someone@uni.edu", "unique_role_name": "U-role1"},
+        ]
+
+        # PID 300: user is NOT a member
+        mock_redcap_300 = _build_mock_redcap(title="Project 300")
+        mock_redcap_300.export_user_role_assignments.return_value = []
+
+        metadata = _build_center_metadata_with_redcap([100, 200, 300])
+
+        def get_redcap_project(pid: int) -> Mock:
+            return {100: mock_redcap_100, 200: mock_redcap_200, 300: mock_redcap_300}[
+                pid
+            ]
+
+        center_groups = _setup_center_map_with_centers(
+            mock_env,
+            [{"adcid": 1, "metadata": metadata}],
+        )
+        center_groups[1].get_redcap_project.side_effect = get_redcap_project
+
+        collector = UserEventCollector()
+        process = InactiveUserProcess(mock_env, collector)
+        entry = _build_entry(email="user@example.com")
+
+        process.visit(entry)
+
+        # Expected: assign_user_role called exactly once (PID 100 only)
+        # Bug: on unfixed code it is called 3 times (all projects)
+        mock_redcap_100.assign_user_role.assert_called_once()
+        mock_redcap_200.assign_user_role.assert_not_called()
+        mock_redcap_300.assign_user_role.assert_not_called()
+
+        # Expected: exactly 1 success event (for PID 100 only)
+        redcap_successes = [
+            e
+            for e in collector.get_successes()
+            if e.category == EventCategory.REDCAP_USER_DISABLED.value
+        ]
+        assert len(redcap_successes) == 1, (
+            f"Expected 1 REDCAP_USER_DISABLED success event (PID 100 only), "
+            f"but got {len(redcap_successes)}: "
+            f"{[e.message for e in redcap_successes]}"
+        )
+
+
+# ===========================================================================
+# Preservation property tests
+# Validates: Requirements 3.1, 3.2, 3.3, 3.4, 3.5
+# ===========================================================================
+
+# Parameterized username/mapping combinations for property-based style tests
+_MEMBER_USER_CASES = [
+    pytest.param(
+        "alice@uni.edu",
+        [
+            {"username": "alice@uni.edu", "unique_role_name": "U-role1"},
+            {"username": "bob@uni.edu", "unique_role_name": "U-role2"},
+        ],
+        id="alice-with-two-users",
+    ),
+    pytest.param(
+        "bob@example.com",
+        [
+            {"username": "bob@example.com", "unique_role_name": "U-admin"},
+        ],
+        id="bob-sole-member",
+    ),
+    pytest.param(
+        "carol@university.edu",
+        [
+            {"username": "other@uni.edu", "unique_role_name": "U-role1"},
+            {"username": "carol@university.edu", "unique_role_name": "U-role2"},
+            {"username": "dave@uni.edu", "unique_role_name": "U-role3"},
+        ],
+        id="carol-among-three",
+    ),
+    pytest.param(
+        "user@example.com",
+        [
+            {"username": "user@example.com", "unique_role_name": ""},
+        ],
+        id="user-with-empty-role-name",
+    ),
+]
+
+
+class TestPreservationProperties:
+    """Preservation property tests: verify that existing behaviors for member
+    users, dry-run mode, error handling, and credential unavailability remain
+    unchanged.
+
+    These tests are written against the UNFIXED code and are expected to
+    PASS, establishing a baseline of behaviors that must be preserved
+    after the fix is applied.
+
+    Validates: Requirements 3.1, 3.2, 3.3, 3.4, 3.5
+    """
+
+    # -----------------------------------------------------------------------
+    # Property 2a: Member user unassignment — assign_user_role is called
+    # and a success event with REDCAP_USER_DISABLED is emitted
+    # Validates: Requirements 3.1
+    # -----------------------------------------------------------------------
+
+    @pytest.mark.parametrize("username,role_mappings", _MEMBER_USER_CASES)
+    def test_member_user_is_unassigned_and_success_event_emitted(
+        self,
+        username: str,
+        role_mappings: list,
+    ) -> None:
+        """When a user IS a member of a REDCap project, assign_user_role is
+        called with (username, "") and a success event with
+        REDCAP_USER_DISABLED category is emitted.
+
+        **Validates: Requirements 3.1**
+        """
+        mock_env = _build_mock_env()
+        mock_redcap = _build_mock_redcap(title="Preservation Project")
+        mock_redcap.export_user_role_assignments.return_value = role_mappings
+        metadata = _build_center_metadata_with_redcap([100])
+        _setup_center_map_with_centers(
+            mock_env,
+            [{"adcid": 1, "metadata": metadata, "redcap_project": mock_redcap}],
+        )
+
+        collector = UserEventCollector()
+        process = InactiveUserProcess(mock_env, collector)
+        entry = _build_entry(email=username)
+
+        process.visit(entry)
+
+        # assign_user_role must be called with (username, "")
+        mock_redcap.assign_user_role.assert_called_once_with(username, "")
+
+        # A success event with REDCAP_USER_DISABLED must be emitted
+        redcap_successes = [
+            e
+            for e in collector.get_successes()
+            if e.category == EventCategory.REDCAP_USER_DISABLED.value
+        ]
+        assert len(redcap_successes) == 1
+        assert "100" in redcap_successes[0].message
+        assert "Preservation Project" in redcap_successes[0].message
+
+    # -----------------------------------------------------------------------
+    # Property 2b: Dry-run mode — assign_user_role is NOT called but a
+    # dry-run success event IS emitted
+    # Validates: Requirements 3.3
+    # -----------------------------------------------------------------------
+
+    @pytest.mark.parametrize("username,role_mappings", _MEMBER_USER_CASES)
+    def test_dry_run_member_user_not_called_but_event_emitted(
+        self,
+        username: str,
+        role_mappings: list,
+    ) -> None:
+        """In dry-run mode with a member user, assign_user_role is NOT called
+        but a dry-run success event with REDCAP_USER_DISABLED IS emitted.
+
+        **Validates: Requirements 3.3**
+        """
+        mock_env = _build_mock_env(dry_run=True)
+        mock_redcap = _build_mock_redcap(title="DryRun Project")
+        mock_redcap.export_user_role_assignments.return_value = role_mappings
+        metadata = _build_center_metadata_with_redcap([100])
+        _setup_center_map_with_centers(
+            mock_env,
+            [{"adcid": 1, "metadata": metadata, "redcap_project": mock_redcap}],
+        )
+
+        collector = UserEventCollector()
+        process = InactiveUserProcess(mock_env, collector)
+        entry = _build_entry(email=username)
+
+        process.visit(entry)
+
+        # assign_user_role must NOT be called in dry-run mode
+        mock_redcap.assign_user_role.assert_not_called()
+
+        # A dry-run success event must be emitted
+        redcap_successes = [
+            e
+            for e in collector.get_successes()
+            if e.category == EventCategory.REDCAP_USER_DISABLED.value
+        ]
+        assert len(redcap_successes) == 1
+        assert "dry run" in redcap_successes[0].message.lower()
+
+    # -----------------------------------------------------------------------
+    # Property 2c: Error handling — REDCapConnectionError from
+    # assign_user_role emits an error event and processing continues
+    # Validates: Requirements 3.4
+    # -----------------------------------------------------------------------
+
+    @pytest.mark.parametrize("username,role_mappings", _MEMBER_USER_CASES)
+    def test_connection_error_emits_error_event_and_continues(
+        self,
+        username: str,
+        role_mappings: list,
+    ) -> None:
+        """When assign_user_role raises REDCapConnectionError for a member
+        user, an error event with REDCAP_USER_DISABLED category is emitted and
+        processing continues to the next project.
+
+        **Validates: Requirements 3.4**
+        """
+        mock_env = _build_mock_env()
+
+        # First project: assign_user_role raises REDCapConnectionError
+        mock_redcap_100 = _build_mock_redcap(title="Error Project")
+        mock_redcap_100.export_user_role_assignments.return_value = role_mappings
+        mock_redcap_100.assign_user_role.side_effect = REDCapConnectionError(
+            "connection timeout"
+        )
+
+        # Second project: succeeds normally
+        mock_redcap_200 = _build_mock_redcap(title="OK Project")
+        mock_redcap_200.export_user_role_assignments.return_value = [
+            {"username": username, "unique_role_name": "U-role1"},
+        ]
+        mock_redcap_200.assign_user_role.return_value = 1
+
+        metadata = _build_center_metadata_with_redcap([100, 200])
+        center_groups = _setup_center_map_with_centers(
+            mock_env,
+            [{"adcid": 1, "metadata": metadata}],
+        )
+        center_groups[1].get_redcap_project.side_effect = (
+            lambda pid: mock_redcap_100 if pid == 100 else mock_redcap_200
+        )
+
+        collector = UserEventCollector()
+        process = InactiveUserProcess(mock_env, collector)
+        entry = _build_entry(email=username)
+
+        process.visit(entry)
+
+        # Both projects should have been attempted
+        mock_redcap_100.assign_user_role.assert_called_once()
+        mock_redcap_200.assign_user_role.assert_called_once()
+
+        # One error event for the failed project
+        redcap_events = [
+            e
+            for e in collector.get_events()
+            if e.category == EventCategory.REDCAP_USER_DISABLED.value
+        ]
+        errors = [e for e in redcap_events if e.event_type == EventType.ERROR.value]
+        successes = [
+            e for e in redcap_events if e.event_type == EventType.SUCCESS.value
+        ]
+        assert len(errors) == 1
+        assert "Error Project" in errors[0].message
+        assert len(successes) == 1
+        assert "OK Project" in successes[0].message
+
+    # -----------------------------------------------------------------------
+    # Property 2d: Credential unavailability — project is skipped with
+    # an error event when get_redcap_project returns None
+    # Validates: Requirements 3.2
+    # -----------------------------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "username",
+        [
+            pytest.param("alice@uni.edu", id="alice"),
+            pytest.param("bob@example.com", id="bob"),
+            pytest.param("user@example.com", id="default-user"),
+        ],
+    )
+    def test_unavailable_credentials_skips_with_error_event(
+        self,
+        username: str,
+    ) -> None:
+        """When get_redcap_project returns None (credentials unavailable), the
+        project is skipped and an error event with REDCAP_USER_DISABLED
+        category is emitted.
+
+        **Validates: Requirements 3.2**
+        """
+        mock_env = _build_mock_env()
+        metadata = _build_center_metadata_with_redcap([100])
+        # get_redcap_project returns None -> credentials unavailable
+        _setup_center_map_with_centers(
+            mock_env,
+            [{"adcid": 1, "metadata": metadata, "redcap_project": None}],
+        )
+
+        collector = UserEventCollector()
+        process = InactiveUserProcess(mock_env, collector)
+        entry = _build_entry(email=username)
+
+        process.visit(entry)
+
+        errors = collector.get_errors()
+        redcap_errors = [
+            e for e in errors if e.category == EventCategory.REDCAP_USER_DISABLED.value
+        ]
+        assert len(redcap_errors) == 1
+        assert "unavailable" in redcap_errors[0].message.lower()
+
+    # -----------------------------------------------------------------------
+    # Property 2e: Center iteration continues after failure
+    # Validates: Requirements 3.5
+    # -----------------------------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "username",
+        [
+            pytest.param("alice@uni.edu", id="alice"),
+            pytest.param("user@example.com", id="default-user"),
+        ],
+    )
+    def test_processing_continues_after_center_retrieval_failure(
+        self,
+        username: str,
+    ) -> None:
+        """When a center group cannot be retrieved, processing continues to
+        remaining centers.
+
+        **Validates: Requirements 3.5**
+        """
+        mock_env = _build_mock_env()
+        metadata_good = _build_center_metadata_with_redcap([200])
+        mock_redcap = _build_mock_redcap(title="Good Project")
+        mock_redcap.export_user_role_assignments.return_value = [
+            {"username": username, "unique_role_name": "U-role1"},
+        ]
+
+        center_map = CenterMapInfo(centers={})
+        mock_env.admin_group.get_center_map.return_value = center_map
+
+        # Center 1 cannot be retrieved, center 2 works
+        center_map.add(1, CenterInfo(adcid=1, name="c1", group="g1"))
+        center_map.add(2, CenterInfo(adcid=2, name="c2", group="g2"))
+
+        mock_cg_2 = Mock()
+        mock_cg_2.get_project_info.return_value = metadata_good
+        mock_cg_2.get_redcap_project.return_value = mock_redcap
+
+        mock_env.admin_group.get_center.side_effect = (
+            lambda a: None if a == 1 else mock_cg_2
+        )
+
+        collector = UserEventCollector()
+        process = InactiveUserProcess(mock_env, collector)
+        entry = _build_entry(email=username)
+
+        process.visit(entry)
+
+        # Center 2's project should still be processed
+        mock_redcap.assign_user_role.assert_called_once()

--- a/common/test/python/user_test/test_redcap_user_operations.py
+++ b/common/test/python/user_test/test_redcap_user_operations.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock
 import pytest
 from redcap_api.redcap_connection import REDCapConnectionError
 from redcap_api.redcap_project import REDCapProject
-from users.redcap_user_operations import unassign_user_role
+from users.redcap_user_operations import unassign_user_role, user_has_role_assignment
 
 
 class TestUnassignUserRole:
@@ -41,3 +41,53 @@ class TestUnassignUserRole:
 
         with pytest.raises(REDCapConnectionError):
             unassign_user_role(mock_project, "user@example.com")
+
+
+class TestUserHasRoleAssignment:
+    """Tests for user_has_role_assignment helper function."""
+
+    def test_returns_true_when_username_in_mapping_list(self):
+        """When the username appears in the role assignment list, returns
+        True."""
+        mock_project = Mock(spec=REDCapProject)
+        mock_project.export_user_role_assignments.return_value = [
+            {"username": "alice@uni.edu", "unique_role_name": "U-role1"},
+            {"username": "bob@uni.edu", "unique_role_name": "U-role2"},
+        ]
+
+        result = user_has_role_assignment(mock_project, "alice@uni.edu")
+
+        assert result is True
+
+    def test_returns_false_when_username_not_in_mapping_list(self):
+        """When the username does not appear in the role assignment list,
+        returns False."""
+        mock_project = Mock(spec=REDCapProject)
+        mock_project.export_user_role_assignments.return_value = [
+            {"username": "alice@uni.edu", "unique_role_name": "U-role1"},
+            {"username": "bob@uni.edu", "unique_role_name": "U-role2"},
+        ]
+
+        result = user_has_role_assignment(mock_project, "carol@uni.edu")
+
+        assert result is False
+
+    def test_returns_false_when_mapping_list_is_empty(self):
+        """When the role assignment list is empty, returns False."""
+        mock_project = Mock(spec=REDCapProject)
+        mock_project.export_user_role_assignments.return_value = []
+
+        result = user_has_role_assignment(mock_project, "user@example.com")
+
+        assert result is False
+
+    def test_propagates_redcap_connection_error(self):
+        """REDCapConnectionError from export_user_role_assignments propagates
+        to the caller."""
+        mock_project = Mock(spec=REDCapProject)
+        mock_project.export_user_role_assignments.side_effect = REDCapConnectionError(
+            "Connection failed"
+        )
+
+        with pytest.raises(REDCapConnectionError):
+            user_has_role_assignment(mock_project, "user@example.com")

--- a/docs/host-venv-for-ide.md
+++ b/docs/host-venv-for-ide.md
@@ -1,0 +1,221 @@
+# Host Virtual Environment for IDE Support
+
+## Summary
+
+This project uses a **devcontainer** for all code execution (tests, linting, type checking, builds) via the Pants build system. Previously, the IDE also relied on the devcontainer's Python environment for analysis features like autocomplete, go-to-definition, and type checking. We changed this so the IDE uses a **host-native `.venv`** instead.
+
+## Why We Changed
+
+When the IDE depended on the devcontainer for Python analysis, several problems came up:
+
+- **Container dependency**: The devcontainer had to be running for any IDE features to work. If the container was stopped or rebuilding, autocomplete, type checking, and import resolution all broke.
+- **Path mismatches**: The devcontainer mounts the workspace at `/workspaces/flywheel-gear-extensions`, but the IDE runs on the host. This caused constant friction with interpreter paths, PYTHONPATH resolution, and source root mapping.
+- **Startup lag**: IDE analysis features were slow to initialize because they had to reach into the container.
+- **Fragility**: Container rebuilds, Docker restarts, or network issues would silently break IDE support with no obvious error.
+
+## What Changed
+
+We introduced a **host-native `.venv`** that exists solely for IDE analysis. All execution still happens in the devcontainer — the host venv is never used to run code, tests, or builds.
+
+### The setup
+
+1. **`bin/create-host-venv.sh`** creates and configures the host venv:
+   - Reads the required Python version from `.python-version` (currently 3.12)
+   - Finds a matching interpreter on the host via `python3.12`, `python3`, or pyenv
+   - Creates `.venv` in the project root
+   - Installs all dependencies from `requirements.txt`
+   - Writes a `.env` file with `PYTHONPATH` pointing to all Pants source roots so the IDE can resolve local packages across the monorepo
+
+2. **`.vscode/settings.json`** points the IDE at the host venv:
+   ```json
+   {
+     "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
+     "python.envFile": "${workspaceFolder}/.env"
+   }
+   ```
+
+3. **`.env`** contains the `PYTHONPATH` with all source roots:
+   ```
+   PYTHONPATH="./common/src/python:./nacc-common/src/python:./gear/*/src/python:..."
+   ```
+
+### Two-environment model
+
+| Concern | Environment | How |
+|---------|------------|-----|
+| IDE analysis (autocomplete, types, go-to-definition) | Host `.venv` | `bin/create-host-venv.sh` |
+| Code execution (tests, lint, check, build) | Devcontainer | Pants via `bin/exec-in-devcontainer.sh` or kiro-pants-power |
+
+## How to Set It Up
+
+```bash
+# One-time setup (or after adding new dependencies)
+./bin/create-host-venv.sh
+```
+
+The script is idempotent — safe to re-run whenever dependencies change or the venv needs refreshing.
+
+### Prerequisites
+
+Python 3.12 must be available on the host through one of:
+
+- System PATH (e.g., `python3.12`)
+- pyenv (`pyenv install 3.12.11`)
+
+### The Script (`bin/create-host-venv.sh`)
+
+```bash
+#!/bin/bash
+# Creates a host-native .venv for IDE analysis (autocomplete, type checking, package inspection).
+# This venv is NOT used for execution — Pants in the devcontainer handles that.
+#
+# Usage: ./bin/create-host-venv.sh
+#
+# The required Python version is read from .python-version in the project root.
+# Ensure that version is available via pyenv, system install, or PATH.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$PROJECT_ROOT"
+
+# Read required version from .python-version
+if [ ! -f .python-version ]; then
+    echo "Error: .python-version file not found in project root."
+    echo "Create one with the desired Python version (e.g., 3.12.11)."
+    exit 1
+fi
+
+REQUIRED_VERSION=$(head -1 .python-version | tr -d '[:space:]')
+REQUIRED_MAJOR_MINOR=$(echo "$REQUIRED_VERSION" | grep -oE '^[0-9]+\.[0-9]+')
+
+if [ -z "$REQUIRED_MAJOR_MINOR" ]; then
+    echo "Error: Could not parse version from .python-version (got: '$REQUIRED_VERSION')."
+    exit 1
+fi
+
+echo "Required Python: $REQUIRED_MAJOR_MINOR.x (from .python-version: $REQUIRED_VERSION)"
+
+# Find a matching Python interpreter
+find_python() {
+    local major_minor="$1"
+
+    # Check for exact versioned command (e.g., python3.12)
+    local cmd="python${major_minor}"
+    if command -v "$cmd" &>/dev/null; then
+        echo "$cmd"
+        return
+    fi
+
+    # Check if python3 matches
+    if command -v python3 &>/dev/null; then
+        local version
+        version=$(python3 --version 2>&1 | grep -oE "${major_minor}\.[0-9]+")
+        if [ -n "$version" ]; then
+            echo "python3"
+            return
+        fi
+    fi
+
+    # Check pyenv versions
+    if command -v pyenv &>/dev/null; then
+        local pyenv_root
+        pyenv_root=$(pyenv root)
+        local match
+        match=$(ls -1 "$pyenv_root/versions/" 2>/dev/null | grep -E "^${major_minor}\." | sort -V | tail -1)
+        if [ -n "$match" ]; then
+            echo "$pyenv_root/versions/$match/bin/python3"
+            return
+        fi
+    fi
+
+    echo ""
+}
+
+PYTHON=$(find_python "$REQUIRED_MAJOR_MINOR")
+
+if [ -z "$PYTHON" ]; then
+    echo "Error: Python $REQUIRED_MAJOR_MINOR not found."
+    echo "Install it via: pyenv install $REQUIRED_VERSION"
+    exit 1
+fi
+
+echo "Using: $PYTHON ($($PYTHON --version))"
+
+# Create or refresh the venv
+if [ -L .venv ]; then
+    echo "Removing existing .venv symlink..."
+    rm .venv
+fi
+
+if [ -d .venv ]; then
+    echo "Updating existing .venv..."
+    "$PYTHON" -m venv .venv --upgrade
+else
+    echo "Creating .venv..."
+    "$PYTHON" -m venv .venv
+fi
+
+echo "Installing dependencies from requirements.txt..."
+.venv/bin/pip install --quiet --upgrade pip
+.venv/bin/pip install --quiet -r requirements.txt
+
+# Set up PYTHONPATH in .env for source roots so the IDE resolves local packages
+echo "Configuring .env with source roots..."
+
+# These are the Pants source roots for this project
+SOURCE_ROOTS=(
+    "common/src/python"
+    "nacc-common/src/python"
+    "ssm_parameter_store/src/python"
+)
+
+# Add gear source roots
+for gear_dir in gear/*/src/python; do
+    if [ -d "$gear_dir" ]; then
+        SOURCE_ROOTS+=("$gear_dir")
+    fi
+done
+
+PYTHONPATH_VALUE=""
+for root in "${SOURCE_ROOTS[@]}"; do
+    if [ -z "$PYTHONPATH_VALUE" ]; then
+        PYTHONPATH_VALUE="./$root"
+    else
+        PYTHONPATH_VALUE="$PYTHONPATH_VALUE:./$root"
+    fi
+done
+
+# Update or add PYTHONPATH in .env
+if [ -f .env ]; then
+    if grep -q "^PYTHONPATH=" .env; then
+        grep -v "^PYTHONPATH=" .env > .env.tmp
+        echo "PYTHONPATH=\"$PYTHONPATH_VALUE\"" >> .env.tmp
+        mv .env.tmp .env
+    else
+        echo "PYTHONPATH=\"$PYTHONPATH_VALUE\"" >> .env
+    fi
+else
+    echo "PYTHONPATH=\"$PYTHONPATH_VALUE\"" > .env
+fi
+
+echo ""
+echo "Done. Host .venv is ready for IDE analysis."
+echo "  Python: $(.venv/bin/python --version)"
+echo "  Packages: $(.venv/bin/pip list --format=columns 2>/dev/null | wc -l | tr -d ' ') installed"
+echo ""
+echo "Note: This venv is for IDE support only. Use the devcontainer for execution (pants test/lint/check)."
+```
+
+## Key Points for AI Agents
+
+When working in this project (or similar projects using this pattern):
+
+- **Never use the host `.venv` for execution.** It exists only so the IDE can resolve imports and provide type information. All code runs in the devcontainer.
+- **All Pants commands run in the devcontainer.** Use `bin/exec-in-devcontainer.sh` or the kiro-pants-power tools. Never run `pants` directly on the host.
+- **If IDE analysis breaks** (missing imports, unresolved references), the fix is usually `./bin/create-host-venv.sh`, not anything in the devcontainer.
+- **The `.env` file is generated** by `create-host-venv.sh`. Don't hand-edit it — re-run the script instead.
+- **The `.venv` and `.env` are gitignored.** Each developer generates their own from the script.
+- **When dependencies change** in `requirements.txt`, developers need to re-run `./bin/create-host-venv.sh` to update their host venv.

--- a/docs/user_management/CHANGELOG.md
+++ b/docs/user_management/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this gear are documented in this file.
 
+## 4.3.2
+
+* Skips REDCap role unassignment for users who have no role assignment in a project
+  * Checks `export_user_role_assignments` before attempting to unassign, avoiding unnecessary API calls
+  * No longer emits misleading success events for projects where the user was never assigned a role
+  * Reduces noise in the REDCap disable notification email sent to support staff
+  * Handles `REDCapConnectionError` from the membership check gracefully without blocking the disable flow
+* Bumps `redcap_api` to 0.3.0
+* Fixes flaky Hypothesis test in CLARiTI role property tests (slow `from_regex` strategy)
+
 ## 4.3.1
 
 * Handles empty user list gracefully instead of failing with an error

--- a/gear/user_management/src/docker/BUILD
+++ b/gear/user_management/src/docker/BUILD
@@ -4,5 +4,5 @@ docker_image(
     name="user-management",
     source="Dockerfile",
     dependencies=[":manifest", "gear/user_management/src/python/user_app:bin"],
-    image_tags=["4.3.1", "latest"],
+    image_tags=["4.3.2", "latest"],
 )

--- a/gear/user_management/src/docker/manifest.json
+++ b/gear/user_management/src/docker/manifest.json
@@ -2,7 +2,7 @@
   "name": "user-management",
   "label": "User Management",
   "description": "Creates and updates user and user roles",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "author": "NACC",
   "maintainer": "NACC <nacchelp@uw.edu>",
   "cite": "",
@@ -15,7 +15,7 @@
   "custom": {
     "gear-builder": {
       "category": "utility",
-      "image": "naccdata/user-management:4.3.1"
+      "image": "naccdata/user-management:4.3.2"
     },
     "flywheel": {
       "suite": "NACC Admin Gears",

--- a/mypy.lock
+++ b/mypy.lock
@@ -193,25 +193,23 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723",
-              "url": "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl"
+              "hash": "a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189",
+              "url": "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645",
-              "url": "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz"
+              "hash": "17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a",
+              "url": "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz"
             }
           ],
           "project_name": "pathspec",
           "requires_dists": [
             "google-re2>=1.1; extra == \"re2\"",
             "hyperscan>=0.7; extra == \"hyperscan\"",
-            "pytest>=9; extra == \"tests\"",
-            "typing-extensions>=4.15; extra == \"tests\"",
             "typing-extensions>=4; extra == \"optional\""
           ],
           "requires_python": ">=3.9",
-          "version": "1.0.4"
+          "version": "1.1.1"
         },
         {
           "artifacts": [

--- a/prompts/redcap-suspension-flagging.md
+++ b/prompts/redcap-suspension-flagging.md
@@ -1,0 +1,96 @@
+# REDCap User Suspension Flagging
+
+> **Status: Shelved (April 2026)**
+>
+> We decided not to implement this because the `export_users` check would be
+> redundant. Every user we unassign a role from will still exist in the project
+> afterward — REDCap auto-creates a user record when you assign a role mapping,
+> and unassigning the role doesn't remove that record. So `export_users` would
+> always return true for users we just unassigned, adding API calls without
+> filtering anyone out of the email.
+>
+> The membership check fix (checking `export_user_role_assignments` before
+> calling `unassign_user_role`) already eliminates the main source of noise:
+> users who never had a role no longer appear in the notification email.
+>
+> The `export_users()` method is available in `redcap_api` if we find a use
+> for it later — for example, if REDCap adds a suspended/expiration flag to
+> the Export Users response that would let us detect users the admin has
+> already dealt with.
+
+## Context
+
+The user management gear disables inactive users across three systems: Flywheel, REDCap, and COmanage. The REDCap disable step (`InactiveUserProcess.__disable_in_redcap` in `common/src/python/users/user_processes.py`) currently only unassigns user roles — it calls `assign_user_role(username, "")` to remove the role mapping. However, unassigning a role does not remove the user from the REDCap project. The user record persists with whatever permissions remain, and an admin must manually suspend them in the REDCap UI.
+
+Today, the gear sends an email to support staff listing every user whose role was unassigned, with the message "Please manually suspend these users' REDCap accounts." This email is sent by `__send_redcap_disable_notification` in `gear/user_management/src/python/user_app/run.py`. The problem is that this email only tells admins *which users had roles removed* — it doesn't tell them which REDCap projects the user still exists in after role removal. The admin has to go check each project manually.
+
+## What We Want
+
+After unassigning a user's role from a REDCap project, check whether the user still exists in that project using the REDCap Export Users API (`content: "user"`). If the user is still present, flag them for manual suspension by collecting an event that will be included in the notification email.
+
+The `redcap_api` package (v0.4.0) now has an `export_users()` method on `REDCapProject`:
+
+```python
+def export_users(self) -> List[Dict[str, Any]]:
+    """Export the list of users for the project.
+
+    Returns the list of users in the project with their privileges.
+    Each entry contains at minimum ``username``, ``email``,
+    ``firstname``, and ``lastname`` keys, along with privilege flags.
+
+    Returns:
+        List of user dicts with privileges
+
+    Raises:
+        REDCapConnectionError if the response has an error
+    """
+```
+
+## Requirements
+
+### Functional
+
+1. After successfully unassigning a user's role from a REDCap project, call `export_users()` on that project and check whether the username still appears in the user list.
+
+2. If the user is still present in the project after role unassignment, collect a new event that indicates the user needs manual suspension. This event should include the username, project title, and PID so the notification email can tell admins exactly where to act.
+
+3. If the user is NOT present in the project after role unassignment (unlikely but possible if they were removed by other means), do not flag them.
+
+4. If `export_users()` fails with a `REDCapConnectionError`, handle it gracefully — log the error, collect an error event, and continue processing. Do not let this failure block the rest of the disable flow.
+
+5. In dry-run mode, skip the `export_users()` check (since no role was actually unassigned, the user's state hasn't changed).
+
+### Event Design
+
+Consider whether to:
+- (a) Add a new `EventCategory` (e.g., `REDCAP_USER_NEEDS_SUSPENSION`) to distinguish "role was removed" from "user still exists and needs manual suspension", or
+- (b) Reuse `REDCAP_USER_DISABLED` with a different message format that the notification code can parse.
+
+Option (a) is cleaner — it lets the notification email have a separate section for users needing suspension vs. roles that were removed. The existing `__send_redcap_disable_notification` in `run.py` would need to be updated to include the new category.
+
+### Notification Email
+
+Update `__send_redcap_disable_notification` in `gear/user_management/src/python/user_app/run.py` to include the suspension-needed information. The email should clearly distinguish between:
+- Role removals that were performed (existing behavior)
+- Users that still need manual suspension in specific REDCap projects (new)
+
+### Unchanged Behavior
+
+- The role unassignment logic must remain unchanged — this is additive.
+- The existing `REDCAP_USER_DISABLED` success events for role removal must continue to work as before.
+- Error handling for role unassignment failures must remain unchanged.
+- The membership check (`user_has_role_assignment`) before unassignment must remain unchanged.
+
+## Key Files
+
+- `common/src/python/users/user_processes.py` — `InactiveUserProcess.__unassign_redcap_project` (add `export_users` check after successful unassignment)
+- `common/src/python/users/redcap_user_operations.py` — add a helper function (e.g., `user_exists_in_project`) that wraps `export_users()` and checks for the username
+- `common/src/python/users/event_models.py` — add new `EventCategory` if going with option (a)
+- `gear/user_management/src/python/user_app/run.py` — update `__send_redcap_disable_notification` to include suspension-needed events
+
+## Implementation Notes
+
+- The `export_users()` call returns a list of dicts, each with a `username` key. The check is: does any returned user dict have `username` matching the target username?
+- This check should happen only after a successful `unassign_user_role` call — not after dry-run, not after errors, not when the user had no role to begin with.
+- The `__unassign_redcap_project` method already has the `redcap_project` object, `username`, `title`, `pid`, and `user_context` in scope at the point where the check would be added.
+- Follow the existing error handling pattern: catch `REDCapConnectionError`, log, collect error event, continue.

--- a/python-default.lock
+++ b/python-default.lock
@@ -33,7 +33,7 @@
 //     "pyyaml>=6.0.1",
 //     "ratelimit-types>=0.0.1",
 //     "ratelimit>=2.2.1",
-//     "redcap_api@ https://github.com/naccdata/redcap-api/releases/download/v0.1.5/redcap_api-0.1.5-py3-none-any.whl",
+//     "redcap_api@ https://github.com/naccdata/redcap-api/releases/download/v0.3.0/redcap_api-0.3.0-py3-none-any.whl",
 //     "requests-oauthlib>=2.0.0",
 //     "requests>=2.18.4",
 //     "setuptools>=68.3.0",
@@ -147,42 +147,42 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "c90d9a170faa0585755fa103a3cd9595e1f53443864e902c180f3d8177589125",
-              "url": "https://files.pythonhosted.org/packages/8f/8f/350ffd50aaa515429464deb1dc85893a21a64cb41892feb6b22ce87304ad/boto3-1.42.92-py3-none-any.whl"
+              "hash": "966e49f0510af9a64057a902b7df53d4348c447de0d3df4cc855dfd85e058fcd",
+              "url": "https://files.pythonhosted.org/packages/38/43/84c1888139aa1aaf1dc53f8f914e6ec629e5a571fbafdd42fb2d98ac361f/boto3-1.42.97-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "55ec6ef6fc81f46d567a7d1d398d1e5c375d468905d0ccd9e1f767f0c77dbe9b",
-              "url": "https://files.pythonhosted.org/packages/e7/3b/84cafa37e85a57618554bd2bc21bd569417097f45f18c23ef488e6c69683/boto3-1.42.92.tar.gz"
+              "hash": "2833dbeda3670ea610ad48dff7d27cdc829dbbfcdfbc6b750b673948e949b6f0",
+              "url": "https://files.pythonhosted.org/packages/55/7d/5c6fa0bb9fd5caf865b9356411793900304328bcd0bc1eda96a32a1368a6/boto3-1.42.97.tar.gz"
             }
           ],
           "project_name": "boto3",
           "requires_dists": [
-            "botocore<1.43.0,>=1.42.92",
+            "botocore<1.43.0,>=1.42.97",
             "botocore[crt]<2.0a0,>=1.21.0; extra == \"crt\"",
             "jmespath<2.0.0,>=0.7.1",
             "s3transfer<0.17.0,>=0.16.0"
           ],
           "requires_python": ">=3.9",
-          "version": "1.42.92"
+          "version": "1.42.97"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "b3994e60f0133b2dd3d9a88ceaeef48fa6367d9a9429426e919575768a1ad9c6",
-              "url": "https://files.pythonhosted.org/packages/6c/ce/2fe2c6456f8dc0b8bb8d80e05e154c7975ec058991bedf54f3aeed634b79/boto3_stubs-1.42.92-py3-none-any.whl"
+              "hash": "47539eaab612d63b5b828657ee0977237725f7608f19563a2ae7f784042411bc",
+              "url": "https://files.pythonhosted.org/packages/93/35/8298310d1cbaf5dcb7b16073a93a9cb64dc91ec951f32a1cb9e0cacc499b/boto3_stubs-1.42.97-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "4bc934069c5e8c7b3cdd2442569dae14e8272fe207d445bd38aa578b8463638f",
-              "url": "https://files.pythonhosted.org/packages/fa/b4/7f472d64a89f6aa6b8e8eeadc876667b7e4edfb526c6118efe2b2c98ba17/boto3_stubs-1.42.92.tar.gz"
+              "hash": "f7f4775b0851ff6db0e3fb097064af6437e4de31b797d874a737104998e028c6",
+              "url": "https://files.pythonhosted.org/packages/2c/36/cf331b6fa18348e5c5a40098f93eb698803db747e4265b0263d60e222c61/boto3_stubs-1.42.97.tar.gz"
             }
           ],
           "project_name": "boto3-stubs",
           "requires_dists": [
             "boto3-stubs-full<1.43.0,>=1.42.0; extra == \"full\"",
-            "boto3==1.42.92; extra == \"boto3\"",
+            "boto3==1.42.97; extra == \"boto3\"",
             "botocore-stubs",
             "mypy-boto3-accessanalyzer<1.43.0,>=1.42.0; extra == \"accessanalyzer\"",
             "mypy-boto3-accessanalyzer<1.43.0,>=1.42.0; extra == \"all\"",
@@ -1041,19 +1041,19 @@
             "typing-extensions>=4.1.0; python_version < \"3.12\""
           ],
           "requires_python": ">=3.9",
-          "version": "1.42.92"
+          "version": "1.42.97"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "09ddefddbb1565ceef4b44b4b6e61b1ca5f12701d1494ecc85c1133d1b1e81fb",
-              "url": "https://files.pythonhosted.org/packages/32/b8/41d4d7ba75a4fb4f11362e96371a12695bc6ba0bb7cc680137db0213f97e/botocore-1.42.92-py3-none-any.whl"
+              "hash": "77d2c8ce1bc592d3fbd7c01c35836f4a5b0cac2ca03ccdf6ffc60faa16b5fadc",
+              "url": "https://files.pythonhosted.org/packages/e3/d2/8e025ba1a4e257879af72d06913272311af79673d82fa2581a351b924317/botocore-1.42.97-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f1193d3057a2d0267353d7ef4e136be37ea432336d097fcb1951fae566ca3a22",
-              "url": "https://files.pythonhosted.org/packages/d5/0a/6785ce224ba4483b3e1282d959e1dd2c2898823336f013464c43cb154036/botocore-1.42.92.tar.gz"
+              "hash": "5c0bb00e32d16ff6d278cc8c9e10dc3672d9c1d569031635ac3c908a60de8310",
+              "url": "https://files.pythonhosted.org/packages/c6/95/c37edb602948fad2253ffd1bb3dba5b938645bd1845ee4160350136a0f41/botocore-1.42.97.tar.gz"
             }
           ],
           "project_name": "botocore",
@@ -1065,7 +1065,7 @@
             "urllib3<1.27,>=1.25.4; python_version < \"3.10\""
           ],
           "requires_python": ">=3.9",
-          "version": "1.42.92"
+          "version": "1.42.97"
         },
         {
           "artifacts": [
@@ -1112,19 +1112,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa",
-              "url": "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl"
+              "hash": "3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a",
+              "url": "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7",
-              "url": "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz"
+              "hash": "8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580",
+              "url": "https://files.pythonhosted.org/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz"
             }
           ],
           "project_name": "certifi",
           "requires_dists": [],
           "requires_python": ">=3.7",
-          "version": "2026.2.25"
+          "version": "2026.4.22"
         },
         {
           "artifacts": [
@@ -1273,159 +1273,139 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "a1529d614f44b863a7b480c6d000fe93b59acee9c82ffa027cfadc77521a9f5e",
-              "url": "https://files.pythonhosted.org/packages/41/52/a8908dcb1a389a459a29008c29966c1d552588d4ae6d43f3a1a4512e0ebe/cryptography-46.0.7-cp38-abi3-musllinux_1_2_x86_64.whl"
+              "hash": "80887c5cbd1774683cb126f0ab4184567f080071d5acf62205acb354b4b753b7",
+              "url": "https://files.pythonhosted.org/packages/70/75/158e494e4c08dc05e039da5bb48553826bd26c23930cf8d3cd5f21fa8921/cryptography-47.0.0-cp38-abi3-musllinux_1_2_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ea42cbe97209df307fdc3b155f1b6fa2577c0defa8f1f7d3be7d31d189108ad4",
-              "url": "https://files.pythonhosted.org/packages/0b/5d/4a8f770695d73be252331e60e526291e3df0c9b27556a90a6b47bccca4c2/cryptography-46.0.7-cp311-abi3-macosx_10_9_universal2.whl"
+              "hash": "1581aef4219f7ca2849d0250edaa3866212fb74bf5667284f46aa92f9e65c1ca",
+              "url": "https://files.pythonhosted.org/packages/00/68/d70c852797aa68e8e48d12e5a87170c43f67bb4a59403627259dd57d15de/cryptography-47.0.0-cp38-abi3-manylinux_2_34_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "cbd5fb06b62bd0721e1170273d3f4d5a277044c47ca27ee257025146c34cbdd1",
-              "url": "https://files.pythonhosted.org/packages/0f/54/6bbbfc5efe86f9d71041827b793c24811a017c6ac0fd12883e4caa86b8ed/cryptography-46.0.7-cp311-abi3-manylinux_2_28_ppc64le.whl"
+              "hash": "f5c15764f261394b22aef6b00252f5195f46f2ca300bec57149474e2538b31f8",
+              "url": "https://files.pythonhosted.org/packages/00/e3/b27be1a670a9b87f855d211cf0e1174a5d721216b7616bd52d8581d912ed/cryptography-47.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5d1c02a14ceb9148cc7816249f64f623fbfee39e8c03b3650d842ad3f34d637e",
-              "url": "https://files.pythonhosted.org/packages/10/f2/19ceb3b3dc14009373432af0c13f46aa08e3ce334ec6eff13492e1812ccd/cryptography-46.0.7-cp311-abi3-musllinux_1_2_x86_64.whl"
+              "hash": "07efe86201817e7d3c18781ca9770bc0db04e1e48c994be384e4602bc38f8f27",
+              "url": "https://files.pythonhosted.org/packages/01/64/d7b1e54fdb69f22d24a64bb3e88dc718b31c7fb10ef0b9691a3cf7eeea6e/cryptography-47.0.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "cdfbe22376065ffcf8be74dc9a909f032df19bc58a699456a21712d6e5eabfd0",
-              "url": "https://files.pythonhosted.org/packages/16/01/0cd51dd86ab5b9befe0d031e276510491976c3a80e9f6e31810cce46c4ad/cryptography-46.0.7-cp38-abi3-manylinux_2_31_armv7l.whl"
+              "hash": "1e47422b5557bb82d3fff997e8d92cff4e28b9789576984f08c248d2b3535d93",
+              "url": "https://files.pythonhosted.org/packages/02/e0/3d30986b30fdbd9e969abbdf8ba00ed0618615144341faeb57f395a084fe/cryptography-47.0.0-cp311-abi3-manylinux_2_31_armv7l.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "420b1e4109cc95f0e5700eed79908cef9268265c773d3a66f7af1eef53d409ef",
-              "url": "https://files.pythonhosted.org/packages/2d/cf/054b9d8220f81509939599c8bdbc0c408dbd2bdd41688616a20731371fe0/cryptography-46.0.7-cp311-abi3-manylinux_2_28_x86_64.whl"
+              "hash": "7a02675e2fabd0c0fc04c868b8781863cbf1967691543c22f5470500ff840b31",
+              "url": "https://files.pythonhosted.org/packages/14/e2/8b7462f4acf21ec509616f0245018bb197194ab0b65c2ea21a0bdd53c0eb/cryptography-47.0.0-cp38-abi3-musllinux_1_2_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8a469028a86f12eb7d2fe97162d0634026d92a21f3ae0ac87ed1c4a447886c83",
-              "url": "https://files.pythonhosted.org/packages/36/5f/313586c3be5a2fbe87e4c9a254207b860155a8e1f3cca99f9910008e7d08/cryptography-46.0.7-cp311-abi3-manylinux_2_34_aarch64.whl"
+              "hash": "ef6b3634087f18d2155b1e8ce264e5345a753da2c5fa9815e7d41315c90f8318",
+              "url": "https://files.pythonhosted.org/packages/22/22/c8ddc25de3010fc8da447648f5a092c40e7a8fadf01dd6d255d9c0b9373d/cryptography-47.0.0-cp311-abi3-musllinux_1_2_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e4cfd68c5f3e0bfdad0d38e023239b96a2fe84146481852dffbcca442c245aa5",
-              "url": "https://files.pythonhosted.org/packages/47/93/ac8f3d5ff04d54bc814e961a43ae5b0b146154c89c61b47bb07557679b18/cryptography-46.0.7.tar.gz"
+              "hash": "4e1de79e047e25d6e9f8cea71c86b4a53aced64134f0f003bbcbf3655fd172c8",
+              "url": "https://files.pythonhosted.org/packages/34/4f/e5711b28e1901f7d480a2b1b688b645aa4c77c73f10731ed17e7f7db3f0d/cryptography-47.0.0-cp311-abi3-manylinux_2_34_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5ad9ef796328c5e3c4ceed237a183f5d41d21150f972455a9d926593a1dcb308",
-              "url": "https://files.pythonhosted.org/packages/4a/9a/1765afe9f572e239c3469f2cb429f3ba7b31878c893b246b4b2994ffe2fe/cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
+              "hash": "b9a8943e359b7615db1a3ba587994618e094ff3d6fa5a390c73d079ce18b3973",
+              "url": "https://files.pythonhosted.org/packages/34/c6/2733531243fba725f58611b918056b277692f1033373dcc8bd01af1c05d4/cryptography-47.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b36a4695e29fe69215d75960b22577197aca3f7a25b9cf9d165dcfe9d80bc325",
-              "url": "https://files.pythonhosted.org/packages/5f/45/6d80dc379b0bbc1f9d1e429f42e4cb9e1d319c7a8201beffd967c516ea01/cryptography-46.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
+              "hash": "edd4da498015da5b9f26d38d3bfc2e90257bfa9cbed1f6767c282a0025ae649b",
+              "url": "https://files.pythonhosted.org/packages/4c/65/4b57bcc823f42a991627c51c2f68c9fd6eb1393c1756aac876cba2accae2/cryptography-47.0.0-cp38-abi3-manylinux_2_28_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "9694078c5d44c157ef3162e3bf3946510b857df5a3955458381d1c7cfc143ddb",
-              "url": "https://files.pythonhosted.org/packages/69/33/60dfc4595f334a2082749673386a4d05e4f0cf4df8248e63b2c3437585f2/cryptography-46.0.7-cp311-abi3-manylinux_2_34_ppc64le.whl"
+              "hash": "5d0e362ff51041b0c0d219cc7d6924d7b8996f57ce5712bdcef71eb3c65a59cc",
+              "url": "https://files.pythonhosted.org/packages/56/fc/9f1de22ff8be99d991f240a46863c52d475404c408886c5a38d2b5c3bb26/cryptography-47.0.0-cp38-abi3-manylinux_2_31_armv7l.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "935ce7e3cfdb53e3536119a542b839bb94ec1ad081013e9ab9b7cfd478b05006",
-              "url": "https://files.pythonhosted.org/packages/80/07/ad9b3c56ebb95ed2473d46df0847357e01583f4c52a85754d1a55e29e4d0/cryptography-46.0.7-cp38-abi3-manylinux_2_34_ppc64le.whl"
+              "hash": "34b4358b925a5ea3e14384ca781a2c0ef7ac219b57bb9eacc4457078e2b19f92",
+              "url": "https://files.pythonhosted.org/packages/5d/5e/13ed0cdd0eb88ba159d6dd5ebfece8cb901dbcf1ae5ac4072e28b55d3153/cryptography-47.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "128c5edfe5e5938b86b03941e94fac9ee793a94452ad1365c9fc3f4f62216832",
-              "url": "https://files.pythonhosted.org/packages/8a/6c/1a42450f464dda6ffbe578a911f773e54dd48c10f9895a23a7e88b3e7db5/cryptography-46.0.7-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
+              "hash": "0024b87d47ae2399165a6bfb20d24888881eeab83ae2566d62467c5ff0030ce7",
+              "url": "https://files.pythonhosted.org/packages/64/16/ed058e1df0f33d440217cd120d41d5dda9dd215a80b8187f68483185af82/cryptography-47.0.0-cp311-abi3-manylinux_2_28_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "73510b83623e080a2c35c62c15298096e2a5dc8d51c3b4e1740211839d0dea77",
-              "url": "https://files.pythonhosted.org/packages/8f/3e/af9246aaf23cd4ee060699adab1e47ced3f5f7e7a8ffdd339f817b446462/cryptography-46.0.7-cp311-abi3-manylinux_2_28_aarch64.whl"
+              "hash": "11dbb9f50a0f1bb9757b3d8c27c1101780efb8f0bdecfb12439c22a74d64c001",
+              "url": "https://files.pythonhosted.org/packages/66/b6/d4a68f4ea999c6d89e8498579cba1c5fcba4276284de7773b17e4fa69293/cryptography-47.0.0-cp311-abi3-musllinux_1_2_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "abad9dac36cbf55de6eb49badd4016806b3165d396f64925bf2999bcb67837ba",
-              "url": "https://files.pythonhosted.org/packages/92/49/819d6ed3a7d9349c2939f81b500a738cb733ab62fbecdbc1e38e83d45e12/cryptography-46.0.7-cp38-abi3-manylinux_2_34_aarch64.whl"
+              "hash": "256d07c78a04d6b276f5df935a9923275f53bd1522f214447fdf365494e2d515",
+              "url": "https://files.pythonhosted.org/packages/7e/b8/ac57107ef32749d2b244e36069bb688792a363aaaa3acc9e3cf84c130315/cryptography-47.0.0-cp38-abi3-manylinux_2_28_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5e51be372b26ef4ba3de3c167cd3d1022934bc838ae9eaad7e644986d2a3d163",
-              "url": "https://files.pythonhosted.org/packages/9a/92/4ed714dbe93a066dc1f4b4581a464d2d7dbec9046f7c8b7016f5286329e2/cryptography-46.0.7-cp38-abi3-manylinux_2_28_aarch64.whl"
+              "hash": "9c59ab0e0fa3a180a5a9c59f3a5abe3ef90d474bc56d7fadfbe80359491b615b",
+              "url": "https://files.pythonhosted.org/packages/81/b9/8443cfe5d17d482d348cee7048acf502bb89a51b6382f06240fd290d4ca3/cryptography-47.0.0-cp311-abi3-manylinux_2_28_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "84d4cced91f0f159a7ddacad249cc077e63195c36aac40b4150e7a57e84fffe7",
-              "url": "https://files.pythonhosted.org/packages/a5/d0/36a49f0262d2319139d2829f773f1b97ef8aef7f97e6e5bd21455e5a8fb5/cryptography-46.0.7-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
+              "hash": "a9b761f012a943b7de0e828843c5688d0de94a0578d44d6c85a1bae32f87791f",
+              "url": "https://files.pythonhosted.org/packages/86/53/5395d944dfd48cb1f67917f533c609c34347185ef15eb4308024c876f274/cryptography-47.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7bbc6ccf49d05ac8f7d7b5e2e2c33830d4fe2061def88210a126d130d7f71a85",
-              "url": "https://files.pythonhosted.org/packages/a5/ef/649750cbf96f3033c3c976e112265c33906f8e462291a33d77f90356548c/cryptography-46.0.7-cp38-abi3-musllinux_1_2_aarch64.whl"
+              "hash": "2b45761c6ec22b7c726d6a829558777e32d0f1c8be7c3f3480f9c912d5ee8a10",
+              "url": "https://files.pythonhosted.org/packages/8b/7b/cca826391fb2a94efdcdfe4631eb69306ee1cff0b22f664a412c90713877/cryptography-47.0.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "462ad5cb1c148a22b2e3bcc5ad52504dff325d17daf5df8d88c17dda1f75f2a4",
-              "url": "https://files.pythonhosted.org/packages/a7/7f/cd42fc3614386bc0c12f0cb3c4ae1fc2bbca5c9662dfed031514911d513d/cryptography-46.0.7-cp38-abi3-macosx_10_9_universal2.whl"
+              "hash": "2207a498b03275d0051589e326b79d4cf59985c99031b05bb292ac52631c37fe",
+              "url": "https://files.pythonhosted.org/packages/94/87/f2b6c374a82cf076cfa1416992ac8e8ec94d79facc37aec87c1a5cb72352/cryptography-47.0.0-cp38-abi3-manylinux_2_34_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "cdf1a610ef82abb396451862739e3fc93b071c844399e15b90726ef7470eeaf2",
-              "url": "https://files.pythonhosted.org/packages/b7/e6/a26b84096eddd51494bba19111f8fffe976f6a09f132706f8f1bf03f51f7/cryptography-46.0.7-cp38-abi3-manylinux_2_28_ppc64le.whl"
+              "hash": "160ad728f128972d362e714054f6ba0067cab7fb350c5202a9ae8ae4ce3ef1a0",
+              "url": "https://files.pythonhosted.org/packages/a4/98/40dfe932134bdcae4f6ab5927c87488754bf9eb79297d7e0070b78dd58e9/cryptography-47.0.0-cp311-abi3-macosx_10_9_universal2.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "35719dc79d4730d30f1c2b6474bd6acda36ae2dfae1e3c16f2051f215df33ce0",
-              "url": "https://files.pythonhosted.org/packages/b8/c7/201d3d58f30c4c2bdbe9b03844c291feb77c20511cc3586daf7edc12a47b/cryptography-46.0.7-cp38-abi3-manylinux_2_34_x86_64.whl"
+              "hash": "a49a3eb5341b9503fa3000a9a0db033161db90d47285291f53c2a9d2cd1b7f76",
+              "url": "https://files.pythonhosted.org/packages/a5/51/661cbee74f594c5d97ff82d34f10d5551c085ca4668645f4606ebd22bd5d/cryptography-47.0.0-cp38-abi3-manylinux_2_34_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1d25aee46d0c6f1a501adcddb2d2fee4b979381346a78558ed13e50aa8a59067",
-              "url": "https://files.pythonhosted.org/packages/c7/08/ffd537b605568a148543ac3c2b239708ae0bd635064bab41359252ef88ed/cryptography-46.0.7-cp38-abi3-manylinux_2_28_x86_64.whl"
+              "hash": "6f29f36582e6151d9686235e586dd35bb67491f024767d10b842e520dc6a07ac",
+              "url": "https://files.pythonhosted.org/packages/df/fd/32db38e3ad0cb331f0691cb4c7a8a6f176f679124dee746b3af6633db4d9/cryptography-47.0.0-cp311-abi3-manylinux_2_34_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "42a1e5f98abb6391717978baf9f90dc28a743b7d9be7f0751a6f56a75d14065b",
-              "url": "https://files.pythonhosted.org/packages/c7/0b/333ddab4270c4f5b972f980adef4faa66951a4aaf646ca067af597f15563/cryptography-46.0.7-cp311-abi3-manylinux_2_34_x86_64.whl"
+              "hash": "14432c8a9bcb37009784f9594a62fae211a2ae9543e96c92b2a8e4c3cd5cd0c4",
+              "url": "https://files.pythonhosted.org/packages/e0/34/a4fae8ae7c3bc227460c9ae43f56abf1b911da0ec29e0ebac53bb0a4b6b7/cryptography-47.0.0-cp38-abi3-macosx_10_9_universal2.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "91bbcb08347344f810cbe49065914fe048949648f6bd5c2519f34619142bbe85",
-              "url": "https://files.pythonhosted.org/packages/d2/14/633913398b43b75f1234834170947957c6b623d1701ffc7a9600da907e89/cryptography-46.0.7-cp311-abi3-musllinux_1_2_aarch64.whl"
+              "hash": "9f8e55fe4e63613a5e1cc5819030f27b97742d720203a087802ce4ce9ceb52bb",
+              "url": "https://files.pythonhosted.org/packages/ef/b2/7ffa7fe8207a8c42147ffe70c3e360b228160c1d85dc3faff16aaa3244c0/cryptography-47.0.0.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "24402210aa54baae71d99441d15bb5a1919c195398a87b563df84468160a65de",
-              "url": "https://files.pythonhosted.org/packages/f9/46/4e4e9c6040fb01c7467d47217d2f882daddeb8828f7df800cb806d8a2288/cryptography-46.0.7-cp311-abi3-manylinux_2_31_armv7l.whl"
+              "hash": "9af828c0d5a65c70ec729cd7495a4bf1a67ecb66417b8f02ff125ab8a6326a74",
+              "url": "https://files.pythonhosted.org/packages/f4/c4/2c5fbeea70adbbca2bbae865e1d605d6a4a7f8dbd9d33eaf69645087f06c/cryptography-47.0.0-cp38-abi3-manylinux_2_28_ppc64le.whl"
             }
           ],
           "project_name": "cryptography",
           "requires_dists": [
             "bcrypt>=3.1.5; extra == \"ssh\"",
-            "build>=1.0.0; extra == \"sdist\"",
-            "certifi>=2024; extra == \"test\"",
             "cffi>=1.14; python_full_version == \"3.8.*\" and platform_python_implementation != \"PyPy\"",
             "cffi>=2.0.0; python_full_version >= \"3.9\" and platform_python_implementation != \"PyPy\"",
-            "check-sdist; extra == \"pep8test\"",
-            "click>=8.0.1; extra == \"pep8test\"",
-            "cryptography-vectors==46.0.7; extra == \"test\"",
-            "mypy>=1.14; extra == \"pep8test\"",
-            "nox[uv]>=2024.4.15; extra == \"nox\"",
-            "pretend>=0.7; extra == \"test\"",
-            "pyenchant>=3; extra == \"docstest\"",
-            "pytest-benchmark>=4.0; extra == \"test\"",
-            "pytest-cov>=2.10.1; extra == \"test\"",
-            "pytest-randomly; extra == \"test-randomorder\"",
-            "pytest-xdist>=3.5.0; extra == \"test\"",
-            "pytest>=7.4.0; extra == \"test\"",
-            "readme-renderer>=30.0; extra == \"docstest\"",
-            "ruff>=0.11.11; extra == \"pep8test\"",
-            "sphinx-inline-tabs; extra == \"docs\"",
-            "sphinx-rtd-theme>=3.0.0; extra == \"docs\"",
-            "sphinx>=5.3.0; extra == \"docs\"",
-            "sphinxcontrib-spelling>=7.3.1; extra == \"docstest\"",
             "typing-extensions>=4.13.2; python_full_version < \"3.11\""
           ],
           "requires_python": "!=3.9.0,!=3.9.1,>=3.8",
-          "version": "46.0.7"
+          "version": "47.0.0"
         },
         {
           "artifacts": [
@@ -1682,13 +1662,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "40a3619d9e0cb97b018857c7986f75cf5de2e5ec0fa8a0b172d00747758f749e",
-              "url": "https://files.pythonhosted.org/packages/5d/83/860fb3075e00b0fc19a22a2301bc3c96f00437558c3911bdd0a3573a4a53/hypothesis-6.152.1-py3-none-any.whl"
+              "hash": "e730fd93c7578182efadc7f90b3c5437ee4d55edf738930eb5043c81ac1d97e8",
+              "url": "https://files.pythonhosted.org/packages/19/89/0f50dd0d92e8a7dffc24f69ab910ff81db89b2f082ba42682bd57695e4d2/hypothesis-6.152.4-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "4f4ed934eee295dd84ee97592477d23e8dc03e9f12ae0ee30a4e7c9ef3fca3b0",
-              "url": "https://files.pythonhosted.org/packages/64/b1/c32bcddb9aab9e3abc700f1f56faf14e7655c64a16ca47701a57362276ea/hypothesis-6.152.1.tar.gz"
+              "hash": "31c8f9ce619716f543e2710b489b1633c833586641d9e6c94cee03f109a5afc4",
+              "url": "https://files.pythonhosted.org/packages/fa/c7/3147bd903d6b18324a016d43a259cf5b4bb4545e1ead6773dc8a0374e70a/hypothesis-6.152.4.tar.gz"
             }
           ],
           "project_name": "hypothesis",
@@ -1732,19 +1712,19 @@
             "watchdog>=4.0.0; extra == \"watchdog\""
           ],
           "requires_python": ">=3.10",
-          "version": "6.152.1"
+          "version": "6.152.4"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "60ffaa1858fac94c9c124728c24fcde8160f3fb4a7f79aa8cdd33a9d1af60a67",
-              "url": "https://files.pythonhosted.org/packages/53/b2/acc33950394b3becb2b664741a0c0889c7ef9f9ffbfa8d47eddb53a50abd/idna-3.12-py3-none-any.whl"
+              "hash": "892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3",
+              "url": "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "724e9952cc9e2bd7550ea784adb098d837ab5267ef67a1ab9cf7846bdbdd8254",
-              "url": "https://files.pythonhosted.org/packages/22/12/2948fbe5513d062169bd91f7d7b1cd97bc8894f32946b71fa39f6e63ca0c/idna-3.12.tar.gz"
+              "hash": "585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242",
+              "url": "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz"
             }
           ],
           "project_name": "idna",
@@ -1754,7 +1734,7 @@
             "ruff>=0.6.2; extra == \"all\""
           ],
           "requires_python": ">=3.8",
-          "version": "3.12"
+          "version": "3.13"
         },
         {
           "artifacts": [
@@ -2788,8 +2768,8 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "d0936bc8758c89c404f65af56fd9a0c898e579c31d63ea13e1cbdc770e9c2447",
-              "url": "https://github.com/naccdata/redcap-api/releases/download/v0.1.5/redcap_api-0.1.5-py3-none-any.whl"
+              "hash": "e9db5166d5fb0d1567edd3da80589c8ad86ade732e4300c103ea16b370f11a77",
+              "url": "https://github.com/naccdata/redcap-api/releases/download/v0.3.0/redcap_api-0.3.0-py3-none-any.whl"
             }
           ],
           "project_name": "redcap-api",
@@ -2799,7 +2779,7 @@
             "requests>=2.18.4"
           ],
           "requires_python": "==3.12.*",
-          "version": "0.1.5"
+          "version": "0.3.0"
         },
         {
           "artifacts": [
@@ -3000,13 +2980,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "18e25d66fed509e3868dc1572b3f427ff947dd2c56f844a5bf09481ad3f3b2fe",
-              "url": "https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl"
+              "hash": "61bcd00ccb83b21a0fe7e91a553fff9729d46c83b4e0106e7c314a733891f7c2",
+              "url": "https://files.pythonhosted.org/packages/03/19/90d7d4ed51932c022d53f1d02d564b62d10e272692a1f9b76425c1ad2a02/s3transfer-0.16.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920",
-              "url": "https://files.pythonhosted.org/packages/05/04/74127fc843314818edfa81b5540e26dd537353b123a4edc563109d8f17dd/s3transfer-0.16.0.tar.gz"
+              "hash": "8e424355754b9ccb32467bdc568edf55be82692ef2002d934b1311dbb3b9e524",
+              "url": "https://files.pythonhosted.org/packages/46/29/af14f4ef3c11a50435308660e2cc68761c9a7742475e0585cd4396b91777/s3transfer-0.16.1.tar.gz"
             }
           ],
           "project_name": "s3transfer",
@@ -3015,7 +2995,7 @@
             "botocore[crt]<2.0a.0,>=1.37.4; extra == \"crt\""
           ],
           "requires_python": ">=3.9",
-          "version": "0.16.0"
+          "version": "0.16.1"
         },
         {
           "artifacts": [
@@ -3312,19 +3292,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "4b1d2be7ac37ceafd7327b961aa3a54e467efbdb563a23655fbfe0d39cfc42a9",
-              "url": "https://files.pythonhosted.org/packages/b0/70/d460bd685a170790ec89317e9bd33047988e4bce507b831f5db771e142de/tzdata-2026.1-py2.py3-none-any.whl"
+              "hash": "bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7",
+              "url": "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "67658a1903c75917309e753fdc349ac0efd8c27db7a0cb406a25be4840f87f98",
-              "url": "https://files.pythonhosted.org/packages/19/f5/cd531b2d15a671a40c0f66cf06bc3570a12cd56eef98960068ebbad1bf5a/tzdata-2026.1.tar.gz"
+              "hash": "9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10",
+              "url": "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz"
             }
           ],
           "project_name": "tzdata",
           "requires_dists": [],
           "requires_python": ">=2",
-          "version": "2026.1"
+          "version": "2026.2"
         },
         {
           "artifacts": [
@@ -3453,7 +3433,7 @@
     "pyyaml>=6.0.1",
     "ratelimit-types>=0.0.1",
     "ratelimit>=2.2.1",
-    "redcap_api@ https://github.com/naccdata/redcap-api/releases/download/v0.1.5/redcap_api-0.1.5-py3-none-any.whl",
+    "redcap_api@ https://github.com/naccdata/redcap-api/releases/download/v0.3.0/redcap_api-0.3.0-py3-none-any.whl",
     "requests-oauthlib>=2.0.0",
     "requests>=2.18.4",
     "setuptools>=68.3.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,6 @@ types-pytz
 urllib3 >= 2.2.1
 ratelimit>=2.2.1
 ratelimit-types>=0.0.1
-redcap_api@ https://github.com/naccdata/redcap-api/releases/download/v0.1.5/redcap_api-0.1.5-py3-none-any.whl
+redcap_api@ https://github.com/naccdata/redcap-api/releases/download/v0.3.0/redcap_api-0.3.0-py3-none-any.whl
 nacc_form_validator@ https://github.com/naccdata/nacc-form-validator/releases/download/v0.6.3/nacc_form_validator-0.6.3-py3-none-any.whl
 nacc_attribute_deriver@ https://github.com/naccdata/nacc-attribute-deriver/releases/download/v2.2.0/nacc_attribute_deriver-2.2.0-py3-none-any.whl


### PR DESCRIPTION
When disabling an inactive user, `__unassign_redcap_project` was calling `unassign_user_role` for every REDCap project across all centers — even projects where the user never had a role. This produced unnecessary API calls and misleading success events that inflated the admin notification email with users who didn't need any action.

Now the method checks `export_user_role_assignments` before attempting to unassign. If the user has no role mapping in the project, it skips the project entirely — no API call, no event, no entry in the email.

## Changes

- Add `user_has_role_assignment` helper in `redcap_user_operations.py`
- Add membership check to `__unassign_redcap_project` before unassign call
- Handle `REDCapConnectionError` from the membership check gracefully
- Bump `redcap_api` to 0.3.0 (adds `export_user_role_assignments` and `export_users`)
- Add bug condition exploration and preservation property tests

