### PR TITLE
identifier-provisioning: report csv header validation errors

### DIFF
--- a/docs/identifier_provisioning/CHANGELOG.md
+++ b/docs/identifier_provisioning/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this gear are documented in this file.
 
-## 2.2.2
+## 2.2.2, 2.2.3
 * Fixes a bug in reporting CSV column header errors
   
 ## 2.2.1

--- a/docs/identifier_provisioning/CHANGELOG.md
+++ b/docs/identifier_provisioning/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this gear are documented in this file.
 
+## 2.2.2
+* Fixes a bug in reporting CSV column header errors
+  
 ## 2.2.1
 * Adds enrollment project URL to transfer request notification
   

--- a/gear/identifier_provisioning/src/docker/BUILD
+++ b/gear/identifier_provisioning/src/docker/BUILD
@@ -7,5 +7,5 @@ docker_image(
         ":manifest",
         "gear/identifier_provisioning/src/python/identifier_provisioning_app:bin",
     ],
-    image_tags=["2.2.2", "latest"],
+    image_tags=["2.2.3", "latest"],
 )

--- a/gear/identifier_provisioning/src/docker/BUILD
+++ b/gear/identifier_provisioning/src/docker/BUILD
@@ -7,5 +7,5 @@ docker_image(
         ":manifest",
         "gear/identifier_provisioning/src/python/identifier_provisioning_app:bin",
     ],
-    image_tags=["2.2.1", "latest"],
+    image_tags=["2.2.2", "latest"],
 )

--- a/gear/identifier_provisioning/src/docker/manifest.json
+++ b/gear/identifier_provisioning/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "identifier-provisioning",
     "label": "Identifier Provisioning",
     "description": "Gear for provisioning NACCIDs from Enrollment forms",
-    "version": "2.2.2",
+    "version": "2.2.3",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/identifier-provisioning:2.2.2"
+            "image": "naccdata/identifier-provisioning:2.2.3"
         },
         "flywheel": {
             "suite": "NACC Admin Gears",

--- a/gear/identifier_provisioning/src/docker/manifest.json
+++ b/gear/identifier_provisioning/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "identifier-provisioning",
     "label": "Identifier Provisioning",
     "description": "Gear for provisioning NACCIDs from Enrollment forms",
-    "version": "2.2.1",
+    "version": "2.2.2",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/identifier-provisioning:2.2.1"
+            "image": "naccdata/identifier-provisioning:2.2.2"
         },
         "flywheel": {
             "suite": "NACC Admin Gears",

--- a/gear/identifier_provisioning/src/python/identifier_provisioning_app/main.py
+++ b/gear/identifier_provisioning/src/python/identifier_provisioning_app/main.py
@@ -51,7 +51,6 @@ from outputs.errors import (
     existing_participant_error,
     identifier_error,
     missing_field_error,
-    partially_failed_file_error,
     system_error,
     unexpected_value_error,
 )
@@ -876,10 +875,7 @@ def run(
         )
 
         if not success:
-            log.warning(
-                "Some records in the input file failed validation. "
-                "Check record level QC status."
-            )
+            log.warning("Some records in the input file failed validation.")
 
         log.info(
             "Requesting new NACCIDs for %s successfully validated records",
@@ -990,9 +986,5 @@ def run(
             transfer_ptids=list(transfer_info.transfers.keys()),
             project_url=project_url,
         )
-
-    if not success:
-        error_writer.clear()
-        error_writer.write(partially_failed_file_error())
 
     return success

--- a/gear/identifier_provisioning/src/python/identifier_provisioning_app/main.py
+++ b/gear/identifier_provisioning/src/python/identifier_provisioning_app/main.py
@@ -681,6 +681,7 @@ class ProvisioningVisitor(CSVVisitor):
             date_field=FieldNames.ENRLFRM_DATE,
             error_writer=error_writer,
         )
+        self.__header: Optional[List[str]] = None
 
     def visit_header(self, header: List[str]) -> bool:
         """Prepares visitor to work with CSV file with given header.
@@ -700,9 +701,9 @@ class ProvisioningVisitor(CSVVisitor):
             self.__error_writer.write(missing_field_error(expected_columns))
             return False
 
-        return self.__enrollment_visitor.visit_header(
-            header
-        ) and self.__transfer_in_visitor.visit_header(header)
+        self.__header = header
+
+        return True
 
     def visit_row(self, row: Dict[str, Any], line_num: int) -> bool:
         """Provisions a NACCID for the ADCID and PTID.
@@ -737,11 +738,21 @@ class ProvisioningVisitor(CSVVisitor):
             )
             return False
 
+        # required columns depends on whether it's a new enrollment or transfer
+        # do the custom header validation here instead of visit_header method
+        # record level error log is created at this point by form-qc-checker gear
+        # update the record level error log at header validation failure
+        #   to prevent the status from being stuck at processing
+        success = False
         if is_new_enrollment(row):
             try:
-                success = self.__enrollment_visitor.visit_row(
-                    row=row, line_num=line_num
-                )
+                if self.__header and self.__enrollment_visitor.visit_header(
+                    self.__header
+                ):
+                    success = self.__enrollment_visitor.visit_row(
+                        row=row, line_num=line_num
+                    )
+
                 if not success:  # Only update record level log if validation failed
                     update_record_level_error_log(
                         input_record=row,
@@ -750,6 +761,7 @@ class ProvisioningVisitor(CSVVisitor):
                         gear_name=self.__gear_name,
                         errors=self.__error_writer.errors(),
                     )
+
                 return success
             except IdentifierRepositoryError as error:
                 message = (
@@ -778,7 +790,8 @@ class ProvisioningVisitor(CSVVisitor):
                 )
                 return False
 
-        success = self.__transfer_in_visitor.visit_row(row=row, line_num=line_num)
+        if self.__header and self.__transfer_in_visitor.visit_header(self.__header):
+            success = self.__transfer_in_visitor.visit_row(row=row, line_num=line_num)
 
         # Update visit level log for the transfer request
         update_record_level_error_log(

--- a/gear/identifier_provisioning/src/python/identifier_provisioning_app/run.py
+++ b/gear/identifier_provisioning/src/python/identifier_provisioning_app/run.py
@@ -136,14 +136,55 @@ class IdentifierProvisioningVisitor(GearExecutionEnvironment):
                 project_url=project_url,
             )
 
-            context.metadata.add_qc_result(
-                self.__file_input.file_input,
-                name="validation",
-                state="PASS" if success else "FAIL",
-                data=error_writer.errors().model_dump(by_alias=True),
-            )
+        self.__update_csv_file_metadata(
+            context=context,
+            project=project,
+            success=success,
+            error_writer=error_writer,
+            gear_name=gear_name,
+        )
 
-            context.metadata.add_file_tags(self.__file_input.file_input, tags=gear_name)
+    def __update_csv_file_metadata(
+        self,
+        *,
+        context: GearContext,
+        project: ProjectAdaptor,
+        success: bool,
+        error_writer: ListErrorWriter,
+        gear_name: str,
+    ) -> None:
+        """Adds QC metadata to the original CSV file. The gear's input is the.
+
+        <filename>_provisioning.csv file created by form-qc-checker. This
+        method finds the original CSV and writes the file-level QC metadata there
+        instead.
+
+        Args:
+            context: Flywheel gear context
+            project: Flywheel project adaptor
+            success: Gear success or failure
+            error_writer: Error writer object that stored processing errors
+            gear_name: Provisioning gear name
+        """
+        filename = Path(self.__file_input.filename)
+        original_stem = filename.stem.removesuffix(f"_{DefaultValues.PROV_SUFFIX}")
+        original_filename = f"{original_stem}{filename.suffix}"
+
+        input_file = project.get_file(original_filename)
+        if not input_file:
+            log.warning(
+                f"Could not find original CSV file {original_filename} to ",
+                f"update QC metadata, updating {self.__file_input.filename} instead",
+            )
+            input_file = self.__file_input.file_input
+
+        context.metadata.add_qc_result(
+            input_file,
+            name="validation",
+            state="PASS" if success else "FAIL",
+            data=error_writer.errors().model_dump(by_alias=True),
+        )
+        context.metadata.add_file_tags(input_file, tags=gear_name)
 
 
 def main():

--- a/gear/identifier_provisioning/src/python/identifier_provisioning_app/run.py
+++ b/gear/identifier_provisioning/src/python/identifier_provisioning_app/run.py
@@ -37,12 +37,10 @@ class IdentifierProvisioningVisitor(GearExecutionEnvironment):
     def __init__(
         self,
         client: ClientWrapper,
-        admin_id: str,
         file_input: InputFileWrapper,
         identifiers_mode: IdentifiersMode,
     ) -> None:
         super().__init__(client=client)
-        self.__admin_id = admin_id
         self.__file_input = file_input
         self.__identifiers_mode: IdentifiersMode = identifiers_mode
 
@@ -59,7 +57,6 @@ class IdentifierProvisioningVisitor(GearExecutionEnvironment):
         options = context.config.opts
         return IdentifierProvisioningVisitor(
             client=client,
-            admin_id=options.get("admin_group", DefaultValues.NACC_GROUP_ID),
             file_input=file_input,
             identifiers_mode=options.get("database_mode", "prod"),
         )

--- a/gear/identifier_provisioning/src/python/identifier_provisioning_app/run.py
+++ b/gear/identifier_provisioning/src/python/identifier_provisioning_app/run.py
@@ -173,7 +173,7 @@ class IdentifierProvisioningVisitor(GearExecutionEnvironment):
                 f"Could not find original CSV file {original_filename} to ",
                 f"update QC metadata, updating {self.__file_input.filename} instead",
             )
-            input_file = self.__file_input.file_input
+            input_file = self.__file_input.file_input # type: ignore
 
         context.metadata.add_qc_result(
             input_file,

--- a/gear/identifier_provisioning/src/python/identifier_provisioning_app/run.py
+++ b/gear/identifier_provisioning/src/python/identifier_provisioning_app/run.py
@@ -173,7 +173,7 @@ class IdentifierProvisioningVisitor(GearExecutionEnvironment):
                 f"Could not find original CSV file {original_filename} to ",
                 f"update QC metadata, updating {self.__file_input.filename} instead",
             )
-            input_file = self.__file_input.file_input # type: ignore
+            input_file = self.__file_input.file_input  # type: ignore
 
         context.metadata.add_qc_result(
             input_file,


### PR DESCRIPTION
Surface the identifier-provisioning workflow specific header validation errors that were hidden at CSV file level. 
Add those to record level error log to prevent the QC status being stuck at "processing"