### PR TITLE
Add authorization client library with SigV4 transport

### DIFF
--- a/.kiro/specs/authorization-client-library/.config.kiro
+++ b/.kiro/specs/authorization-client-library/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "3012e30c-f7a4-4595-beb6-df8a924910e2", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/authorization-client-library/design.md
+++ b/.kiro/specs/authorization-client-library/design.md
@@ -1,0 +1,478 @@
+# Design Document
+
+## Overview
+
+The Authorization Client Library is a shared Python package at `common/src/python/authorization/` that provides a typed, idempotent interface to the NACC Authorization API. It abstracts HTTP transport, SigV4 signing, retry logic, and batch chunking behind a clean Python API.
+
+The library follows the dependency injection pattern established in the codebase (see `LambdaClient` in `common/src/python/lambdas/`): the HTTP transport layer is injected at construction time, making the client fully testable with mocked responses.
+
+### Design Decisions
+
+1. **Protocol-based transport abstraction**: Use a Python `Protocol` to define the HTTP transport interface rather than coupling to `requests` or `boto3` directly. This enables test doubles without monkey-patching.
+
+2. **Pydantic models for all payloads**: Every request and response is a Pydantic v2 `BaseModel`. This gives validation, serialization, and IDE support for free.
+
+3. **Idempotent by default**: The client treats 409 on grant and 404 on revoke as success — callers never need to handle "already exists" logic.
+
+4. **Transparent batch chunking**: The `batch()` method accepts any number of operations and automatically splits into chunks of ≤100, aggregating results across chunks.
+
+5. **Retry only on 503**: Exponential backoff is applied exclusively to 503 (service unavailable). All other errors fail immediately. This matches the API's documented behavior.
+
+6. **No gear dependencies**: The library imports only standard library, `pydantic`, `boto3`/`botocore` (for SigV4), and `requests`. It is usable by any gear or script.
+
+## Architecture
+
+```mermaid
+graph TD
+    subgraph "Gear / Script"
+        A[Caller Code]
+    end
+
+    subgraph "authorization package"
+        B[AuthorizationClient]
+        C[Models<br/>Pydantic request/response]
+        D[Transport Protocol]
+        E[SigV4Transport<br/>production implementation]
+        F[Retry Logic]
+    end
+
+    subgraph "External"
+        G[Authorization API<br/>AWS Lambda + API Gateway]
+    end
+
+    A --> B
+    B --> C
+    B --> F
+    F --> D
+    D -.-> E
+    E --> G
+```
+
+The `AuthorizationClient` is the public entry point. It constructs typed request models, delegates HTTP calls through the injected transport (with retry wrapping), and parses responses into typed result models.
+
+For testing, callers inject a mock transport that returns pre-built responses without network calls.
+
+## Components and Interfaces
+
+### Transport Protocol
+
+```python
+from typing import Protocol
+
+class HttpResponse(Protocol):
+    """Minimal response interface returned by transport."""
+    @property
+    def status_code(self) -> int: ...
+    @property
+    def body(self) -> bytes: ...
+
+class HttpTransport(Protocol):
+    """Abstract HTTP transport for the Authorization API."""
+    def request(
+        self,
+        method: str,
+        path: str,
+        body: bytes | None = None,
+        query_params: dict[str, str] | None = None,
+    ) -> HttpResponse: ...
+```
+
+### SigV4Transport (Production Implementation)
+
+```python
+class SigV4Transport:
+    """HTTP transport that signs requests with AWS SigV4."""
+
+    def __init__(self, base_url: str, region: str | None = None):
+        ...
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        body: bytes | None = None,
+        query_params: dict[str, str] | None = None,
+    ) -> HttpResponse:
+        ...
+```
+
+Uses `botocore.auth.SigV4Auth` with the standard credential chain to sign each request against the `execute-api` service.
+
+### AuthorizationClient
+
+```python
+class AuthorizationClient:
+    """Client for the NACC Authorization API."""
+
+    def __init__(
+        self,
+        transport: HttpTransport,
+        max_retries: int = 3,
+        base_backoff: float = 1.0,
+    ):
+        ...
+
+    def grant(
+        self,
+        user_id: str,
+        resource_type: str,
+        resource_id: str,
+        relation: str,
+    ) -> GrantResult: ...
+
+    def revoke(
+        self,
+        user_id: str,
+        resource_type: str,
+        resource_id: str,
+        relation: str,
+    ) -> RevokeResult: ...
+
+    def batch(
+        self,
+        operations: list[BatchOperation],
+    ) -> BatchResult: ...
+
+    def get_user_permissions(
+        self,
+        user_id: str,
+        type_filter: str | None = None,
+        relation_filter: str | None = None,
+    ) -> UserPermissions: ...
+
+    def set_resource_parents(
+        self,
+        resource_type: str,
+        resource_id: str,
+        parents: list[ParentRelationship],
+    ) -> ResourceParents: ...
+
+    def health_check(self) -> HealthResult: ...
+```
+
+### Factory Function
+
+```python
+def create_authorization_client(
+    base_url: str | None = None,
+    max_retries: int = 3,
+    base_backoff: float = 1.0,
+) -> AuthorizationClient:
+    """Create an AuthorizationClient with SigV4 transport.
+
+    Args:
+        base_url: API base URL. Falls back to AUTHORIZATION_API_URL env var.
+        max_retries: Maximum retry attempts on 503.
+        base_backoff: Base delay in seconds for exponential backoff.
+
+    Raises:
+        ConfigurationError: If no base URL is resolvable.
+    """
+    ...
+```
+
+## Data Models
+
+### Request Models
+
+```python
+class GrantRequest(BaseModel):
+    user_id: str = Field(alias="userId")
+    relation: str
+    type: str
+    resource_id: str = Field(alias="resourceId")
+
+class RevokeRequest(BaseModel):
+    user_id: str = Field(alias="userId")
+    relation: str
+    type: str
+    resource_id: str = Field(alias="resourceId")
+
+class BatchOperationModel(BaseModel):
+    action: Literal["grant", "revoke"]
+    user_id: str = Field(alias="userId")
+    relation: str
+    type: str
+    resource_id: str = Field(alias="resourceId")
+
+class BatchRequestModel(BaseModel):
+    operations: list[BatchOperationModel]
+
+class SetParentsRequestModel(BaseModel):
+    parents: list[ParentRelationshipModel]
+
+class ParentRelationshipModel(BaseModel):
+    structural_relation: str = Field(alias="structuralRelation")
+    parent_type: str = Field(alias="parentType")
+    parent_id: str = Field(alias="parentId")
+
+class PermissionCheckRequestModel(BaseModel):
+    user_id: str = Field(alias="userId")
+    relation: str
+    type: str
+    resource_id: str = Field(alias="resourceId")
+```
+
+### Response Models
+
+```python
+class GrantResult(BaseModel):
+    user_id: str = Field(alias="userId")
+    relation: str
+    type: str
+    resource_id: str = Field(alias="resourceId")
+
+class RevokeResult(BaseModel):
+    user_id: str = Field(alias="userId")
+    relation: str
+    type: str
+    resource_id: str = Field(alias="resourceId")
+
+class BatchError(BaseModel):
+    index: int
+    error: str
+    message: str
+
+class BatchResult(BaseModel):
+    total: int
+    succeeded: int
+    failed: int
+    errors: list[BatchError] = []
+
+class InheritanceSource(BaseModel):
+    parent_type: str = Field(alias="parentType")
+    parent_id: str = Field(alias="parentId")
+    parent_role: str = Field(alias="parentRole")
+
+class PermissionEntry(BaseModel):
+    resource_id: str = Field(alias="resourceId")
+    relation: str
+    access: Literal["direct", "inherited", "both"]
+    inherited_from: InheritanceSource | None = Field(
+        default=None, alias="inheritedFrom"
+    )
+
+class UserPermissions(BaseModel):
+    user_id: str = Field(alias="userId")
+    permissions: dict[str, list[PermissionEntry]]
+
+class ParentRelationship(BaseModel):
+    structural_relation: str = Field(alias="structuralRelation")
+    parent_type: str = Field(alias="parentType")
+    parent_id: str = Field(alias="parentId")
+
+class ResourceParents(BaseModel):
+    type: str
+    resource_id: str = Field(alias="resourceId")
+    parents: list[ParentRelationship]
+
+class HealthResult(BaseModel):
+    status: Literal["healthy", "degraded", "unhealthy"]
+    authorization_engine: Literal["connected", "unreachable"] | None = Field(
+        default=None, alias="authorizationEngine"
+    )
+
+class ErrorResponse(BaseModel):
+    error: str
+    message: str
+    details: dict | None = None
+```
+
+### Domain Types (used by callers)
+
+```python
+class BatchOperation(BaseModel):
+    """A single grant or revoke operation for batch submission."""
+    action: Literal["grant", "revoke"]
+    user_id: str
+    resource_type: str
+    resource_id: str
+    relation: str
+```
+
+### Exceptions
+
+```python
+class AuthorizationClientError(Exception):
+    """Base exception for authorization client errors."""
+
+class ConfigurationError(AuthorizationClientError):
+    """Raised when the client cannot be configured (e.g., missing base URL)."""
+
+class ValidationError(AuthorizationClientError):
+    """Raised when the API returns 400 (validation error)."""
+    def __init__(self, message: str, details: dict | None = None): ...
+
+class ServiceUnavailableError(AuthorizationClientError):
+    """Raised when retries are exhausted on 503."""
+
+class UnexpectedError(AuthorizationClientError):
+    """Raised on unexpected HTTP errors (non-retriable 4xx/5xx)."""
+    def __init__(self, status_code: int, message: str): ...
+
+class ParseError(AuthorizationClientError):
+    """Raised when a response body cannot be parsed into the expected model."""
+    def __init__(self, message: str, raw_content: bytes): ...
+```
+
+
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: Request construction correctness
+
+*For any* valid operation (grant, revoke, get_user_permissions, set_resource_parents) with any valid combination of parameters, the client SHALL construct an HTTP request with the correct method, path, and JSON body containing all provided fields.
+
+**Validates: Requirements 2.1, 3.1, 5.1, 6.1**
+
+### Property 2: Response model round-trip
+
+*For any* valid response model instance (GrantResult, RevokeResult, UserPermissions, ResourceParents, BatchResult), serializing to JSON and parsing back SHALL produce an equivalent model instance.
+
+**Validates: Requirements 2.2, 3.2, 5.2, 6.2, 9.2**
+
+### Property 3: Idempotent status codes yield success
+
+*For any* grant request that receives HTTP 409, or any revoke request that receives HTTP 404, the client SHALL return a success result (not raise an exception).
+
+**Validates: Requirements 2.3, 3.3**
+
+### Property 4: Validation errors propagate message
+
+*For any* API response with HTTP 400 containing an error message, the client SHALL raise a ValidationError whose message matches the API error message.
+
+**Validates: Requirements 2.4, 3.4, 4.6, 6.3**
+
+### Property 5: Retry on 503 with exponential backoff
+
+*For any* request that receives HTTP 503 responses, the client SHALL retry up to max_retries times with delays following the pattern base_backoff × 2^(attempt-1), then raise ServiceUnavailableError if all retries are exhausted.
+
+**Validates: Requirements 2.5, 3.5, 5.3, 6.4, 8.1, 8.2**
+
+### Property 6: Immediate failure on non-retriable errors
+
+*For any* HTTP status code that is not 503 and not an idempotent success code (409 for grant, 404 for revoke) and not 200/201, the client SHALL raise an error on the first attempt without retrying.
+
+**Validates: Requirements 2.6, 3.6, 5.4, 6.5, 8.4**
+
+### Property 7: Batch chunking respects size limit
+
+*For any* list of N batch operations, the client SHALL send exactly ⌈N/100⌉ HTTP requests, each containing at most 100 operations.
+
+**Validates: Requirements 4.1, 4.2**
+
+### Property 8: Batch chunking preserves order
+
+*For any* list of batch operations, the concatenation of operations across all chunks (in chunk order) SHALL equal the original list.
+
+**Validates: Requirements 4.3**
+
+### Property 9: Batch result aggregation
+
+*For any* multi-chunk batch execution with mixed per-operation outcomes, the aggregate BatchResult SHALL have total equal to the sum of all chunk totals, succeeded equal to the sum of chunk successes plus idempotent errors (conflict, not_found), and failed equal to only non-idempotent failures.
+
+**Validates: Requirements 4.4, 4.7**
+
+### Property 10: Malformed response raises ParseError with raw content
+
+*For any* response body that does not conform to the expected JSON schema, the client SHALL raise a ParseError whose raw_content attribute contains the original response bytes.
+
+**Validates: Requirements 9.3**
+
+## Error Handling
+
+### Error Classification
+
+| HTTP Status | Context | Client Behavior |
+|---|---|---|
+| 200, 201 | Any | Return typed success result |
+| 400 | Any | Raise `ValidationError` with API message |
+| 404 | Revoke only | Return success (idempotent) |
+| 404 | Other endpoints | Raise `UnexpectedError` |
+| 409 | Grant only | Return success (idempotent) |
+| 409 | Other endpoints | Raise `UnexpectedError` |
+| 503 | Any (except health) | Retry with exponential backoff |
+| 503 | Health check | Return `HealthResult(status="unhealthy")` |
+| Other 4xx/5xx | Any | Raise `UnexpectedError` immediately |
+
+### Retry Strategy
+
+```
+delay(attempt) = base_backoff × 2^(attempt - 1)
+```
+
+- Default `base_backoff`: 1.0 seconds
+- Default `max_retries`: 3
+- Delays: 1s, 2s, 4s (then fail)
+- Only triggered by HTTP 503
+- Each retry is logged at WARNING level
+
+### Response Parsing Failures
+
+If a successful HTTP response (200/201) contains a body that cannot be parsed into the expected Pydantic model, the client raises `ParseError` with the raw bytes. This distinguishes API contract violations from network/auth errors.
+
+### Batch Error Handling
+
+Batch operations have two error modes:
+
+1. **Validation rejection (400)**: The entire batch is rejected before execution. The client raises `ValidationError`.
+2. **Per-operation failures**: Individual operations may fail during execution. The client classifies each:
+   - `conflict` / `not_found` → idempotent success (counted in `succeeded`)
+   - `service_unavailable` → retriable failure (reported in errors with retriable flag)
+   - Other → non-retriable failure (reported in errors)
+
+## Testing Strategy
+
+### Property-Based Testing
+
+This feature is well-suited for property-based testing because:
+- The client has clear input/output behavior (parameters → HTTP request; HTTP response → typed result)
+- Universal properties hold across a wide input space (any valid user_id, resource_type, etc.)
+- The transport protocol abstraction makes it cost-effective to run 100+ iterations (no real HTTP calls)
+
+**Library**: `hypothesis` (already in project dependencies)
+
+**Configuration**:
+- Minimum 100 examples per property test
+- Each test tagged with: `Feature: authorization-client-library, Property {N}: {title}`
+
+**Generators needed**:
+- Valid user IDs (non-empty strings, alphanumeric + common separators)
+- Valid resource types (from the known set: study, research_center, community, data_pipeline, dashboard, page)
+- Valid resource IDs (non-empty strings)
+- Valid relations (from the known set per type)
+- Batch operation lists (1-500 items)
+- HTTP status codes (partitioned into retriable, idempotent, and unexpected)
+- Valid/invalid JSON response bodies
+
+### Unit Tests (Example-Based)
+
+- Client instantiation with explicit URL, env var fallback, and missing URL
+- Health check request construction and response parsing
+- Logging behavior (debug for success, warning for retry, error for failures)
+- Retry logging includes attempt number and wait duration
+- `service_unavailable` errors in batch responses flagged as retriable
+
+### Integration Tests
+
+- SigV4 signing produces valid Authorization headers (using moto or botocore test utilities)
+- End-to-end flow with a mock HTTP server (optional, for confidence)
+
+### Test Organization
+
+```
+common/test/python/authorization_test/
+├── __init__.py
+├── conftest.py              # Shared fixtures, mock transport, generators
+├── test_client_grant.py     # Grant operation tests
+├── test_client_revoke.py    # Revoke operation tests
+├── test_client_batch.py     # Batch operation tests
+├── test_client_query.py     # Permissions query tests
+├── test_client_parents.py   # Set parents tests
+├── test_client_health.py    # Health check tests
+├── test_retry.py            # Retry behavior tests
+├── test_models.py           # Pydantic model round-trip tests
+└── test_transport.py        # SigV4Transport tests
+```

--- a/.kiro/specs/authorization-client-library/openapi.yaml
+++ b/.kiro/specs/authorization-client-library/openapi.yaml
@@ -1,0 +1,1015 @@
+openapi: 3.1.0
+info:
+  title: NACC Authorization API
+  version: 1.0.0
+  description: |
+    Domain-level REST interface to the NACC authorization system.
+    
+    This API provides authorization operations in NACC domain terms — granting access,
+    querying permissions, checking authorization, and managing resource hierarchy.
+    The underlying authorization engine (OpenFGA) is an implementation detail;
+    consumers interact only with this API.
+    
+    See ADR-008 for the architectural decision and rationale.
+  contact:
+    name: NACC Development Team
+
+servers:
+  - url: https://{environment}.api.nacc.example/authorization
+    description: NACC Authorization API
+    variables:
+      environment:
+        default: dev
+        enum: [dev, staging, prod]
+
+tags:
+  - name: Model
+    description: Authorization model metadata — resource types, relations, hierarchy rules, and computed permissions.
+  - name: Permissions
+    description: Query what access exists — user permissions, resource access, and authorization checks.
+  - name: Access Management
+    description: Grant and revoke access to resources and organizations.
+  - name: Resource Hierarchy
+    description: Manage parent relationships that define the resource hierarchy and enable inherited permissions.
+  - name: Batch Operations
+    description: Bulk grant and revoke operations for data loading and synchronization.
+  - name: Health
+    description: Operational health checks.
+
+paths:
+  # ---------------------------------------------------------------------------
+  # Model
+  # ---------------------------------------------------------------------------
+  /model:
+    get:
+      operationId: getModel
+      summary: Get authorization model metadata
+      description: |
+        Returns the complete authorization model: all organization types, resource types,
+        their relations, categories, structural relations, computed relations, and valid
+        parent combinations.
+        
+        This is the single source of truth for authorization model semantics. Consumers
+        use this to populate UI dropdowns, validate inputs client-side, and understand
+        the permission structure.
+      tags: [Model]
+      responses:
+        "200":
+          description: Authorization model metadata.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthorizationModel"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+  /model/types/{type}:
+    get:
+      operationId: getTypeMetadata
+      summary: Get metadata for a specific type
+      description: |
+        Returns metadata for a single organization or resource type, including its
+        relations, category, structural relations, computed relations, and valid
+        parent combinations.
+      tags: [Model]
+      parameters:
+        - $ref: "#/components/parameters/TypePath"
+      responses:
+        "200":
+          description: Type metadata.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TypeMetadata"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  # ---------------------------------------------------------------------------
+  # Permissions
+  # ---------------------------------------------------------------------------
+  /users/{userId}/permissions:
+    get:
+      operationId: getUserPermissions
+      summary: Get all permissions for a user
+      description: |
+        Returns every resource and organization a user can access, grouped by type.
+        Each entry includes the relation and whether the access is direct, inherited,
+        or both.
+        
+        For inherited permissions, the response includes the inheritance source —
+        which parent organization and role grants the access (e.g., "inherited from
+        admin role on study:study1").
+        
+        This is the primary endpoint Portal uses to render what a user can see.
+      tags: [Permissions]
+      parameters:
+        - $ref: "#/components/parameters/UserIdPath"
+        - name: type
+          in: query
+          description: Filter results to a specific resource or organization type.
+          schema:
+            type: string
+            example: data_pipeline
+        - name: relation
+          in: query
+          description: Filter results to a specific relation.
+          schema:
+            type: string
+            example: viewer
+      responses:
+        "200":
+          description: User permissions grouped by type.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserPermissions"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+
+  /resources/{type}/{resourceId}/access:
+    get:
+      operationId: getResourceAccess
+      summary: Get all users with access to a resource
+      description: |
+        Returns all users who have access to the specified resource, with their
+        relation and whether access is direct, inherited, or both.
+        
+        For inherited access, includes the source (parent organization and role).
+        This is the endpoint the Authorization Interface uses for the resource
+        access view.
+      tags: [Permissions]
+      parameters:
+        - $ref: "#/components/parameters/TypePath"
+        - $ref: "#/components/parameters/ResourceIdPath"
+        - name: relation
+          in: query
+          description: Filter to a specific relation.
+          schema:
+            type: string
+            example: viewer
+      responses:
+        "200":
+          description: Users with access to the resource.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResourceAccessList"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /check:
+    post:
+      operationId: checkPermission
+      summary: Check whether a user has a specific permission
+      description: |
+        Returns whether the specified user has the specified relation on the
+        specified resource. Validates that the resource type and relation are
+        valid per the authorization model before evaluating.
+        
+        Use this for real-time authorization decisions (e.g., "can this user
+        view this dashboard?").
+      tags: [Permissions]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PermissionCheckRequest"
+      responses:
+        "200":
+          description: Permission check result.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PermissionCheckResponse"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+
+  /users/{userId}/effective-permissions/{type}/{resourceId}:
+    get:
+      operationId: getEffectivePermissions
+      summary: Get all effective relations a user has on a resource
+      description: |
+        Returns all relations the user effectively holds on the specified resource,
+        including both direct and inherited. This answers "what can this user do
+        on this resource?" without requiring the caller to check each relation
+        individually.
+      tags: [Permissions]
+      parameters:
+        - $ref: "#/components/parameters/UserIdPath"
+        - $ref: "#/components/parameters/TypePath"
+        - $ref: "#/components/parameters/ResourceIdPath"
+      responses:
+        "200":
+          description: Effective permissions on the resource.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EffectivePermissions"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+
+  # ---------------------------------------------------------------------------
+  # Access Management
+  # ---------------------------------------------------------------------------
+  /grants:
+    post:
+      operationId: grantAccess
+      summary: Grant a user access to a resource or organization
+      description: |
+        Grants the specified user the specified relation on the specified resource
+        or organization. Validates that:
+        - The type exists in the authorization model
+        - The relation is user-assignable for that type (not a computed or structural relation)
+        - The user and resource IDs are well-formed
+        
+        Returns 409 if the grant already exists (idempotent consumers should treat
+        409 as success).
+      tags: [Access Management]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/GrantRequest"
+      responses:
+        "201":
+          description: Access granted.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GrantResponse"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "409":
+          description: Grant already exists.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+    delete:
+      operationId: revokeAccess
+      summary: Revoke a user's access to a resource or organization
+      description: |
+        Revokes the specified user's relation on the specified resource or
+        organization. Same validation as grant.
+        
+        Returns 404 if the grant does not exist.
+      tags: [Access Management]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RevokeRequest"
+      responses:
+        "200":
+          description: Access revoked.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RevokeResponse"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  # ---------------------------------------------------------------------------
+  # Resource Hierarchy
+  # ---------------------------------------------------------------------------
+  /resources/{type}/{resourceId}/parents:
+    get:
+      operationId: getResourceParents
+      summary: Get the parent organizations of a resource
+      description: |
+        Returns the current parent relationships for a resource — which study,
+        research center, or community it is linked to. This defines the resource's
+        position in the hierarchy and determines inherited permissions.
+      tags: [Resource Hierarchy]
+      parameters:
+        - $ref: "#/components/parameters/TypePath"
+        - $ref: "#/components/parameters/ResourceIdPath"
+      responses:
+        "200":
+          description: Parent relationships for the resource.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResourceParents"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+
+    put:
+      operationId: setResourceParents
+      summary: Set the parent organizations of a resource
+      description: |
+        Sets the parent relationships for a resource, replacing any existing parents.
+        Validates that:
+        - The structural relation is valid for the resource type
+        - The parent type matches the expected type for that structural relation
+        - The combination of parents is valid per the authorization model
+        
+        This is the primary way to place a resource in the hierarchy. For example,
+        linking a data pipeline to its parent study and center, or linking a
+        dashboard to its parent community.
+      tags: [Resource Hierarchy]
+      parameters:
+        - $ref: "#/components/parameters/TypePath"
+        - $ref: "#/components/parameters/ResourceIdPath"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SetParentsRequest"
+      responses:
+        "200":
+          description: Parents set successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResourceParents"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+
+    delete:
+      operationId: removeResourceParents
+      summary: Remove all parent relationships from a resource
+      description: |
+        Removes all parent relationships from a resource, effectively unlinking it
+        from the hierarchy. This removes any inherited permissions that flowed
+        through those parent relationships.
+        
+        Use with caution — this will immediately revoke inherited access for all
+        users who had it through the hierarchy.
+      tags: [Resource Hierarchy]
+      parameters:
+        - $ref: "#/components/parameters/TypePath"
+        - $ref: "#/components/parameters/ResourceIdPath"
+      responses:
+        "200":
+          description: Parents removed.
+        "400":
+          $ref: "#/components/responses/ValidationError"
+
+  # ---------------------------------------------------------------------------
+  # Batch Operations
+  # ---------------------------------------------------------------------------
+  /grants/batch:
+    post:
+      operationId: batchModifyAccess
+      summary: Grant and/or revoke access in bulk
+      description: |
+        Accepts a list of grant and/or revoke operations (up to 100 per request).
+        Each operation is validated individually. The entire batch is rejected if
+        any operation fails validation (all-or-nothing semantics).
+        
+        Returns a summary of results. Designed for data loading scripts and
+        synchronization workflows.
+      tags: [Batch Operations]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BatchRequest"
+      responses:
+        "200":
+          description: Batch completed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BatchResponse"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+
+  # ---------------------------------------------------------------------------
+  # Health
+  # ---------------------------------------------------------------------------
+  /health:
+    get:
+      operationId: healthCheck
+      summary: Health check
+      description: |
+        Returns the health status of the API, including connectivity to the
+        authorization engine.
+      tags: [Health]
+      responses:
+        "200":
+          description: Service is healthy.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HealthResponse"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+# =============================================================================
+# Components
+# =============================================================================
+components:
+
+  # ---------------------------------------------------------------------------
+  # Parameters
+  # ---------------------------------------------------------------------------
+  parameters:
+    UserIdPath:
+      name: userId
+      in: path
+      required: true
+      description: |
+        User identifier. This is the user's ID within the authorization system
+        (not prefixed with "user:" — the API handles that internally).
+      schema:
+        type: string
+        example: alice
+
+    TypePath:
+      name: type
+      in: path
+      required: true
+      description: |
+        Organization or resource type as defined in the authorization model
+        (e.g., study, research_center, data_pipeline, dashboard, page).
+      schema:
+        type: string
+        example: data_pipeline
+
+    ResourceIdPath:
+      name: resourceId
+      in: path
+      required: true
+      description: |
+        Resource or organization identifier (e.g., "study1",
+        "study1-center1-clinical-ingest").
+      schema:
+        type: string
+        example: study1-center1-clinical-ingest
+
+  # ---------------------------------------------------------------------------
+  # Responses
+  # ---------------------------------------------------------------------------
+  responses:
+    ValidationError:
+      description: Request validation failed.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+          example:
+            error: validation_error
+            message: "Relation 'submitter' is not valid for type 'dashboard'. Valid relations: viewer, editor."
+
+    NotFound:
+      description: Resource not found.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+          example:
+            error: not_found
+            message: "Type 'invalid_type' does not exist in the authorization model."
+
+    ServiceUnavailable:
+      description: Authorization engine is unreachable.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+          example:
+            error: service_unavailable
+            message: "Unable to connect to the authorization engine."
+
+  # ---------------------------------------------------------------------------
+  # Schemas
+  # ---------------------------------------------------------------------------
+  schemas:
+
+    # --- Model schemas ---
+
+    AuthorizationModel:
+      type: object
+      required: [version, types]
+      properties:
+        version:
+          type: string
+          description: Authorization model version (semantic versioning).
+          example: "2.0.0"
+        types:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/TypeMetadata"
+          description: Map of type name to type metadata.
+
+    TypeMetadata:
+      type: object
+      required: [name, category, relations]
+      properties:
+        name:
+          type: string
+          description: Type name.
+          example: data_pipeline
+        category:
+          type: string
+          enum: [organization, resource]
+          description: Whether this is an organization type or a resource type.
+        description:
+          type: string
+          description: Human-readable description of the type.
+          example: "Datatype-specific data collections for ingest or distribution."
+        relations:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/RelationMetadata"
+          description: Map of relation name to relation metadata.
+        structuralRelations:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/StructuralRelationMetadata"
+          description: |
+            Structural relations that link this type to parent organizations.
+            Only present for resource types that participate in the hierarchy.
+        computedRelations:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/ComputedRelationMetadata"
+          description: |
+            Computed relations that derive permissions from the hierarchy.
+            These are never directly assigned — they are resolved by the
+            authorization engine based on structural relations.
+        validParentCombinations:
+          type: array
+          items:
+            $ref: "#/components/schemas/ParentCombination"
+          description: |
+            Valid combinations of parent relationships for this type.
+            Only present for resource types with structural relations.
+
+    RelationMetadata:
+      type: object
+      required: [name, assignable]
+      properties:
+        name:
+          type: string
+          example: viewer
+        description:
+          type: string
+          example: "Can view pipeline data."
+        assignable:
+          type: boolean
+          description: |
+            Whether this relation can be directly assigned to a user via the
+            grant endpoint. False for computed and structural relations.
+
+    StructuralRelationMetadata:
+      type: object
+      required: [name, parentType]
+      properties:
+        name:
+          type: string
+          example: parent_study
+        parentType:
+          type: string
+          description: The type of the parent organization.
+          example: study
+        description:
+          type: string
+          example: "Links this resource to its parent study."
+
+    ComputedRelationMetadata:
+      type: object
+      required: [name, sourceRelation, parentRelation, grantsRelation]
+      properties:
+        name:
+          type: string
+          example: study_admin_access
+        description:
+          type: string
+          example: "Grants viewer access to admins of the parent study."
+        sourceRelation:
+          type: string
+          description: The role on the parent organization that grants this computed access.
+          example: admin
+        parentRelation:
+          type: string
+          description: The structural relation traversed to reach the parent.
+          example: parent_study
+        grantsRelation:
+          type: string
+          description: The user-facing relation that this computed relation effectively grants on the resource.
+          example: viewer
+
+    ParentCombination:
+      type: object
+      required: [parents]
+      properties:
+        parents:
+          type: array
+          items:
+            type: string
+          description: |
+            List of structural relation names that form a valid combination.
+            For types where valid combinations depend on additional context
+            (e.g., pipeline_type), the condition field describes when this
+            combination applies.
+          example: ["parent_study", "parent_center"]
+        description:
+          type: string
+          example: "Center ingest pipeline — ingests data from a center for a study."
+        condition:
+          type: string
+          description: |
+            Optional condition describing when this parent combination applies.
+            Used when a single resource type has multiple valid parent
+            combinations that depend on the resource's characteristics.
+          example: "pipeline_type is center-ingest"
+
+    # --- Permission schemas ---
+
+    UserPermissions:
+      type: object
+      required: [userId, permissions]
+      properties:
+        userId:
+          type: string
+          example: alice
+        permissions:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              $ref: "#/components/schemas/PermissionEntry"
+          description: |
+            Map of type name to list of permission entries. Each entry represents
+            one resource the user can access with a specific relation.
+          example:
+            study:
+              - resourceId: study1
+                relation: admin
+                access: direct
+            data_pipeline:
+              - resourceId: study1-center1-clinical-ingest
+                relation: viewer
+                access: inherited
+                inheritedFrom:
+                  parentType: study
+                  parentId: study1
+                  parentRole: admin
+
+    PermissionEntry:
+      type: object
+      required: [resourceId, relation, access]
+      properties:
+        resourceId:
+          type: string
+          example: study1-center1-clinical-ingest
+        relation:
+          type: string
+          example: viewer
+        access:
+          type: string
+          enum: [direct, inherited, both]
+          description: |
+            How the user has this access:
+            - direct: explicitly granted
+            - inherited: derived from a parent organization role
+            - both: both directly granted and inherited
+        inheritedFrom:
+          $ref: "#/components/schemas/InheritanceSource"
+
+    InheritanceSource:
+      type: object
+      required: [parentType, parentId, parentRole]
+      description: |
+        Describes why inherited access exists, in domain terms.
+        For example: "user is admin of study:study1, which is the parent study
+        of this data pipeline."
+      properties:
+        parentType:
+          type: string
+          description: The type of the parent organization granting inherited access.
+          example: study
+        parentId:
+          type: string
+          description: The ID of the parent organization.
+          example: study1
+        parentRole:
+          type: string
+          description: The user's role on the parent organization that grants this access.
+          example: admin
+
+    ResourceAccessList:
+      type: object
+      required: [type, resourceId, users]
+      properties:
+        type:
+          type: string
+          example: data_pipeline
+        resourceId:
+          type: string
+          example: study1-center1-clinical-ingest
+        users:
+          type: array
+          items:
+            $ref: "#/components/schemas/ResourceAccessEntry"
+
+    ResourceAccessEntry:
+      type: object
+      required: [userId, relation, access]
+      properties:
+        userId:
+          type: string
+          example: alice
+        relation:
+          type: string
+          example: viewer
+        access:
+          type: string
+          enum: [direct, inherited, both]
+        inheritedFrom:
+          $ref: "#/components/schemas/InheritanceSource"
+
+    PermissionCheckRequest:
+      type: object
+      required: [userId, relation, type, resourceId]
+      properties:
+        userId:
+          type: string
+          example: alice
+        relation:
+          type: string
+          example: viewer
+        type:
+          type: string
+          example: data_pipeline
+        resourceId:
+          type: string
+          example: study1-center1-clinical-ingest
+
+    PermissionCheckResponse:
+      type: object
+      required: [allowed]
+      properties:
+        allowed:
+          type: boolean
+          description: Whether the user has the specified permission.
+          example: true
+
+    EffectivePermissions:
+      type: object
+      required: [userId, type, resourceId, relations]
+      properties:
+        userId:
+          type: string
+          example: alice
+        type:
+          type: string
+          example: data_pipeline
+        resourceId:
+          type: string
+          example: study1-center1-clinical-ingest
+        relations:
+          type: array
+          items:
+            $ref: "#/components/schemas/EffectiveRelation"
+          description: All relations the user effectively holds on this resource.
+
+    EffectiveRelation:
+      type: object
+      required: [relation, access]
+      properties:
+        relation:
+          type: string
+          example: viewer
+        access:
+          type: string
+          enum: [direct, inherited, both]
+        inheritedFrom:
+          $ref: "#/components/schemas/InheritanceSource"
+
+    # --- Access management schemas ---
+
+    GrantRequest:
+      type: object
+      required: [userId, relation, type, resourceId]
+      properties:
+        userId:
+          type: string
+          description: The user to grant access to.
+          example: charlie
+        relation:
+          type: string
+          description: |
+            The relation to grant. Must be a user-assignable relation for the
+            specified type (not a computed or structural relation).
+          example: viewer
+        type:
+          type: string
+          description: The resource or organization type.
+          example: data_pipeline
+        resourceId:
+          type: string
+          description: The resource or organization ID.
+          example: study1-center1-clinical-ingest
+
+    GrantResponse:
+      type: object
+      required: [userId, relation, type, resourceId]
+      properties:
+        userId:
+          type: string
+        relation:
+          type: string
+        type:
+          type: string
+        resourceId:
+          type: string
+
+    RevokeRequest:
+      type: object
+      required: [userId, relation, type, resourceId]
+      properties:
+        userId:
+          type: string
+          example: charlie
+        relation:
+          type: string
+          example: viewer
+        type:
+          type: string
+          example: data_pipeline
+        resourceId:
+          type: string
+          example: study1-center1-clinical-ingest
+
+    RevokeResponse:
+      type: object
+      required: [userId, relation, type, resourceId]
+      properties:
+        userId:
+          type: string
+        relation:
+          type: string
+        type:
+          type: string
+        resourceId:
+          type: string
+
+    # --- Resource hierarchy schemas ---
+
+    ResourceParents:
+      type: object
+      required: [type, resourceId, parents]
+      properties:
+        type:
+          type: string
+          example: data_pipeline
+        resourceId:
+          type: string
+          example: study1-center1-clinical-ingest
+        parents:
+          type: array
+          items:
+            $ref: "#/components/schemas/ParentRelationship"
+
+    ParentRelationship:
+      type: object
+      required: [structuralRelation, parentType, parentId]
+      properties:
+        structuralRelation:
+          type: string
+          description: The structural relation name (e.g., parent_study, parent_center).
+          example: parent_study
+        parentType:
+          type: string
+          description: The type of the parent organization.
+          example: study
+        parentId:
+          type: string
+          description: The ID of the parent organization.
+          example: study1
+
+    SetParentsRequest:
+      type: object
+      required: [parents]
+      properties:
+        parents:
+          type: array
+          items:
+            $ref: "#/components/schemas/ParentRelationship"
+          description: |
+            The parent relationships to set. Must be a valid combination per the
+            authorization model's validParentCombinations for this resource type.
+          example:
+            - structuralRelation: parent_study
+              parentType: study
+              parentId: study1
+            - structuralRelation: parent_center
+              parentType: research_center
+              parentId: center1
+
+    # --- Batch schemas ---
+
+    BatchRequest:
+      type: object
+      required: [operations]
+      properties:
+        operations:
+          type: array
+          maxItems: 100
+          items:
+            $ref: "#/components/schemas/BatchOperation"
+
+    BatchOperation:
+      type: object
+      required: [action, userId, relation, type, resourceId]
+      properties:
+        action:
+          type: string
+          enum: [grant, revoke]
+          description: Whether to grant or revoke this access.
+        userId:
+          type: string
+          example: charlie
+        relation:
+          type: string
+          example: viewer
+        type:
+          type: string
+          example: data_pipeline
+        resourceId:
+          type: string
+          example: study1-center1-clinical-ingest
+
+    BatchResponse:
+      type: object
+      required: [total, succeeded, failed]
+      properties:
+        total:
+          type: integer
+          description: Total number of operations in the batch.
+          example: 10
+        succeeded:
+          type: integer
+          description: Number of operations that succeeded.
+          example: 9
+        failed:
+          type: integer
+          description: Number of operations that failed.
+          example: 1
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/BatchError"
+
+    BatchError:
+      type: object
+      required: [index, error, message]
+      properties:
+        index:
+          type: integer
+          description: Zero-based index of the failed operation in the batch.
+          example: 3
+        error:
+          type: string
+          example: conflict
+        message:
+          type: string
+          example: "Grant already exists."
+
+    # --- Health schemas ---
+
+    HealthResponse:
+      type: object
+      required: [status]
+      properties:
+        status:
+          type: string
+          enum: [healthy, degraded, unhealthy]
+          example: healthy
+        authorizationEngine:
+          type: string
+          enum: [connected, unreachable]
+          example: connected
+
+    # --- Error schemas ---
+
+    ErrorResponse:
+      type: object
+      required: [error, message]
+      properties:
+        error:
+          type: string
+          description: Machine-readable error code.
+          example: validation_error
+        message:
+          type: string
+          description: Human-readable error description.
+          example: "Relation 'parent_study' is a structural relation and cannot be directly assigned. Use the resource hierarchy endpoints instead."
+        details:
+          type: object
+          additionalProperties: true
+          description: Additional error context (optional).

--- a/.kiro/specs/authorization-client-library/prompt.md
+++ b/.kiro/specs/authorization-client-library/prompt.md
@@ -1,0 +1,98 @@
+# Authorization API Client Library — Spec Prompt
+
+## Goal
+
+Create a shared Python client library in `common/src/python/` that wraps the NACC Authorization API. This library will be used by both the user_management gear (for grant/revoke sync) and the project_management gear (for resource hierarchy seeding).
+
+This is the first increment toward using the Authorization Service as the centralized authorization store. The Portal will query the Authorization API for permission checks (pull model). The gears populate and maintain the store.
+
+## Context
+
+### Authorization API (deployed, production)
+
+The Authorization API is a REST service (AWS Lambda + API Gateway, IAM/SigV4 auth) with 13 endpoints. It stores authorization relationships in OpenFGA. Key endpoints:
+
+- `POST /grants` — grant a user a relation on a resource (returns 201, or 409 if already exists)
+- `DELETE /grants` — revoke a user's relation on a resource (returns 200, or 404 if not found)
+- `POST /grants/batch` — bulk grant/revoke (up to 100 operations per call)
+- `GET /users/{userId}/permissions` — get all resources a user can access
+- `PUT /resources/{type}/{resourceId}/parents` — set parent organizations on a resource
+- `GET /health` — health check
+
+API authentication: AWS SigV4 signing against the `execute-api` service.
+
+### Authorization Model (types and relations)
+
+The Authorization API enforces this model:
+
+**Organization types:**
+
+- `study` — relations: `member`, `admin`
+- `research_center` — relations: `member`, `admin`
+- `community` — relations: `member`
+
+**Resource types:**
+
+- `data_pipeline` — relations: `viewer`, `submitter`, `auditor`; parents: `parent_study`, `parent_center`
+- `dashboard` — relations: `viewer`, `editor`; parents: `parent_study`, `parent_center`, `parent_community`
+- `page` — relations: `viewer`; parents: `parent_study`, `parent_center`, `parent_community`
+
+### Idempotency Semantics
+
+- Granting something that already exists → 409 (treat as success)
+- Revoking something that doesn't exist → 404 (treat as success)
+
+### Batch Operation Semantics
+
+`POST /grants/batch` has two phases:
+
+- **Validation** (all-or-nothing): if any operation has invalid input (bad type, bad relation), the entire batch is rejected with 400.
+- **Execution** (individual): each operation executes sequentially. Failures are collected per-operation.
+
+The response includes `total`, `succeeded`, `failed`, and an `errors` array with the index of each failed operation. The client should:
+
+- Treat `conflict` (409) and `not_found` (404) as acceptable (idempotent)
+- Retry on `service_unavailable` (503 — OpenFGA unreachable)
+- Alert/log on unexpected failures
+
+### Rate Limits
+
+No explicit rate limits are configured. At current scale (hundreds of users, nightly runs, sequential batch calls), throttling is not a concern. No backoff needed for normal operation — only retry on 503.
+
+### User ID Format
+
+The `userId` is the `registry_id` (ePPN from CILogon), passed as-is. The API prefixes it with `user:` internally when talking to OpenFGA.
+
+## Requirements
+
+### Client Library
+
+Create a Python client library in `common/src/python/` that wraps the Authorization API:
+
+- SigV4 request signing (AWS credential chain)
+- Methods for:
+  - `grant(user_id, resource_type, resource_id, relation)` — single grant
+  - `revoke(user_id, resource_type, resource_id, relation)` — single revoke
+  - `batch(operations)` — bulk grant/revoke (chunks into multiple calls if > 100 operations)
+  - `get_user_permissions(user_id)` — get all resources a user can access
+  - `set_resource_parents(resource_type, resource_id, parents)` — set parent organizations
+  - `health_check()` — health check
+- Handles 409 (duplicate grant) as success
+- Handles 404 (revoke non-existent) as success
+- Configurable API endpoint URL (from environment or parameter)
+- Retry on 503 with exponential backoff; fail immediately on other 4xx/5xx
+- Proper error handling and logging
+- Not coupled to any specific gear — usable by any gear or script in the monorepo
+
+## Design Considerations
+
+- The 100-operation batch limit is not a concern for a single user (typical max ~30-50 grants). The client should still handle chunking transparently.
+- The library should expose typed request/response models (Pydantic) for the API payloads.
+- SigV4 signing should use the standard AWS credential chain (environment variables, IAM role, etc.). The implementation may use an OpenAPI-generated HTTP client, a hand-written client, or any approach that satisfies the behavioral requirements.
+- The library should be testable with mocked HTTP responses (no real AWS calls in tests).
+
+## References
+
+- Authorization API OpenAPI spec: #[[file:openapi.yaml]]
+- Authorization model definition: `user-management/components/authorization-api/src/python/authorization_api/auth_model.py`
+- OpenFGA schema: `user-management/components/authorization-service/models/schema.json`

--- a/.kiro/specs/authorization-client-library/requirements.md
+++ b/.kiro/specs/authorization-client-library/requirements.md
@@ -1,0 +1,148 @@
+# Requirements Document
+
+## Introduction
+
+A shared Python client library that wraps the NACC Authorization API, providing typed, idempotent access to authorization operations. The library lives in `common/src/python/authorization/` and is usable by any gear or script in the monorepo. It is the first increment toward using the Authorization Service as the centralized authorization store — gears populate and maintain the store, and the Portal queries it for permission checks.
+
+## Glossary
+
+- **Authorization_Client**: The Python client class that sends HTTP requests to the Authorization API with SigV4 signing.
+- **Authorization_API**: The deployed REST service (AWS Lambda + API Gateway) that manages authorization relationships in OpenFGA.
+- **Grant_Operation**: An operation that creates a user-to-resource relationship (user, relation, type, resource_id).
+- **Revoke_Operation**: An operation that removes a user-to-resource relationship.
+- **Batch_Operation**: A single grant or revoke item within a batch request.
+- **Batch_Chunk**: A group of up to 100 batch operations sent in one API call.
+- **SigV4_Signing**: AWS Signature Version 4 request signing for `execute-api` service authentication.
+- **Idempotent_Success**: Treating HTTP 409 (conflict on grant) and HTTP 404 (not found on revoke) as successful outcomes.
+- **Resource_Type**: A type in the authorization model (study, research_center, community, data_pipeline, dashboard, page).
+- **Relation**: A named relationship between a user and a resource (e.g., member, admin, viewer, submitter, auditor, editor).
+- **Parent_Relationship**: A structural link from a resource to a parent organization (e.g., parent_study, parent_center, parent_community).
+- **Registry_ID**: The user identifier (ePPN from CILogon) passed as-is to the API.
+
+## Requirements
+
+### Requirement 1: Client Instantiation and Configuration
+
+**User Story:** As a gear developer, I want to create an Authorization_Client with a configurable API endpoint, so that I can target different environments without code changes.
+
+#### Acceptance Criteria
+
+1. THE Authorization_Client SHALL accept an API base URL as a parameter.
+2. THE Authorization_Client SHALL support reading the API base URL from an environment variable as an alternative to an explicit parameter.
+3. IF no API base URL is resolvable, THEN THE Authorization_Client SHALL raise a configuration error.
+4. THE Authorization_Client SHALL use the standard AWS credential chain for SigV4 signing without requiring explicit credential parameters.
+
+### Requirement 2: Single Grant Operation
+
+**User Story:** As a gear developer, I want to grant a user a relation on a resource with a single method call, so that I can synchronize access without managing HTTP details.
+
+#### Acceptance Criteria
+
+1. WHEN a grant request is sent with a valid user_id, resource_type, resource_id, and relation, THE Authorization_Client SHALL send a POST request to `/grants` with the appropriate JSON body signed with SigV4.
+2. WHEN the API returns HTTP 201, THE Authorization_Client SHALL return a success result containing the granted relationship details.
+3. WHEN the API returns HTTP 409 (grant already exists), THE Authorization_Client SHALL treat the response as a successful outcome and return a success result.
+4. WHEN the API returns HTTP 400 (validation error), THE Authorization_Client SHALL raise an error containing the API error message.
+5. WHEN the API returns HTTP 503 (service unavailable), THE Authorization_Client SHALL retry the request with exponential backoff.
+6. IF the API returns an unexpected HTTP error (any 4xx other than 400 or 409, or any 5xx other than 503), THEN THE Authorization_Client SHALL raise an error immediately without retrying.
+
+### Requirement 3: Single Revoke Operation
+
+**User Story:** As a gear developer, I want to revoke a user's relation on a resource with a single method call, so that I can remove access without managing HTTP details.
+
+#### Acceptance Criteria
+
+1. WHEN a revoke request is sent with a valid user_id, resource_type, resource_id, and relation, THE Authorization_Client SHALL send a DELETE request to `/grants` with the appropriate JSON body signed with SigV4.
+2. WHEN the API returns HTTP 200, THE Authorization_Client SHALL return a success result containing the revoked relationship details.
+3. WHEN the API returns HTTP 404 (grant does not exist), THE Authorization_Client SHALL treat the response as a successful outcome and return a success result.
+4. WHEN the API returns HTTP 400 (validation error), THE Authorization_Client SHALL raise an error containing the API error message.
+5. WHEN the API returns HTTP 503 (service unavailable), THE Authorization_Client SHALL retry the request with exponential backoff.
+6. IF the API returns an unexpected HTTP error (any 4xx other than 400 or 404, or any 5xx other than 503), THEN THE Authorization_Client SHALL raise an error immediately without retrying.
+
+### Requirement 4: Batch Grant and Revoke Operations
+
+**User Story:** As a gear developer, I want to submit a list of grant and revoke operations in bulk, so that I can synchronize many access changes efficiently.
+
+#### Acceptance Criteria
+
+1. WHEN a batch request contains 100 or fewer operations, THE Authorization_Client SHALL send a single POST request to `/grants/batch`.
+2. WHEN a batch request contains more than 100 operations, THE Authorization_Client SHALL split the operations into chunks of at most 100 and send each chunk as a separate POST request to `/grants/batch`.
+3. THE Authorization_Client SHALL preserve the original operation order when splitting into chunks.
+4. WHEN the API returns a batch response, THE Authorization_Client SHALL classify per-operation errors with error code `conflict` or `not_found` as acceptable (idempotent) outcomes.
+5. WHEN the API returns a batch response containing per-operation errors with error code `service_unavailable`, THE Authorization_Client SHALL report those operations as retriable failures.
+6. WHEN the API returns HTTP 400 for the entire batch (validation failure), THE Authorization_Client SHALL raise an error containing the validation error message.
+7. THE Authorization_Client SHALL return an aggregate result containing the total count, succeeded count, failed count, and details of each non-idempotent failure across all chunks.
+
+### Requirement 5: Query User Permissions
+
+**User Story:** As a gear developer, I want to retrieve all resources a user can access, so that I can inspect current authorization state.
+
+#### Acceptance Criteria
+
+1. WHEN a user permissions request is sent with a valid user_id, THE Authorization_Client SHALL send a GET request to `/users/{userId}/permissions` signed with SigV4.
+2. THE Authorization_Client SHALL return a typed result containing the user's permissions grouped by resource type.
+3. WHEN the API returns HTTP 503, THE Authorization_Client SHALL retry the request with exponential backoff.
+4. IF the API returns an unexpected HTTP error, THEN THE Authorization_Client SHALL raise an error immediately without retrying.
+
+### Requirement 6: Set Resource Parents
+
+**User Story:** As a gear developer, I want to set the parent organizations of a resource, so that I can seed the resource hierarchy for inherited permissions.
+
+#### Acceptance Criteria
+
+1. WHEN a set-parents request is sent with a valid resource_type, resource_id, and list of parent relationships, THE Authorization_Client SHALL send a PUT request to `/resources/{type}/{resourceId}/parents` with the appropriate JSON body signed with SigV4.
+2. WHEN the API returns HTTP 200, THE Authorization_Client SHALL return a success result containing the updated parent relationships.
+3. WHEN the API returns HTTP 400 (validation error), THE Authorization_Client SHALL raise an error containing the API error message.
+4. WHEN the API returns HTTP 503, THE Authorization_Client SHALL retry the request with exponential backoff.
+5. IF the API returns an unexpected HTTP error, THEN THE Authorization_Client SHALL raise an error immediately without retrying.
+
+### Requirement 7: Health Check
+
+**User Story:** As a gear developer, I want to check the health of the Authorization API, so that I can verify connectivity before performing operations.
+
+#### Acceptance Criteria
+
+1. WHEN a health check request is sent, THE Authorization_Client SHALL send a GET request to `/health` signed with SigV4.
+2. WHEN the API returns HTTP 200, THE Authorization_Client SHALL return a typed result containing the service health status and authorization engine connectivity status.
+3. WHEN the API returns HTTP 503, THE Authorization_Client SHALL return a result indicating the service is unhealthy rather than raising an error.
+
+### Requirement 8: Retry Behavior
+
+**User Story:** As a gear developer, I want the client to automatically retry on transient failures, so that temporary outages do not require manual intervention.
+
+#### Acceptance Criteria
+
+1. WHEN the Authorization_Client retries a request, THE Authorization_Client SHALL use exponential backoff between retry attempts.
+2. THE Authorization_Client SHALL limit the number of retry attempts to a configurable maximum before raising an error.
+3. THE Authorization_Client SHALL log each retry attempt at warning level, including the attempt number and wait duration.
+4. THE Authorization_Client SHALL only retry on HTTP 503 responses; all other error responses SHALL fail immediately.
+
+### Requirement 9: Typed Request and Response Models
+
+**User Story:** As a gear developer, I want typed Pydantic models for all API payloads, so that I get validation and IDE support when constructing requests and reading responses.
+
+#### Acceptance Criteria
+
+1. THE Authorization_Client SHALL expose Pydantic models for grant requests, revoke requests, batch operations, parent relationships, and all response types.
+2. THE Authorization_Client SHALL parse API response bodies into typed Pydantic models.
+3. IF a response body does not conform to the expected schema, THEN THE Authorization_Client SHALL raise a parse error with the raw response content.
+
+### Requirement 10: Logging
+
+**User Story:** As a gear developer, I want the client to log operations at appropriate levels, so that I can diagnose issues without excessive noise.
+
+#### Acceptance Criteria
+
+1. THE Authorization_Client SHALL log successful operations at debug level.
+2. THE Authorization_Client SHALL log idempotent outcomes (409 on grant, 404 on revoke) at debug level.
+3. THE Authorization_Client SHALL log retry attempts at warning level.
+4. THE Authorization_Client SHALL log non-retriable errors at error level.
+5. THE Authorization_Client SHALL use the standard Python logging module with a named logger.
+
+### Requirement 11: Testability
+
+**User Story:** As a gear developer, I want to test code that uses the Authorization_Client without making real HTTP calls, so that tests are fast and deterministic.
+
+#### Acceptance Criteria
+
+1. THE Authorization_Client SHALL support dependency injection of the HTTP transport layer so that tests can substitute a mock.
+2. THE Authorization_Client SHALL not import or depend on any gear-specific modules.

--- a/.kiro/specs/authorization-client-library/tasks.md
+++ b/.kiro/specs/authorization-client-library/tasks.md
@@ -53,8 +53,8 @@ Implement a shared Python client library at `common/src/python/authorization/` t
 - [x] 3. Checkpoint - Ensure all tests pass
   - Ensure all tests pass, ask the user if questions arise.
 
-- [ ] 4. Implement AuthorizationClient operations
-  - [ ] 4.1 Implement grant and revoke methods
+- [x] 4. Implement AuthorizationClient operations
+  - [x] 4.1 Implement grant and revoke methods
     - Create `common/src/python/authorization/client.py`
     - Implement `AuthorizationClient.__init__` accepting `transport`, `max_retries`, `base_backoff`
     - Implement `grant()`: POST to `/grants`, return `GrantResult`, treat 409 as success
@@ -64,14 +64,14 @@ Implement a shared Python client library at `common/src/python/authorization/` t
     - Log successful operations at debug, idempotent outcomes at debug, errors at error level
     - _Requirements: 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 10.1, 10.2, 10.4_
 
-  - [ ] 4.2 Write property tests for grant and revoke (Properties 1, 3, 4, 6)
+  - [x] 4.2 Write property tests for grant and revoke (Properties 1, 3, 4, 6)
     - **Property 1: Request construction correctness** — verify correct HTTP method, path, and JSON body for grant/revoke
     - **Property 3: Idempotent status codes yield success** — verify 409 on grant and 404 on revoke return success
     - **Property 4: Validation errors propagate message** — verify 400 raises ValidationError with API message
     - **Property 6: Immediate failure on non-retriable errors** — verify non-503/non-idempotent errors fail immediately
     - **Validates: Requirements 2.1, 2.3, 2.4, 2.6, 3.1, 3.3, 3.4, 3.6**
 
-  - [ ] 4.3 Implement batch method with chunking
+  - [x] 4.3 Implement batch method with chunking
     - Implement `batch()` on `AuthorizationClient`
     - Split operations into chunks of ≤100, preserving order
     - POST each chunk to `/grants/batch`
@@ -80,79 +80,79 @@ Implement a shared Python client library at `common/src/python/authorization/` t
     - Return aggregate `BatchResult` with total, succeeded, failed, and error details
     - _Requirements: 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7_
 
-  - [ ] 4.4 Write property tests for batch operations (Properties 7, 8, 9)
+  - [x] 4.4 Write property tests for batch operations (Properties 7, 8, 9)
     - **Property 7: Batch chunking respects size limit** — verify ⌈N/100⌉ requests each with ≤100 operations
     - **Property 8: Batch chunking preserves order** — verify concatenation of chunks equals original list
     - **Property 9: Batch result aggregation** — verify aggregate totals across multi-chunk execution
     - **Validates: Requirements 4.1, 4.2, 4.3, 4.4, 4.7**
 
-  - [ ] 4.5 Implement get_user_permissions method
+  - [x] 4.5 Implement get_user_permissions method
     - Implement `get_user_permissions()` on `AuthorizationClient`
     - GET to `/users/{userId}/permissions` with optional type and relation query params
     - Return typed `UserPermissions` model
     - Retry on 503, raise on other errors
     - _Requirements: 5.1, 5.2, 5.3, 5.4_
 
-  - [ ] 4.6 Implement set_resource_parents method
+  - [x] 4.6 Implement set_resource_parents method
     - Implement `set_resource_parents()` on `AuthorizationClient`
     - PUT to `/resources/{type}/{resourceId}/parents`
     - Return typed `ResourceParents` model
     - Raise `ValidationError` on 400, retry on 503, raise on other errors
     - _Requirements: 6.1, 6.2, 6.3, 6.4, 6.5_
 
-  - [ ] 4.7 Implement health_check method
+  - [x] 4.7 Implement health_check method
     - Implement `health_check()` on `AuthorizationClient`
     - GET to `/health`
     - Return `HealthResult` on 200
     - Return `HealthResult(status="unhealthy")` on 503 (no exception)
     - _Requirements: 7.1, 7.2, 7.3_
 
-  - [ ] 4.8 Write property tests for query, parents, and retry (Properties 1, 5, 6)
+  - [x] 4.8 Write property tests for query, parents, and retry (Properties 1, 5, 6)
     - **Property 1: Request construction correctness** — verify correct method, path, and body for get_user_permissions and set_resource_parents
     - **Property 5: Retry on 503 with exponential backoff** — verify retry count and delay pattern, then ServiceUnavailableError
     - **Property 6: Immediate failure on non-retriable errors** — verify non-503 errors fail immediately for query/parents
     - **Validates: Requirements 5.1, 5.3, 5.4, 6.1, 6.4, 6.5, 8.1, 8.2, 8.4**
 
-- [ ] 5. Checkpoint - Ensure all tests pass
+- [x] 5. Checkpoint - Ensure all tests pass
   - Ensure all tests pass, ask the user if questions arise.
 
-- [ ] 6. Implement factory and response parsing
-  - [ ] 6.1 Implement factory function
+- [x] 6. Implement factory and response parsing
+  - [x] 6.1 Implement factory function
     - Create `common/src/python/authorization/factory.py`
     - Implement `create_authorization_client()` that resolves base URL from parameter or `AUTHORIZATION_API_URL` env var
     - Raise `ConfigurationError` if no URL resolvable
     - Instantiate `SigV4Transport` and return configured `AuthorizationClient`
     - _Requirements: 1.1, 1.2, 1.3, 1.4_
 
-  - [ ] 6.2 Write property tests for response model round-trip and parse errors (Properties 2, 10)
+  - [x] 6.2 Write property tests for response model round-trip and parse errors (Properties 2, 10)
     - **Property 2: Response model round-trip** — verify serialize-then-parse produces equivalent model for all response types
     - **Property 10: Malformed response raises ParseError with raw content** — verify non-conforming JSON raises ParseError with original bytes
     - **Validates: Requirements 9.2, 9.3**
 
-  - [ ] 6.3 Wire up package exports
+  - [x] 6.3 Wire up package exports
     - Update `common/src/python/authorization/__init__.py` to export public API
     - Export: `AuthorizationClient`, `create_authorization_client`, all models, all exceptions, `HttpTransport`, `HttpResponse`
     - Ensure the package is importable as `from authorization import ...`
     - _Requirements: 11.2_
 
-- [ ] 7. Integration and unit tests
-  - [ ] 7.1 Write unit tests for client instantiation and configuration
+- [x] 7. Integration and unit tests
+  - [x] 7.1 Write unit tests for client instantiation and configuration
     - Test explicit URL parameter, env var fallback, and missing URL raises ConfigurationError
     - Test default and custom max_retries/base_backoff values
     - _Requirements: 1.1, 1.2, 1.3_
 
-  - [ ] 7.2 Write unit tests for health check and logging behavior
+  - [x] 7.2 Write unit tests for health check and logging behavior
     - Test health check request construction and response parsing
     - Test 503 on health returns unhealthy result (no exception)
     - Test logging: debug for success, warning for retry, error for failures
     - _Requirements: 7.1, 7.2, 7.3, 10.1, 10.2, 10.3, 10.4, 10.5_
 
-  - [ ] 7.3 Write unit tests for SigV4Transport signing
+  - [x] 7.3 Write unit tests for SigV4Transport signing
     - Test that SigV4Transport produces valid Authorization headers
     - Use botocore test utilities or moto for credential mocking
     - _Requirements: 1.4_
 
-- [ ] 8. Final checkpoint - Ensure all tests pass
+- [x] 8. Final checkpoint - Ensure all tests pass
   - Ensure all tests pass, ask the user if questions arise.
 
 ## Notes

--- a/.kiro/specs/authorization-client-library/tasks.md
+++ b/.kiro/specs/authorization-client-library/tasks.md
@@ -1,0 +1,183 @@
+# Implementation Plan: Authorization Client Library
+
+## Overview
+
+Implement a shared Python client library at `common/src/python/authorization/` that wraps the NACC Authorization API. The implementation follows the design's protocol-based transport abstraction, Pydantic v2 models, and retry logic with exponential backoff. Tests go in `common/test/python/authorization_test/`.
+
+## Tasks
+
+- [x] 1. Set up package structure and core types
+  - [x] 1.1 Create package directory structure and BUILD files
+    - Create `common/src/python/authorization/` with `__init__.py` and `BUILD`
+    - Create `common/test/python/authorization_test/` with `__init__.py`, `conftest.py`, and `BUILD`
+    - Configure Pants targets for sources and tests
+    - _Requirements: 11.2_
+
+  - [x] 1.2 Implement exception hierarchy
+    - Create `common/src/python/authorization/exceptions.py`
+    - Define `AuthorizationClientError`, `ConfigurationError`, `ValidationError`, `ServiceUnavailableError`, `UnexpectedError`, `ParseError`
+    - Each exception includes the attributes specified in the design (e.g., `ParseError.raw_content`, `UnexpectedError.status_code`)
+    - _Requirements: 2.4, 2.6, 3.4, 3.6, 9.3_
+
+  - [x] 1.3 Implement Pydantic request and response models
+    - Create `common/src/python/authorization/models.py`
+    - Define all request models: `GrantRequest`, `RevokeRequest`, `BatchOperationModel`, `BatchRequestModel`, `SetParentsRequestModel`, `ParentRelationshipModel`
+    - Define all response models: `GrantResult`, `RevokeResult`, `BatchError`, `BatchResult`, `InheritanceSource`, `PermissionEntry`, `UserPermissions`, `ParentRelationship`, `ResourceParents`, `HealthResult`, `ErrorResponse`
+    - Define domain types: `BatchOperation`
+    - Use Pydantic v2 `Field(alias=...)` for camelCase JSON serialization
+    - _Requirements: 9.1, 9.2_
+
+  - [x] 1.4 Define the HttpTransport protocol and HttpResponse protocol
+    - Create `common/src/python/authorization/transport.py`
+    - Define `HttpResponse` protocol with `status_code` and `body` properties
+    - Define `HttpTransport` protocol with `request(method, path, body, query_params)` method
+    - _Requirements: 11.1_
+
+- [x] 2. Implement transport and retry logic
+  - [x] 2.1 Implement SigV4Transport
+    - Create `common/src/python/authorization/sigv4_transport.py`
+    - Implement `SigV4Transport` class using `botocore.auth.SigV4Auth` with standard credential chain
+    - Sign requests against `execute-api` service
+    - Accept `base_url` and optional `region` parameters
+    - _Requirements: 1.4, 2.1, 3.1, 5.1, 6.1_
+
+  - [x] 2.2 Implement retry logic with exponential backoff
+    - Create `common/src/python/authorization/retry.py`
+    - Implement retry wrapper that retries only on HTTP 503
+    - Use exponential backoff: `base_backoff × 2^(attempt-1)`
+    - Accept configurable `max_retries` and `base_backoff`
+    - Log each retry attempt at WARNING level with attempt number and wait duration
+    - Raise `ServiceUnavailableError` when retries exhausted
+    - _Requirements: 8.1, 8.2, 8.3, 8.4_
+
+- [x] 3. Checkpoint - Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [ ] 4. Implement AuthorizationClient operations
+  - [ ] 4.1 Implement grant and revoke methods
+    - Create `common/src/python/authorization/client.py`
+    - Implement `AuthorizationClient.__init__` accepting `transport`, `max_retries`, `base_backoff`
+    - Implement `grant()`: POST to `/grants`, return `GrantResult`, treat 409 as success
+    - Implement `revoke()`: DELETE to `/grants`, return `RevokeResult`, treat 404 as success
+    - Raise `ValidationError` on 400, `UnexpectedError` on other errors
+    - Use retry logic for 503 responses
+    - Log successful operations at debug, idempotent outcomes at debug, errors at error level
+    - _Requirements: 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 10.1, 10.2, 10.4_
+
+  - [ ] 4.2 Write property tests for grant and revoke (Properties 1, 3, 4, 6)
+    - **Property 1: Request construction correctness** — verify correct HTTP method, path, and JSON body for grant/revoke
+    - **Property 3: Idempotent status codes yield success** — verify 409 on grant and 404 on revoke return success
+    - **Property 4: Validation errors propagate message** — verify 400 raises ValidationError with API message
+    - **Property 6: Immediate failure on non-retriable errors** — verify non-503/non-idempotent errors fail immediately
+    - **Validates: Requirements 2.1, 2.3, 2.4, 2.6, 3.1, 3.3, 3.4, 3.6**
+
+  - [ ] 4.3 Implement batch method with chunking
+    - Implement `batch()` on `AuthorizationClient`
+    - Split operations into chunks of ≤100, preserving order
+    - POST each chunk to `/grants/batch`
+    - Classify per-operation errors: `conflict`/`not_found` as idempotent success, `service_unavailable` as retriable
+    - Raise `ValidationError` on 400 for entire batch
+    - Return aggregate `BatchResult` with total, succeeded, failed, and error details
+    - _Requirements: 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7_
+
+  - [ ] 4.4 Write property tests for batch operations (Properties 7, 8, 9)
+    - **Property 7: Batch chunking respects size limit** — verify ⌈N/100⌉ requests each with ≤100 operations
+    - **Property 8: Batch chunking preserves order** — verify concatenation of chunks equals original list
+    - **Property 9: Batch result aggregation** — verify aggregate totals across multi-chunk execution
+    - **Validates: Requirements 4.1, 4.2, 4.3, 4.4, 4.7**
+
+  - [ ] 4.5 Implement get_user_permissions method
+    - Implement `get_user_permissions()` on `AuthorizationClient`
+    - GET to `/users/{userId}/permissions` with optional type and relation query params
+    - Return typed `UserPermissions` model
+    - Retry on 503, raise on other errors
+    - _Requirements: 5.1, 5.2, 5.3, 5.4_
+
+  - [ ] 4.6 Implement set_resource_parents method
+    - Implement `set_resource_parents()` on `AuthorizationClient`
+    - PUT to `/resources/{type}/{resourceId}/parents`
+    - Return typed `ResourceParents` model
+    - Raise `ValidationError` on 400, retry on 503, raise on other errors
+    - _Requirements: 6.1, 6.2, 6.3, 6.4, 6.5_
+
+  - [ ] 4.7 Implement health_check method
+    - Implement `health_check()` on `AuthorizationClient`
+    - GET to `/health`
+    - Return `HealthResult` on 200
+    - Return `HealthResult(status="unhealthy")` on 503 (no exception)
+    - _Requirements: 7.1, 7.2, 7.3_
+
+  - [ ] 4.8 Write property tests for query, parents, and retry (Properties 1, 5, 6)
+    - **Property 1: Request construction correctness** — verify correct method, path, and body for get_user_permissions and set_resource_parents
+    - **Property 5: Retry on 503 with exponential backoff** — verify retry count and delay pattern, then ServiceUnavailableError
+    - **Property 6: Immediate failure on non-retriable errors** — verify non-503 errors fail immediately for query/parents
+    - **Validates: Requirements 5.1, 5.3, 5.4, 6.1, 6.4, 6.5, 8.1, 8.2, 8.4**
+
+- [ ] 5. Checkpoint - Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [ ] 6. Implement factory and response parsing
+  - [ ] 6.1 Implement factory function
+    - Create `common/src/python/authorization/factory.py`
+    - Implement `create_authorization_client()` that resolves base URL from parameter or `AUTHORIZATION_API_URL` env var
+    - Raise `ConfigurationError` if no URL resolvable
+    - Instantiate `SigV4Transport` and return configured `AuthorizationClient`
+    - _Requirements: 1.1, 1.2, 1.3, 1.4_
+
+  - [ ] 6.2 Write property tests for response model round-trip and parse errors (Properties 2, 10)
+    - **Property 2: Response model round-trip** — verify serialize-then-parse produces equivalent model for all response types
+    - **Property 10: Malformed response raises ParseError with raw content** — verify non-conforming JSON raises ParseError with original bytes
+    - **Validates: Requirements 9.2, 9.3**
+
+  - [ ] 6.3 Wire up package exports
+    - Update `common/src/python/authorization/__init__.py` to export public API
+    - Export: `AuthorizationClient`, `create_authorization_client`, all models, all exceptions, `HttpTransport`, `HttpResponse`
+    - Ensure the package is importable as `from authorization import ...`
+    - _Requirements: 11.2_
+
+- [ ] 7. Integration and unit tests
+  - [ ] 7.1 Write unit tests for client instantiation and configuration
+    - Test explicit URL parameter, env var fallback, and missing URL raises ConfigurationError
+    - Test default and custom max_retries/base_backoff values
+    - _Requirements: 1.1, 1.2, 1.3_
+
+  - [ ] 7.2 Write unit tests for health check and logging behavior
+    - Test health check request construction and response parsing
+    - Test 503 on health returns unhealthy result (no exception)
+    - Test logging: debug for success, warning for retry, error for failures
+    - _Requirements: 7.1, 7.2, 7.3, 10.1, 10.2, 10.3, 10.4, 10.5_
+
+  - [ ] 7.3 Write unit tests for SigV4Transport signing
+    - Test that SigV4Transport produces valid Authorization headers
+    - Use botocore test utilities or moto for credential mocking
+    - _Requirements: 1.4_
+
+- [ ] 8. Final checkpoint - Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- All test tasks are enabled and required
+- Each task references specific requirements for traceability
+- Checkpoints ensure incremental validation
+- Property tests validate universal correctness properties from the design document
+- Unit tests validate specific examples and edge cases
+- The mock transport pattern (inject a test double for `HttpTransport`) enables all property tests to run without network calls
+- Test directory uses `authorization_test` suffix per project conventions to avoid namespace conflicts
+
+## Task Dependency Graph
+
+```json
+{
+  "waves": [
+    { "id": 0, "tasks": ["1.1"] },
+    { "id": 1, "tasks": ["1.2", "1.3", "1.4"] },
+    { "id": 2, "tasks": ["2.1", "2.2"] },
+    { "id": 3, "tasks": ["4.1", "4.3", "4.5", "4.6", "4.7"] },
+    { "id": 4, "tasks": ["4.2", "4.4", "4.8"] },
+    { "id": 5, "tasks": ["6.1", "6.2"] },
+    { "id": 6, "tasks": ["6.3"] },
+    { "id": 7, "tasks": ["7.1", "7.2", "7.3"] }
+  ]
+}
+```

--- a/.kiro/specs/authorization-resource-hierarchy/openapi.yaml
+++ b/.kiro/specs/authorization-resource-hierarchy/openapi.yaml
@@ -1,0 +1,1015 @@
+openapi: 3.1.0
+info:
+  title: NACC Authorization API
+  version: 1.0.0
+  description: |
+    Domain-level REST interface to the NACC authorization system.
+    
+    This API provides authorization operations in NACC domain terms — granting access,
+    querying permissions, checking authorization, and managing resource hierarchy.
+    The underlying authorization engine (OpenFGA) is an implementation detail;
+    consumers interact only with this API.
+    
+    See ADR-008 for the architectural decision and rationale.
+  contact:
+    name: NACC Development Team
+
+servers:
+  - url: https://{environment}.api.nacc.example/authorization
+    description: NACC Authorization API
+    variables:
+      environment:
+        default: dev
+        enum: [dev, staging, prod]
+
+tags:
+  - name: Model
+    description: Authorization model metadata — resource types, relations, hierarchy rules, and computed permissions.
+  - name: Permissions
+    description: Query what access exists — user permissions, resource access, and authorization checks.
+  - name: Access Management
+    description: Grant and revoke access to resources and organizations.
+  - name: Resource Hierarchy
+    description: Manage parent relationships that define the resource hierarchy and enable inherited permissions.
+  - name: Batch Operations
+    description: Bulk grant and revoke operations for data loading and synchronization.
+  - name: Health
+    description: Operational health checks.
+
+paths:
+  # ---------------------------------------------------------------------------
+  # Model
+  # ---------------------------------------------------------------------------
+  /model:
+    get:
+      operationId: getModel
+      summary: Get authorization model metadata
+      description: |
+        Returns the complete authorization model: all organization types, resource types,
+        their relations, categories, structural relations, computed relations, and valid
+        parent combinations.
+        
+        This is the single source of truth for authorization model semantics. Consumers
+        use this to populate UI dropdowns, validate inputs client-side, and understand
+        the permission structure.
+      tags: [Model]
+      responses:
+        "200":
+          description: Authorization model metadata.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthorizationModel"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+  /model/types/{type}:
+    get:
+      operationId: getTypeMetadata
+      summary: Get metadata for a specific type
+      description: |
+        Returns metadata for a single organization or resource type, including its
+        relations, category, structural relations, computed relations, and valid
+        parent combinations.
+      tags: [Model]
+      parameters:
+        - $ref: "#/components/parameters/TypePath"
+      responses:
+        "200":
+          description: Type metadata.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TypeMetadata"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  # ---------------------------------------------------------------------------
+  # Permissions
+  # ---------------------------------------------------------------------------
+  /users/{userId}/permissions:
+    get:
+      operationId: getUserPermissions
+      summary: Get all permissions for a user
+      description: |
+        Returns every resource and organization a user can access, grouped by type.
+        Each entry includes the relation and whether the access is direct, inherited,
+        or both.
+        
+        For inherited permissions, the response includes the inheritance source —
+        which parent organization and role grants the access (e.g., "inherited from
+        admin role on study:study1").
+        
+        This is the primary endpoint Portal uses to render what a user can see.
+      tags: [Permissions]
+      parameters:
+        - $ref: "#/components/parameters/UserIdPath"
+        - name: type
+          in: query
+          description: Filter results to a specific resource or organization type.
+          schema:
+            type: string
+            example: data_pipeline
+        - name: relation
+          in: query
+          description: Filter results to a specific relation.
+          schema:
+            type: string
+            example: viewer
+      responses:
+        "200":
+          description: User permissions grouped by type.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserPermissions"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+
+  /resources/{type}/{resourceId}/access:
+    get:
+      operationId: getResourceAccess
+      summary: Get all users with access to a resource
+      description: |
+        Returns all users who have access to the specified resource, with their
+        relation and whether access is direct, inherited, or both.
+        
+        For inherited access, includes the source (parent organization and role).
+        This is the endpoint the Authorization Interface uses for the resource
+        access view.
+      tags: [Permissions]
+      parameters:
+        - $ref: "#/components/parameters/TypePath"
+        - $ref: "#/components/parameters/ResourceIdPath"
+        - name: relation
+          in: query
+          description: Filter to a specific relation.
+          schema:
+            type: string
+            example: viewer
+      responses:
+        "200":
+          description: Users with access to the resource.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResourceAccessList"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /check:
+    post:
+      operationId: checkPermission
+      summary: Check whether a user has a specific permission
+      description: |
+        Returns whether the specified user has the specified relation on the
+        specified resource. Validates that the resource type and relation are
+        valid per the authorization model before evaluating.
+        
+        Use this for real-time authorization decisions (e.g., "can this user
+        view this dashboard?").
+      tags: [Permissions]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PermissionCheckRequest"
+      responses:
+        "200":
+          description: Permission check result.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PermissionCheckResponse"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+
+  /users/{userId}/effective-permissions/{type}/{resourceId}:
+    get:
+      operationId: getEffectivePermissions
+      summary: Get all effective relations a user has on a resource
+      description: |
+        Returns all relations the user effectively holds on the specified resource,
+        including both direct and inherited. This answers "what can this user do
+        on this resource?" without requiring the caller to check each relation
+        individually.
+      tags: [Permissions]
+      parameters:
+        - $ref: "#/components/parameters/UserIdPath"
+        - $ref: "#/components/parameters/TypePath"
+        - $ref: "#/components/parameters/ResourceIdPath"
+      responses:
+        "200":
+          description: Effective permissions on the resource.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EffectivePermissions"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+
+  # ---------------------------------------------------------------------------
+  # Access Management
+  # ---------------------------------------------------------------------------
+  /grants:
+    post:
+      operationId: grantAccess
+      summary: Grant a user access to a resource or organization
+      description: |
+        Grants the specified user the specified relation on the specified resource
+        or organization. Validates that:
+        - The type exists in the authorization model
+        - The relation is user-assignable for that type (not a computed or structural relation)
+        - The user and resource IDs are well-formed
+        
+        Returns 409 if the grant already exists (idempotent consumers should treat
+        409 as success).
+      tags: [Access Management]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/GrantRequest"
+      responses:
+        "201":
+          description: Access granted.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GrantResponse"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "409":
+          description: Grant already exists.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+    delete:
+      operationId: revokeAccess
+      summary: Revoke a user's access to a resource or organization
+      description: |
+        Revokes the specified user's relation on the specified resource or
+        organization. Same validation as grant.
+        
+        Returns 404 if the grant does not exist.
+      tags: [Access Management]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RevokeRequest"
+      responses:
+        "200":
+          description: Access revoked.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RevokeResponse"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  # ---------------------------------------------------------------------------
+  # Resource Hierarchy
+  # ---------------------------------------------------------------------------
+  /resources/{type}/{resourceId}/parents:
+    get:
+      operationId: getResourceParents
+      summary: Get the parent organizations of a resource
+      description: |
+        Returns the current parent relationships for a resource — which study,
+        research center, or community it is linked to. This defines the resource's
+        position in the hierarchy and determines inherited permissions.
+      tags: [Resource Hierarchy]
+      parameters:
+        - $ref: "#/components/parameters/TypePath"
+        - $ref: "#/components/parameters/ResourceIdPath"
+      responses:
+        "200":
+          description: Parent relationships for the resource.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResourceParents"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+
+    put:
+      operationId: setResourceParents
+      summary: Set the parent organizations of a resource
+      description: |
+        Sets the parent relationships for a resource, replacing any existing parents.
+        Validates that:
+        - The structural relation is valid for the resource type
+        - The parent type matches the expected type for that structural relation
+        - The combination of parents is valid per the authorization model
+        
+        This is the primary way to place a resource in the hierarchy. For example,
+        linking a data pipeline to its parent study and center, or linking a
+        dashboard to its parent community.
+      tags: [Resource Hierarchy]
+      parameters:
+        - $ref: "#/components/parameters/TypePath"
+        - $ref: "#/components/parameters/ResourceIdPath"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SetParentsRequest"
+      responses:
+        "200":
+          description: Parents set successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResourceParents"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+
+    delete:
+      operationId: removeResourceParents
+      summary: Remove all parent relationships from a resource
+      description: |
+        Removes all parent relationships from a resource, effectively unlinking it
+        from the hierarchy. This removes any inherited permissions that flowed
+        through those parent relationships.
+        
+        Use with caution — this will immediately revoke inherited access for all
+        users who had it through the hierarchy.
+      tags: [Resource Hierarchy]
+      parameters:
+        - $ref: "#/components/parameters/TypePath"
+        - $ref: "#/components/parameters/ResourceIdPath"
+      responses:
+        "200":
+          description: Parents removed.
+        "400":
+          $ref: "#/components/responses/ValidationError"
+
+  # ---------------------------------------------------------------------------
+  # Batch Operations
+  # ---------------------------------------------------------------------------
+  /grants/batch:
+    post:
+      operationId: batchModifyAccess
+      summary: Grant and/or revoke access in bulk
+      description: |
+        Accepts a list of grant and/or revoke operations (up to 100 per request).
+        Each operation is validated individually. The entire batch is rejected if
+        any operation fails validation (all-or-nothing semantics).
+        
+        Returns a summary of results. Designed for data loading scripts and
+        synchronization workflows.
+      tags: [Batch Operations]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BatchRequest"
+      responses:
+        "200":
+          description: Batch completed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BatchResponse"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+
+  # ---------------------------------------------------------------------------
+  # Health
+  # ---------------------------------------------------------------------------
+  /health:
+    get:
+      operationId: healthCheck
+      summary: Health check
+      description: |
+        Returns the health status of the API, including connectivity to the
+        authorization engine.
+      tags: [Health]
+      responses:
+        "200":
+          description: Service is healthy.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HealthResponse"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+# =============================================================================
+# Components
+# =============================================================================
+components:
+
+  # ---------------------------------------------------------------------------
+  # Parameters
+  # ---------------------------------------------------------------------------
+  parameters:
+    UserIdPath:
+      name: userId
+      in: path
+      required: true
+      description: |
+        User identifier. This is the user's ID within the authorization system
+        (not prefixed with "user:" — the API handles that internally).
+      schema:
+        type: string
+        example: alice
+
+    TypePath:
+      name: type
+      in: path
+      required: true
+      description: |
+        Organization or resource type as defined in the authorization model
+        (e.g., study, research_center, data_pipeline, dashboard, page).
+      schema:
+        type: string
+        example: data_pipeline
+
+    ResourceIdPath:
+      name: resourceId
+      in: path
+      required: true
+      description: |
+        Resource or organization identifier (e.g., "study1",
+        "study1-center1-clinical-ingest").
+      schema:
+        type: string
+        example: study1-center1-clinical-ingest
+
+  # ---------------------------------------------------------------------------
+  # Responses
+  # ---------------------------------------------------------------------------
+  responses:
+    ValidationError:
+      description: Request validation failed.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+          example:
+            error: validation_error
+            message: "Relation 'submitter' is not valid for type 'dashboard'. Valid relations: viewer, editor."
+
+    NotFound:
+      description: Resource not found.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+          example:
+            error: not_found
+            message: "Type 'invalid_type' does not exist in the authorization model."
+
+    ServiceUnavailable:
+      description: Authorization engine is unreachable.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+          example:
+            error: service_unavailable
+            message: "Unable to connect to the authorization engine."
+
+  # ---------------------------------------------------------------------------
+  # Schemas
+  # ---------------------------------------------------------------------------
+  schemas:
+
+    # --- Model schemas ---
+
+    AuthorizationModel:
+      type: object
+      required: [version, types]
+      properties:
+        version:
+          type: string
+          description: Authorization model version (semantic versioning).
+          example: "2.0.0"
+        types:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/TypeMetadata"
+          description: Map of type name to type metadata.
+
+    TypeMetadata:
+      type: object
+      required: [name, category, relations]
+      properties:
+        name:
+          type: string
+          description: Type name.
+          example: data_pipeline
+        category:
+          type: string
+          enum: [organization, resource]
+          description: Whether this is an organization type or a resource type.
+        description:
+          type: string
+          description: Human-readable description of the type.
+          example: "Datatype-specific data collections for ingest or distribution."
+        relations:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/RelationMetadata"
+          description: Map of relation name to relation metadata.
+        structuralRelations:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/StructuralRelationMetadata"
+          description: |
+            Structural relations that link this type to parent organizations.
+            Only present for resource types that participate in the hierarchy.
+        computedRelations:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/ComputedRelationMetadata"
+          description: |
+            Computed relations that derive permissions from the hierarchy.
+            These are never directly assigned — they are resolved by the
+            authorization engine based on structural relations.
+        validParentCombinations:
+          type: array
+          items:
+            $ref: "#/components/schemas/ParentCombination"
+          description: |
+            Valid combinations of parent relationships for this type.
+            Only present for resource types with structural relations.
+
+    RelationMetadata:
+      type: object
+      required: [name, assignable]
+      properties:
+        name:
+          type: string
+          example: viewer
+        description:
+          type: string
+          example: "Can view pipeline data."
+        assignable:
+          type: boolean
+          description: |
+            Whether this relation can be directly assigned to a user via the
+            grant endpoint. False for computed and structural relations.
+
+    StructuralRelationMetadata:
+      type: object
+      required: [name, parentType]
+      properties:
+        name:
+          type: string
+          example: parent_study
+        parentType:
+          type: string
+          description: The type of the parent organization.
+          example: study
+        description:
+          type: string
+          example: "Links this resource to its parent study."
+
+    ComputedRelationMetadata:
+      type: object
+      required: [name, sourceRelation, parentRelation, grantsRelation]
+      properties:
+        name:
+          type: string
+          example: study_admin_access
+        description:
+          type: string
+          example: "Grants viewer access to admins of the parent study."
+        sourceRelation:
+          type: string
+          description: The role on the parent organization that grants this computed access.
+          example: admin
+        parentRelation:
+          type: string
+          description: The structural relation traversed to reach the parent.
+          example: parent_study
+        grantsRelation:
+          type: string
+          description: The user-facing relation that this computed relation effectively grants on the resource.
+          example: viewer
+
+    ParentCombination:
+      type: object
+      required: [parents]
+      properties:
+        parents:
+          type: array
+          items:
+            type: string
+          description: |
+            List of structural relation names that form a valid combination.
+            For types where valid combinations depend on additional context
+            (e.g., pipeline_type), the condition field describes when this
+            combination applies.
+          example: ["parent_study", "parent_center"]
+        description:
+          type: string
+          example: "Center ingest pipeline — ingests data from a center for a study."
+        condition:
+          type: string
+          description: |
+            Optional condition describing when this parent combination applies.
+            Used when a single resource type has multiple valid parent
+            combinations that depend on the resource's characteristics.
+          example: "pipeline_type is center-ingest"
+
+    # --- Permission schemas ---
+
+    UserPermissions:
+      type: object
+      required: [userId, permissions]
+      properties:
+        userId:
+          type: string
+          example: alice
+        permissions:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              $ref: "#/components/schemas/PermissionEntry"
+          description: |
+            Map of type name to list of permission entries. Each entry represents
+            one resource the user can access with a specific relation.
+          example:
+            study:
+              - resourceId: study1
+                relation: admin
+                access: direct
+            data_pipeline:
+              - resourceId: study1-center1-clinical-ingest
+                relation: viewer
+                access: inherited
+                inheritedFrom:
+                  parentType: study
+                  parentId: study1
+                  parentRole: admin
+
+    PermissionEntry:
+      type: object
+      required: [resourceId, relation, access]
+      properties:
+        resourceId:
+          type: string
+          example: study1-center1-clinical-ingest
+        relation:
+          type: string
+          example: viewer
+        access:
+          type: string
+          enum: [direct, inherited, both]
+          description: |
+            How the user has this access:
+            - direct: explicitly granted
+            - inherited: derived from a parent organization role
+            - both: both directly granted and inherited
+        inheritedFrom:
+          $ref: "#/components/schemas/InheritanceSource"
+
+    InheritanceSource:
+      type: object
+      required: [parentType, parentId, parentRole]
+      description: |
+        Describes why inherited access exists, in domain terms.
+        For example: "user is admin of study:study1, which is the parent study
+        of this data pipeline."
+      properties:
+        parentType:
+          type: string
+          description: The type of the parent organization granting inherited access.
+          example: study
+        parentId:
+          type: string
+          description: The ID of the parent organization.
+          example: study1
+        parentRole:
+          type: string
+          description: The user's role on the parent organization that grants this access.
+          example: admin
+
+    ResourceAccessList:
+      type: object
+      required: [type, resourceId, users]
+      properties:
+        type:
+          type: string
+          example: data_pipeline
+        resourceId:
+          type: string
+          example: study1-center1-clinical-ingest
+        users:
+          type: array
+          items:
+            $ref: "#/components/schemas/ResourceAccessEntry"
+
+    ResourceAccessEntry:
+      type: object
+      required: [userId, relation, access]
+      properties:
+        userId:
+          type: string
+          example: alice
+        relation:
+          type: string
+          example: viewer
+        access:
+          type: string
+          enum: [direct, inherited, both]
+        inheritedFrom:
+          $ref: "#/components/schemas/InheritanceSource"
+
+    PermissionCheckRequest:
+      type: object
+      required: [userId, relation, type, resourceId]
+      properties:
+        userId:
+          type: string
+          example: alice
+        relation:
+          type: string
+          example: viewer
+        type:
+          type: string
+          example: data_pipeline
+        resourceId:
+          type: string
+          example: study1-center1-clinical-ingest
+
+    PermissionCheckResponse:
+      type: object
+      required: [allowed]
+      properties:
+        allowed:
+          type: boolean
+          description: Whether the user has the specified permission.
+          example: true
+
+    EffectivePermissions:
+      type: object
+      required: [userId, type, resourceId, relations]
+      properties:
+        userId:
+          type: string
+          example: alice
+        type:
+          type: string
+          example: data_pipeline
+        resourceId:
+          type: string
+          example: study1-center1-clinical-ingest
+        relations:
+          type: array
+          items:
+            $ref: "#/components/schemas/EffectiveRelation"
+          description: All relations the user effectively holds on this resource.
+
+    EffectiveRelation:
+      type: object
+      required: [relation, access]
+      properties:
+        relation:
+          type: string
+          example: viewer
+        access:
+          type: string
+          enum: [direct, inherited, both]
+        inheritedFrom:
+          $ref: "#/components/schemas/InheritanceSource"
+
+    # --- Access management schemas ---
+
+    GrantRequest:
+      type: object
+      required: [userId, relation, type, resourceId]
+      properties:
+        userId:
+          type: string
+          description: The user to grant access to.
+          example: charlie
+        relation:
+          type: string
+          description: |
+            The relation to grant. Must be a user-assignable relation for the
+            specified type (not a computed or structural relation).
+          example: viewer
+        type:
+          type: string
+          description: The resource or organization type.
+          example: data_pipeline
+        resourceId:
+          type: string
+          description: The resource or organization ID.
+          example: study1-center1-clinical-ingest
+
+    GrantResponse:
+      type: object
+      required: [userId, relation, type, resourceId]
+      properties:
+        userId:
+          type: string
+        relation:
+          type: string
+        type:
+          type: string
+        resourceId:
+          type: string
+
+    RevokeRequest:
+      type: object
+      required: [userId, relation, type, resourceId]
+      properties:
+        userId:
+          type: string
+          example: charlie
+        relation:
+          type: string
+          example: viewer
+        type:
+          type: string
+          example: data_pipeline
+        resourceId:
+          type: string
+          example: study1-center1-clinical-ingest
+
+    RevokeResponse:
+      type: object
+      required: [userId, relation, type, resourceId]
+      properties:
+        userId:
+          type: string
+        relation:
+          type: string
+        type:
+          type: string
+        resourceId:
+          type: string
+
+    # --- Resource hierarchy schemas ---
+
+    ResourceParents:
+      type: object
+      required: [type, resourceId, parents]
+      properties:
+        type:
+          type: string
+          example: data_pipeline
+        resourceId:
+          type: string
+          example: study1-center1-clinical-ingest
+        parents:
+          type: array
+          items:
+            $ref: "#/components/schemas/ParentRelationship"
+
+    ParentRelationship:
+      type: object
+      required: [structuralRelation, parentType, parentId]
+      properties:
+        structuralRelation:
+          type: string
+          description: The structural relation name (e.g., parent_study, parent_center).
+          example: parent_study
+        parentType:
+          type: string
+          description: The type of the parent organization.
+          example: study
+        parentId:
+          type: string
+          description: The ID of the parent organization.
+          example: study1
+
+    SetParentsRequest:
+      type: object
+      required: [parents]
+      properties:
+        parents:
+          type: array
+          items:
+            $ref: "#/components/schemas/ParentRelationship"
+          description: |
+            The parent relationships to set. Must be a valid combination per the
+            authorization model's validParentCombinations for this resource type.
+          example:
+            - structuralRelation: parent_study
+              parentType: study
+              parentId: study1
+            - structuralRelation: parent_center
+              parentType: research_center
+              parentId: center1
+
+    # --- Batch schemas ---
+
+    BatchRequest:
+      type: object
+      required: [operations]
+      properties:
+        operations:
+          type: array
+          maxItems: 100
+          items:
+            $ref: "#/components/schemas/BatchOperation"
+
+    BatchOperation:
+      type: object
+      required: [action, userId, relation, type, resourceId]
+      properties:
+        action:
+          type: string
+          enum: [grant, revoke]
+          description: Whether to grant or revoke this access.
+        userId:
+          type: string
+          example: charlie
+        relation:
+          type: string
+          example: viewer
+        type:
+          type: string
+          example: data_pipeline
+        resourceId:
+          type: string
+          example: study1-center1-clinical-ingest
+
+    BatchResponse:
+      type: object
+      required: [total, succeeded, failed]
+      properties:
+        total:
+          type: integer
+          description: Total number of operations in the batch.
+          example: 10
+        succeeded:
+          type: integer
+          description: Number of operations that succeeded.
+          example: 9
+        failed:
+          type: integer
+          description: Number of operations that failed.
+          example: 1
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/BatchError"
+
+    BatchError:
+      type: object
+      required: [index, error, message]
+      properties:
+        index:
+          type: integer
+          description: Zero-based index of the failed operation in the batch.
+          example: 3
+        error:
+          type: string
+          example: conflict
+        message:
+          type: string
+          example: "Grant already exists."
+
+    # --- Health schemas ---
+
+    HealthResponse:
+      type: object
+      required: [status]
+      properties:
+        status:
+          type: string
+          enum: [healthy, degraded, unhealthy]
+          example: healthy
+        authorizationEngine:
+          type: string
+          enum: [connected, unreachable]
+          example: connected
+
+    # --- Error schemas ---
+
+    ErrorResponse:
+      type: object
+      required: [error, message]
+      properties:
+        error:
+          type: string
+          description: Machine-readable error code.
+          example: validation_error
+        message:
+          type: string
+          description: Human-readable error description.
+          example: "Relation 'parent_study' is a structural relation and cannot be directly assigned. Use the resource hierarchy endpoints instead."
+        details:
+          type: object
+          additionalProperties: true
+          description: Additional error context (optional).

--- a/.kiro/specs/authorization-resource-hierarchy/prompt.md
+++ b/.kiro/specs/authorization-resource-hierarchy/prompt.md
@@ -1,0 +1,97 @@
+# Authorization Resource Hierarchy — Spec Prompt
+
+## Goal
+
+Integrate the project_management gear with the NACC Authorization API so that when the gear creates or manages projects/resources, it seeds the resource parent hierarchy in the Authorization Service. This enables inherited permissions (e.g., study admins automatically get `viewer` on child pipelines).
+
+This depends on the shared client library defined in the `authorization-client-library` spec.
+
+## Context
+
+### Why Resource Hierarchy Matters
+
+The Authorization API uses OpenFGA's hierarchical model. Computed relations (inherited permissions) only work when parent relationships are set:
+
+- `data_pipeline.study_admin_access` — study admins get `viewer` on child pipelines
+- `dashboard.site_viewer` — center members get `viewer` on center-scoped dashboards
+- `dashboard.program_viewer` — study members get `viewer` on study-scoped dashboards
+- `page.community_viewer` — community members get `viewer` on community-scoped pages
+
+Without parent relationships, these computed relations produce no results — users would only have directly-granted permissions.
+
+### Resource Scoping
+
+Resources have different scopes that determine their parent hierarchy:
+
+1. **Center-scoped (by study)** — most data pipelines and center-level dashboards
+   - Parents: `parent_study` + `parent_center`
+   - Example: pipeline `ingest-form` at center `washington` for study `adrc`
+
+2. **Study-scoped** — study-level dashboards, some pages
+   - Parents: `parent_study` only
+   - Example: dashboard `enrollment-all-sites` for study `clariti`
+
+3. **General/community-scoped** — community pages
+   - Parents: `parent_community`
+   - Example: page `community-resources`
+
+### Resource ID Naming Convention
+
+Resource IDs use the existing Flywheel project label scheme:
+
+- `data_pipeline`: `{stage}-{datatype}{suffix}` — e.g., `ingest-form`, `ingest-form-dvcid`, `distribution-data-freeze`
+- `dashboard`: `{name}{suffix}` — e.g., `adrc-reports`, `payment-tracker-clariti`
+- `page`: `{name}{suffix}` — e.g., `community-resources`, `quick-access-link-generator`
+
+Where `suffix` is empty for the primary study (adrc) and `-{study_id}` for affiliated studies.
+
+### Organization IDs
+
+- `study`: the study_id — e.g., `adrc`, `clariti`, `dvcid`, `allftd`, `dlbc`
+- `research_center`: the Flywheel group ID — e.g., `washington`, `upenn-ftld`, `columbia`
+- `community`: `nacc` (single community for now)
+
+### API Endpoint
+
+`PUT /resources/{type}/{resourceId}/parents` — sets parent organizations on a resource. This is idempotent (PUT replaces existing parents).
+
+## Requirements
+
+### Resource Hierarchy Seeding in project_management Gear
+
+When the project_management gear creates a project, it should also set the resource's parent hierarchy in the Authorization API:
+
+- Center-scoped pipelines: `parent_study` + `parent_center`
+- Study-scoped dashboards: `parent_study`
+- Center-scoped dashboards: `parent_study` + `parent_center`
+- Community-scoped pages: `parent_community`
+- Study-scoped pages: `parent_study`
+
+The study YAML files (in data-platform-admin-tasks) contain all the information needed to derive these relationships. The project_management gear already knows the study config, center relationships, and creates the resources — this is the natural place.
+
+### Behavior
+
+- Call `PUT /resources/{type}/{resourceId}/parents` via the shared client library
+- Idempotent: safe to call on every project creation run (PUT replaces existing parents)
+- Should handle transient failures (503) with retry
+- Log errors but do not block project creation on auth service failures
+
+## Design Considerations
+
+- The project_management gear already has the study and center context needed to determine resource scope and parents
+- No new data sources are needed — the study YAML files already define the relationships
+- This should run as part of the existing project creation flow, not as a separate script
+- The PUT endpoint is idempotent, so re-running is safe (no need to check current state first)
+
+## Dependencies
+
+- Shared client library: `.kiro/specs/authorization-client-library`
+
+## References
+
+- Authorization API OpenAPI spec: #[[file:openapi.yaml]]
+- Authorization model definition: `user-management/components/authorization-api/src/python/authorization_api/auth_model.py`
+- OpenFGA schema: `user-management/components/authorization-service/models/schema.json`
+- Study configuration: `data-platform-admin-tasks/data/studies/*/study.yaml`
+- Project naming: `data-platform-admin-tasks/.kiro/steering/project-naming.md`
+- Project management gear: `gear/project_management/`

--- a/.kiro/specs/authorization-user-sync/openapi.yaml
+++ b/.kiro/specs/authorization-user-sync/openapi.yaml
@@ -1,0 +1,1015 @@
+openapi: 3.1.0
+info:
+  title: NACC Authorization API
+  version: 1.0.0
+  description: |
+    Domain-level REST interface to the NACC authorization system.
+    
+    This API provides authorization operations in NACC domain terms — granting access,
+    querying permissions, checking authorization, and managing resource hierarchy.
+    The underlying authorization engine (OpenFGA) is an implementation detail;
+    consumers interact only with this API.
+    
+    See ADR-008 for the architectural decision and rationale.
+  contact:
+    name: NACC Development Team
+
+servers:
+  - url: https://{environment}.api.nacc.example/authorization
+    description: NACC Authorization API
+    variables:
+      environment:
+        default: dev
+        enum: [dev, staging, prod]
+
+tags:
+  - name: Model
+    description: Authorization model metadata — resource types, relations, hierarchy rules, and computed permissions.
+  - name: Permissions
+    description: Query what access exists — user permissions, resource access, and authorization checks.
+  - name: Access Management
+    description: Grant and revoke access to resources and organizations.
+  - name: Resource Hierarchy
+    description: Manage parent relationships that define the resource hierarchy and enable inherited permissions.
+  - name: Batch Operations
+    description: Bulk grant and revoke operations for data loading and synchronization.
+  - name: Health
+    description: Operational health checks.
+
+paths:
+  # ---------------------------------------------------------------------------
+  # Model
+  # ---------------------------------------------------------------------------
+  /model:
+    get:
+      operationId: getModel
+      summary: Get authorization model metadata
+      description: |
+        Returns the complete authorization model: all organization types, resource types,
+        their relations, categories, structural relations, computed relations, and valid
+        parent combinations.
+        
+        This is the single source of truth for authorization model semantics. Consumers
+        use this to populate UI dropdowns, validate inputs client-side, and understand
+        the permission structure.
+      tags: [Model]
+      responses:
+        "200":
+          description: Authorization model metadata.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthorizationModel"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+  /model/types/{type}:
+    get:
+      operationId: getTypeMetadata
+      summary: Get metadata for a specific type
+      description: |
+        Returns metadata for a single organization or resource type, including its
+        relations, category, structural relations, computed relations, and valid
+        parent combinations.
+      tags: [Model]
+      parameters:
+        - $ref: "#/components/parameters/TypePath"
+      responses:
+        "200":
+          description: Type metadata.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TypeMetadata"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  # ---------------------------------------------------------------------------
+  # Permissions
+  # ---------------------------------------------------------------------------
+  /users/{userId}/permissions:
+    get:
+      operationId: getUserPermissions
+      summary: Get all permissions for a user
+      description: |
+        Returns every resource and organization a user can access, grouped by type.
+        Each entry includes the relation and whether the access is direct, inherited,
+        or both.
+        
+        For inherited permissions, the response includes the inheritance source —
+        which parent organization and role grants the access (e.g., "inherited from
+        admin role on study:study1").
+        
+        This is the primary endpoint Portal uses to render what a user can see.
+      tags: [Permissions]
+      parameters:
+        - $ref: "#/components/parameters/UserIdPath"
+        - name: type
+          in: query
+          description: Filter results to a specific resource or organization type.
+          schema:
+            type: string
+            example: data_pipeline
+        - name: relation
+          in: query
+          description: Filter results to a specific relation.
+          schema:
+            type: string
+            example: viewer
+      responses:
+        "200":
+          description: User permissions grouped by type.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserPermissions"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+
+  /resources/{type}/{resourceId}/access:
+    get:
+      operationId: getResourceAccess
+      summary: Get all users with access to a resource
+      description: |
+        Returns all users who have access to the specified resource, with their
+        relation and whether access is direct, inherited, or both.
+        
+        For inherited access, includes the source (parent organization and role).
+        This is the endpoint the Authorization Interface uses for the resource
+        access view.
+      tags: [Permissions]
+      parameters:
+        - $ref: "#/components/parameters/TypePath"
+        - $ref: "#/components/parameters/ResourceIdPath"
+        - name: relation
+          in: query
+          description: Filter to a specific relation.
+          schema:
+            type: string
+            example: viewer
+      responses:
+        "200":
+          description: Users with access to the resource.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResourceAccessList"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /check:
+    post:
+      operationId: checkPermission
+      summary: Check whether a user has a specific permission
+      description: |
+        Returns whether the specified user has the specified relation on the
+        specified resource. Validates that the resource type and relation are
+        valid per the authorization model before evaluating.
+        
+        Use this for real-time authorization decisions (e.g., "can this user
+        view this dashboard?").
+      tags: [Permissions]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PermissionCheckRequest"
+      responses:
+        "200":
+          description: Permission check result.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PermissionCheckResponse"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+
+  /users/{userId}/effective-permissions/{type}/{resourceId}:
+    get:
+      operationId: getEffectivePermissions
+      summary: Get all effective relations a user has on a resource
+      description: |
+        Returns all relations the user effectively holds on the specified resource,
+        including both direct and inherited. This answers "what can this user do
+        on this resource?" without requiring the caller to check each relation
+        individually.
+      tags: [Permissions]
+      parameters:
+        - $ref: "#/components/parameters/UserIdPath"
+        - $ref: "#/components/parameters/TypePath"
+        - $ref: "#/components/parameters/ResourceIdPath"
+      responses:
+        "200":
+          description: Effective permissions on the resource.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EffectivePermissions"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+
+  # ---------------------------------------------------------------------------
+  # Access Management
+  # ---------------------------------------------------------------------------
+  /grants:
+    post:
+      operationId: grantAccess
+      summary: Grant a user access to a resource or organization
+      description: |
+        Grants the specified user the specified relation on the specified resource
+        or organization. Validates that:
+        - The type exists in the authorization model
+        - The relation is user-assignable for that type (not a computed or structural relation)
+        - The user and resource IDs are well-formed
+        
+        Returns 409 if the grant already exists (idempotent consumers should treat
+        409 as success).
+      tags: [Access Management]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/GrantRequest"
+      responses:
+        "201":
+          description: Access granted.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GrantResponse"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "409":
+          description: Grant already exists.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+    delete:
+      operationId: revokeAccess
+      summary: Revoke a user's access to a resource or organization
+      description: |
+        Revokes the specified user's relation on the specified resource or
+        organization. Same validation as grant.
+        
+        Returns 404 if the grant does not exist.
+      tags: [Access Management]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RevokeRequest"
+      responses:
+        "200":
+          description: Access revoked.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RevokeResponse"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  # ---------------------------------------------------------------------------
+  # Resource Hierarchy
+  # ---------------------------------------------------------------------------
+  /resources/{type}/{resourceId}/parents:
+    get:
+      operationId: getResourceParents
+      summary: Get the parent organizations of a resource
+      description: |
+        Returns the current parent relationships for a resource — which study,
+        research center, or community it is linked to. This defines the resource's
+        position in the hierarchy and determines inherited permissions.
+      tags: [Resource Hierarchy]
+      parameters:
+        - $ref: "#/components/parameters/TypePath"
+        - $ref: "#/components/parameters/ResourceIdPath"
+      responses:
+        "200":
+          description: Parent relationships for the resource.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResourceParents"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+
+    put:
+      operationId: setResourceParents
+      summary: Set the parent organizations of a resource
+      description: |
+        Sets the parent relationships for a resource, replacing any existing parents.
+        Validates that:
+        - The structural relation is valid for the resource type
+        - The parent type matches the expected type for that structural relation
+        - The combination of parents is valid per the authorization model
+        
+        This is the primary way to place a resource in the hierarchy. For example,
+        linking a data pipeline to its parent study and center, or linking a
+        dashboard to its parent community.
+      tags: [Resource Hierarchy]
+      parameters:
+        - $ref: "#/components/parameters/TypePath"
+        - $ref: "#/components/parameters/ResourceIdPath"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SetParentsRequest"
+      responses:
+        "200":
+          description: Parents set successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResourceParents"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+
+    delete:
+      operationId: removeResourceParents
+      summary: Remove all parent relationships from a resource
+      description: |
+        Removes all parent relationships from a resource, effectively unlinking it
+        from the hierarchy. This removes any inherited permissions that flowed
+        through those parent relationships.
+        
+        Use with caution — this will immediately revoke inherited access for all
+        users who had it through the hierarchy.
+      tags: [Resource Hierarchy]
+      parameters:
+        - $ref: "#/components/parameters/TypePath"
+        - $ref: "#/components/parameters/ResourceIdPath"
+      responses:
+        "200":
+          description: Parents removed.
+        "400":
+          $ref: "#/components/responses/ValidationError"
+
+  # ---------------------------------------------------------------------------
+  # Batch Operations
+  # ---------------------------------------------------------------------------
+  /grants/batch:
+    post:
+      operationId: batchModifyAccess
+      summary: Grant and/or revoke access in bulk
+      description: |
+        Accepts a list of grant and/or revoke operations (up to 100 per request).
+        Each operation is validated individually. The entire batch is rejected if
+        any operation fails validation (all-or-nothing semantics).
+        
+        Returns a summary of results. Designed for data loading scripts and
+        synchronization workflows.
+      tags: [Batch Operations]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BatchRequest"
+      responses:
+        "200":
+          description: Batch completed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BatchResponse"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+
+  # ---------------------------------------------------------------------------
+  # Health
+  # ---------------------------------------------------------------------------
+  /health:
+    get:
+      operationId: healthCheck
+      summary: Health check
+      description: |
+        Returns the health status of the API, including connectivity to the
+        authorization engine.
+      tags: [Health]
+      responses:
+        "200":
+          description: Service is healthy.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HealthResponse"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+# =============================================================================
+# Components
+# =============================================================================
+components:
+
+  # ---------------------------------------------------------------------------
+  # Parameters
+  # ---------------------------------------------------------------------------
+  parameters:
+    UserIdPath:
+      name: userId
+      in: path
+      required: true
+      description: |
+        User identifier. This is the user's ID within the authorization system
+        (not prefixed with "user:" — the API handles that internally).
+      schema:
+        type: string
+        example: alice
+
+    TypePath:
+      name: type
+      in: path
+      required: true
+      description: |
+        Organization or resource type as defined in the authorization model
+        (e.g., study, research_center, data_pipeline, dashboard, page).
+      schema:
+        type: string
+        example: data_pipeline
+
+    ResourceIdPath:
+      name: resourceId
+      in: path
+      required: true
+      description: |
+        Resource or organization identifier (e.g., "study1",
+        "study1-center1-clinical-ingest").
+      schema:
+        type: string
+        example: study1-center1-clinical-ingest
+
+  # ---------------------------------------------------------------------------
+  # Responses
+  # ---------------------------------------------------------------------------
+  responses:
+    ValidationError:
+      description: Request validation failed.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+          example:
+            error: validation_error
+            message: "Relation 'submitter' is not valid for type 'dashboard'. Valid relations: viewer, editor."
+
+    NotFound:
+      description: Resource not found.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+          example:
+            error: not_found
+            message: "Type 'invalid_type' does not exist in the authorization model."
+
+    ServiceUnavailable:
+      description: Authorization engine is unreachable.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+          example:
+            error: service_unavailable
+            message: "Unable to connect to the authorization engine."
+
+  # ---------------------------------------------------------------------------
+  # Schemas
+  # ---------------------------------------------------------------------------
+  schemas:
+
+    # --- Model schemas ---
+
+    AuthorizationModel:
+      type: object
+      required: [version, types]
+      properties:
+        version:
+          type: string
+          description: Authorization model version (semantic versioning).
+          example: "2.0.0"
+        types:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/TypeMetadata"
+          description: Map of type name to type metadata.
+
+    TypeMetadata:
+      type: object
+      required: [name, category, relations]
+      properties:
+        name:
+          type: string
+          description: Type name.
+          example: data_pipeline
+        category:
+          type: string
+          enum: [organization, resource]
+          description: Whether this is an organization type or a resource type.
+        description:
+          type: string
+          description: Human-readable description of the type.
+          example: "Datatype-specific data collections for ingest or distribution."
+        relations:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/RelationMetadata"
+          description: Map of relation name to relation metadata.
+        structuralRelations:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/StructuralRelationMetadata"
+          description: |
+            Structural relations that link this type to parent organizations.
+            Only present for resource types that participate in the hierarchy.
+        computedRelations:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/ComputedRelationMetadata"
+          description: |
+            Computed relations that derive permissions from the hierarchy.
+            These are never directly assigned — they are resolved by the
+            authorization engine based on structural relations.
+        validParentCombinations:
+          type: array
+          items:
+            $ref: "#/components/schemas/ParentCombination"
+          description: |
+            Valid combinations of parent relationships for this type.
+            Only present for resource types with structural relations.
+
+    RelationMetadata:
+      type: object
+      required: [name, assignable]
+      properties:
+        name:
+          type: string
+          example: viewer
+        description:
+          type: string
+          example: "Can view pipeline data."
+        assignable:
+          type: boolean
+          description: |
+            Whether this relation can be directly assigned to a user via the
+            grant endpoint. False for computed and structural relations.
+
+    StructuralRelationMetadata:
+      type: object
+      required: [name, parentType]
+      properties:
+        name:
+          type: string
+          example: parent_study
+        parentType:
+          type: string
+          description: The type of the parent organization.
+          example: study
+        description:
+          type: string
+          example: "Links this resource to its parent study."
+
+    ComputedRelationMetadata:
+      type: object
+      required: [name, sourceRelation, parentRelation, grantsRelation]
+      properties:
+        name:
+          type: string
+          example: study_admin_access
+        description:
+          type: string
+          example: "Grants viewer access to admins of the parent study."
+        sourceRelation:
+          type: string
+          description: The role on the parent organization that grants this computed access.
+          example: admin
+        parentRelation:
+          type: string
+          description: The structural relation traversed to reach the parent.
+          example: parent_study
+        grantsRelation:
+          type: string
+          description: The user-facing relation that this computed relation effectively grants on the resource.
+          example: viewer
+
+    ParentCombination:
+      type: object
+      required: [parents]
+      properties:
+        parents:
+          type: array
+          items:
+            type: string
+          description: |
+            List of structural relation names that form a valid combination.
+            For types where valid combinations depend on additional context
+            (e.g., pipeline_type), the condition field describes when this
+            combination applies.
+          example: ["parent_study", "parent_center"]
+        description:
+          type: string
+          example: "Center ingest pipeline — ingests data from a center for a study."
+        condition:
+          type: string
+          description: |
+            Optional condition describing when this parent combination applies.
+            Used when a single resource type has multiple valid parent
+            combinations that depend on the resource's characteristics.
+          example: "pipeline_type is center-ingest"
+
+    # --- Permission schemas ---
+
+    UserPermissions:
+      type: object
+      required: [userId, permissions]
+      properties:
+        userId:
+          type: string
+          example: alice
+        permissions:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              $ref: "#/components/schemas/PermissionEntry"
+          description: |
+            Map of type name to list of permission entries. Each entry represents
+            one resource the user can access with a specific relation.
+          example:
+            study:
+              - resourceId: study1
+                relation: admin
+                access: direct
+            data_pipeline:
+              - resourceId: study1-center1-clinical-ingest
+                relation: viewer
+                access: inherited
+                inheritedFrom:
+                  parentType: study
+                  parentId: study1
+                  parentRole: admin
+
+    PermissionEntry:
+      type: object
+      required: [resourceId, relation, access]
+      properties:
+        resourceId:
+          type: string
+          example: study1-center1-clinical-ingest
+        relation:
+          type: string
+          example: viewer
+        access:
+          type: string
+          enum: [direct, inherited, both]
+          description: |
+            How the user has this access:
+            - direct: explicitly granted
+            - inherited: derived from a parent organization role
+            - both: both directly granted and inherited
+        inheritedFrom:
+          $ref: "#/components/schemas/InheritanceSource"
+
+    InheritanceSource:
+      type: object
+      required: [parentType, parentId, parentRole]
+      description: |
+        Describes why inherited access exists, in domain terms.
+        For example: "user is admin of study:study1, which is the parent study
+        of this data pipeline."
+      properties:
+        parentType:
+          type: string
+          description: The type of the parent organization granting inherited access.
+          example: study
+        parentId:
+          type: string
+          description: The ID of the parent organization.
+          example: study1
+        parentRole:
+          type: string
+          description: The user's role on the parent organization that grants this access.
+          example: admin
+
+    ResourceAccessList:
+      type: object
+      required: [type, resourceId, users]
+      properties:
+        type:
+          type: string
+          example: data_pipeline
+        resourceId:
+          type: string
+          example: study1-center1-clinical-ingest
+        users:
+          type: array
+          items:
+            $ref: "#/components/schemas/ResourceAccessEntry"
+
+    ResourceAccessEntry:
+      type: object
+      required: [userId, relation, access]
+      properties:
+        userId:
+          type: string
+          example: alice
+        relation:
+          type: string
+          example: viewer
+        access:
+          type: string
+          enum: [direct, inherited, both]
+        inheritedFrom:
+          $ref: "#/components/schemas/InheritanceSource"
+
+    PermissionCheckRequest:
+      type: object
+      required: [userId, relation, type, resourceId]
+      properties:
+        userId:
+          type: string
+          example: alice
+        relation:
+          type: string
+          example: viewer
+        type:
+          type: string
+          example: data_pipeline
+        resourceId:
+          type: string
+          example: study1-center1-clinical-ingest
+
+    PermissionCheckResponse:
+      type: object
+      required: [allowed]
+      properties:
+        allowed:
+          type: boolean
+          description: Whether the user has the specified permission.
+          example: true
+
+    EffectivePermissions:
+      type: object
+      required: [userId, type, resourceId, relations]
+      properties:
+        userId:
+          type: string
+          example: alice
+        type:
+          type: string
+          example: data_pipeline
+        resourceId:
+          type: string
+          example: study1-center1-clinical-ingest
+        relations:
+          type: array
+          items:
+            $ref: "#/components/schemas/EffectiveRelation"
+          description: All relations the user effectively holds on this resource.
+
+    EffectiveRelation:
+      type: object
+      required: [relation, access]
+      properties:
+        relation:
+          type: string
+          example: viewer
+        access:
+          type: string
+          enum: [direct, inherited, both]
+        inheritedFrom:
+          $ref: "#/components/schemas/InheritanceSource"
+
+    # --- Access management schemas ---
+
+    GrantRequest:
+      type: object
+      required: [userId, relation, type, resourceId]
+      properties:
+        userId:
+          type: string
+          description: The user to grant access to.
+          example: charlie
+        relation:
+          type: string
+          description: |
+            The relation to grant. Must be a user-assignable relation for the
+            specified type (not a computed or structural relation).
+          example: viewer
+        type:
+          type: string
+          description: The resource or organization type.
+          example: data_pipeline
+        resourceId:
+          type: string
+          description: The resource or organization ID.
+          example: study1-center1-clinical-ingest
+
+    GrantResponse:
+      type: object
+      required: [userId, relation, type, resourceId]
+      properties:
+        userId:
+          type: string
+        relation:
+          type: string
+        type:
+          type: string
+        resourceId:
+          type: string
+
+    RevokeRequest:
+      type: object
+      required: [userId, relation, type, resourceId]
+      properties:
+        userId:
+          type: string
+          example: charlie
+        relation:
+          type: string
+          example: viewer
+        type:
+          type: string
+          example: data_pipeline
+        resourceId:
+          type: string
+          example: study1-center1-clinical-ingest
+
+    RevokeResponse:
+      type: object
+      required: [userId, relation, type, resourceId]
+      properties:
+        userId:
+          type: string
+        relation:
+          type: string
+        type:
+          type: string
+        resourceId:
+          type: string
+
+    # --- Resource hierarchy schemas ---
+
+    ResourceParents:
+      type: object
+      required: [type, resourceId, parents]
+      properties:
+        type:
+          type: string
+          example: data_pipeline
+        resourceId:
+          type: string
+          example: study1-center1-clinical-ingest
+        parents:
+          type: array
+          items:
+            $ref: "#/components/schemas/ParentRelationship"
+
+    ParentRelationship:
+      type: object
+      required: [structuralRelation, parentType, parentId]
+      properties:
+        structuralRelation:
+          type: string
+          description: The structural relation name (e.g., parent_study, parent_center).
+          example: parent_study
+        parentType:
+          type: string
+          description: The type of the parent organization.
+          example: study
+        parentId:
+          type: string
+          description: The ID of the parent organization.
+          example: study1
+
+    SetParentsRequest:
+      type: object
+      required: [parents]
+      properties:
+        parents:
+          type: array
+          items:
+            $ref: "#/components/schemas/ParentRelationship"
+          description: |
+            The parent relationships to set. Must be a valid combination per the
+            authorization model's validParentCombinations for this resource type.
+          example:
+            - structuralRelation: parent_study
+              parentType: study
+              parentId: study1
+            - structuralRelation: parent_center
+              parentType: research_center
+              parentId: center1
+
+    # --- Batch schemas ---
+
+    BatchRequest:
+      type: object
+      required: [operations]
+      properties:
+        operations:
+          type: array
+          maxItems: 100
+          items:
+            $ref: "#/components/schemas/BatchOperation"
+
+    BatchOperation:
+      type: object
+      required: [action, userId, relation, type, resourceId]
+      properties:
+        action:
+          type: string
+          enum: [grant, revoke]
+          description: Whether to grant or revoke this access.
+        userId:
+          type: string
+          example: charlie
+        relation:
+          type: string
+          example: viewer
+        type:
+          type: string
+          example: data_pipeline
+        resourceId:
+          type: string
+          example: study1-center1-clinical-ingest
+
+    BatchResponse:
+      type: object
+      required: [total, succeeded, failed]
+      properties:
+        total:
+          type: integer
+          description: Total number of operations in the batch.
+          example: 10
+        succeeded:
+          type: integer
+          description: Number of operations that succeeded.
+          example: 9
+        failed:
+          type: integer
+          description: Number of operations that failed.
+          example: 1
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/BatchError"
+
+    BatchError:
+      type: object
+      required: [index, error, message]
+      properties:
+        index:
+          type: integer
+          description: Zero-based index of the failed operation in the batch.
+          example: 3
+        error:
+          type: string
+          example: conflict
+        message:
+          type: string
+          example: "Grant already exists."
+
+    # --- Health schemas ---
+
+    HealthResponse:
+      type: object
+      required: [status]
+      properties:
+        status:
+          type: string
+          enum: [healthy, degraded, unhealthy]
+          example: healthy
+        authorizationEngine:
+          type: string
+          enum: [connected, unreachable]
+          example: connected
+
+    # --- Error schemas ---
+
+    ErrorResponse:
+      type: object
+      required: [error, message]
+      properties:
+        error:
+          type: string
+          description: Machine-readable error code.
+          example: validation_error
+        message:
+          type: string
+          description: Human-readable error description.
+          example: "Relation 'parent_study' is a structural relation and cannot be directly assigned. Use the resource hierarchy endpoints instead."
+        details:
+          type: object
+          additionalProperties: true
+          description: Additional error context (optional).

--- a/.kiro/specs/authorization-user-sync/prompt.md
+++ b/.kiro/specs/authorization-user-sync/prompt.md
@@ -1,0 +1,124 @@
+# Authorization User Sync — Spec Prompt
+
+## Goal
+
+Integrate the user_management gear with the NACC Authorization API so that when the gear processes user authorizations, it writes the corresponding grants to the Authorization Service in addition to its existing Flywheel role assignment.
+
+This depends on the shared client library defined in the `authorization-client-library` spec.
+
+## Context
+
+### Authorization Model (types and relations)
+
+The Authorization API enforces this model:
+
+**Resource types relevant to user sync:**
+
+- `data_pipeline` — relations: `viewer`, `submitter`, `auditor`
+- `dashboard` — relations: `viewer`, `editor`
+- `page` — relations: `viewer`
+
+**Organization IDs:**
+
+- `study`: the study_id — e.g., `adrc`, `clariti`, `dvcid`, `allftd`, `dlbc`
+- `research_center`: the Flywheel group ID — e.g., `washington`, `upenn-ftld`, `columbia`
+- `community`: `nacc` (single community for now)
+
+### Resource ID Naming Convention
+
+Resource IDs use the existing Flywheel project label scheme:
+
+- `data_pipeline`: `{stage}-{datatype}{suffix}` — e.g., `ingest-form`, `ingest-form-dvcid`, `distribution-data-freeze`
+- `dashboard`: `{name}{suffix}` — e.g., `adrc-reports`, `payment-tracker-clariti`
+- `page`: `{name}{suffix}` — e.g., `community-resources`, `quick-access-link-generator`
+
+Where `suffix` is empty for the primary study (adrc) and `-{study_id}` for affiliated studies.
+
+### Gear's Current Authorization Model
+
+The gear processes `DirectoryAuthorizations` from the NACC Directory (REDCap) and produces:
+
+- `CenterUserEntry` with:
+  - `registry_id` — the user's registry identifier (ePPN from CILogon), used as the user ID in the Authorization API
+  - `study_authorizations: list[StudyAuthorizations]` — each has a `study_id` and activities
+  - `authorizations: Authorizations` — general (non-center) activities
+  - The center group ID (string, e.g., `washington`) is resolved by the caller via `CenterGroup`
+
+- `Activity` = `action` + `Resource`:
+  - Actions: `submit-audit`, `view`
+  - Resources: `DatatypeResource(datatype)`, `DashboardResource(dashboard)`, `PageResource(page)`
+
+### Activity-to-Relation Mapping
+
+| Gear Action    | Resource Type       | Auth API Type   | Auth API Relation |
+| -------------- | ------------------- | --------------- | ----------------- |
+| `submit-audit` | `DatatypeResource`  | `data_pipeline` | `submitter`       |
+| `view`         | `DatatypeResource`  | `data_pipeline` | `viewer`          |
+| `view`         | `DashboardResource` | `dashboard`     | `viewer`          |
+| `view`         | `PageResource`      | `page`          | `viewer`          |
+
+`submitter` and `viewer` are independent relations in the OpenFGA schema — `submitter` does NOT imply `viewer`. The gear must grant both `submitter` and `viewer` when the user has `submit-audit`. When downgrading from `submit-audit` to `view`, the diff logic revokes `submitter` and keeps `viewer`.
+
+### Sync Model
+
+The gear's pattern is "here's a user, here's what they should have." There is no "replace all" endpoint — the API is grant/revoke based. The sync process:
+
+1. Queries current grants via `GET /users/{userId}/permissions`
+2. Computes the diff against desired state
+3. Applies adds/revokes via `POST /grants/batch`
+
+The 100-operation batch limit is not a concern for a single user (typical max ~30-50 grants). If it ever exceeds 100, the client chunks into multiple batch calls.
+
+## Requirements
+
+### 1. Activity-to-Grant Translator
+
+A module that translates the gear's authorization vocabulary to the API's vocabulary:
+
+- Maps `Activity` (action + resource) to `(type, relation)` pairs using a simple module-level constant (no external config file — the mapping is small and well-defined)
+- Resolves resource IDs from study context (study_id, center group ID, datatype, etc.)
+- Receives the already-resolved center group ID from the caller (does not perform adcid → group ID lookup itself)
+- Handles the suffix logic (primary study = no suffix, affiliated = `-{study_id}`)
+- Determines resource scope (center-scoped, study-scoped, general)
+
+### 2. Authorization Sync Process
+
+A process that, given a user (identified by `registry_id`) and their authorizations:
+
+1. Translates the user's activities to the set of grants they should have
+2. Queries the Authorization API for the user's current grants (via the client library)
+3. Computes the diff (grants to add, grants to revoke)
+4. Applies the diff via batch operations (via the client library)
+5. Retries on transient failures (503); logs errors if retries are exhausted but does not block Flywheel processing
+
+### 3. Integration with User Management Gear
+
+Add the authorization sync as a step in the user processing pipeline:
+
+- After the gear computes what a user should have (existing logic unchanged)
+- Call the authorization sync process with the user's `registry_id` and translated grants
+- The existing Flywheel role assignment continues unchanged (parallel output)
+- Auth service sync retries on transient failures; if retries are exhausted, log the failure (the Portal depends on this data being current) but do not block Flywheel processing
+- Failed syncs should be reported via the existing `UserEventCollector` pattern so operators have visibility
+
+## Design Considerations
+
+- The activity-to-relation mapping is a simple module-level constant (not externally configurable); refactor to config if it grows
+- The sync process should support both full-sync (all users) and single-user sync
+- Consider batching: the gear processes many users per run; batch API calls where possible
+- The user ID in the Authorization API is the `registry_id` (ePPN from CILogon), passed as-is
+- The center group ID (string) is passed to the translator by the caller — no adcid resolution needed in this layer
+- No rate limiting concerns at current scale (hundreds of users, nightly runs, sequential batch calls)
+
+## Dependencies
+
+- Shared client library: `.kiro/specs/authorization-client-library`
+- Resource hierarchy must be seeded by project_management gear before grants will inherit correctly: `.kiro/specs/authorization-resource-hierarchy`
+
+## References
+
+- Gear authorization logic: `common/src/python/users/authorization_visitor.py`, `user_processes.py`
+- Study configuration: `data-platform-admin-tasks/data/studies/*/study.yaml`
+- Project naming: `data-platform-admin-tasks/.kiro/steering/project-naming.md`
+- Auth map (activity → Flywheel roles): `data-platform-admin-tasks/data/user-admin/authorizations.yaml`
+- Authorization API OpenAPI spec: #[[file:openapi.yaml]]

--- a/common/src/python/authorization/BUILD
+++ b/common/src/python/authorization/BUILD
@@ -1,0 +1,1 @@
+python_sources(name="lib")

--- a/common/src/python/authorization/__init__.py
+++ b/common/src/python/authorization/__init__.py
@@ -1,1 +1,66 @@
 """Authorization client library for the NACC Authorization API."""
+
+from authorization.client import AuthorizationClient
+from authorization.exceptions import (
+    AuthorizationClientError,
+    ConfigurationError,
+    ParseError,
+    ServiceUnavailableError,
+    UnexpectedError,
+    ValidationError,
+)
+from authorization.factory import create_authorization_client
+from authorization.models import (
+    BatchError,
+    BatchOperation,
+    BatchOperationModel,
+    BatchRequestModel,
+    BatchResult,
+    ErrorResponse,
+    GrantRequest,
+    GrantResult,
+    HealthResult,
+    InheritanceSource,
+    ParentRelationship,
+    ParentRelationshipModel,
+    PermissionEntry,
+    ResourceParents,
+    RevokeRequest,
+    RevokeResult,
+    SetParentsRequestModel,
+    UserPermissions,
+)
+from authorization.sigv4_transport import SigV4Transport
+from authorization.transport import HttpResponse, HttpTransport
+
+__all__ = [
+    "AuthorizationClient",
+    "AuthorizationClientError",
+    "BatchError",
+    "BatchOperation",
+    "BatchOperationModel",
+    "BatchRequestModel",
+    "BatchResult",
+    "ConfigurationError",
+    "ErrorResponse",
+    "GrantRequest",
+    "GrantResult",
+    "HealthResult",
+    "HttpResponse",
+    "HttpTransport",
+    "InheritanceSource",
+    "ParentRelationship",
+    "ParentRelationshipModel",
+    "ParseError",
+    "PermissionEntry",
+    "ResourceParents",
+    "RevokeRequest",
+    "RevokeResult",
+    "ServiceUnavailableError",
+    "SetParentsRequestModel",
+    "SigV4Transport",
+    "UnexpectedError",
+    "UserPermissions",
+    "ValidationError",
+    "create_authorization_client",
+]

--- a/common/src/python/authorization/__init__.py
+++ b/common/src/python/authorization/__init__.py
@@ -1,0 +1,1 @@
+"""Authorization client library for the NACC Authorization API."""

--- a/common/src/python/authorization/client.py
+++ b/common/src/python/authorization/client.py
@@ -1,0 +1,698 @@
+"""Authorization client for the NACC Authorization API."""
+
+import json
+import logging
+import math
+from collections.abc import Callable
+from typing import Any
+
+from authorization.exceptions import (
+    ParseError,
+    UnexpectedError,
+    ValidationError,
+)
+from authorization.models import (
+    BatchError,
+    BatchOperation,
+    BatchOperationModel,
+    BatchRequestModel,
+    BatchResult,
+    ErrorResponse,
+    GrantRequest,
+    GrantResult,
+    HealthResult,
+    ParentRelationshipModel,
+    ResourceParents,
+    RevokeRequest,
+    RevokeResult,
+    SetParentsRequestModel,
+    UserPermissions,
+)
+from authorization.retry import retry_on_503
+from authorization.transport import HttpResponse, HttpTransport
+
+log = logging.getLogger(__name__)
+
+# Maximum number of operations per batch chunk
+_BATCH_CHUNK_SIZE = 100
+
+# Per-operation error codes treated as idempotent success
+_IDEMPOTENT_ERROR_CODES = frozenset({"conflict", "not_found"})
+
+# Per-operation error codes treated as retriable failures
+_RETRIABLE_ERROR_CODES = frozenset({"service_unavailable"})
+
+
+class AuthorizationClient:
+    """Client for the NACC Authorization API.
+
+    Provides typed, idempotent access to authorization operations with
+    automatic retry on transient failures and transparent batch
+    chunking.
+    """
+
+    def __init__(
+        self,
+        transport: HttpTransport,
+        max_retries: int = 3,
+        base_backoff: float = 1.0,
+        sleep: Callable[[float], None] | None = None,
+    ) -> None:
+        """Initialize the authorization client.
+
+        Args:
+            transport: HTTP transport implementation for sending requests.
+            max_retries: Maximum retry attempts on 503 responses.
+            base_backoff: Base delay in seconds for exponential backoff.
+            sleep: Optional sleep callable for testing. If None, uses
+                time.sleep via the retry module default.
+        """
+        self._transport = transport
+        self._max_retries = max_retries
+        self._base_backoff = base_backoff
+        self._sleep = sleep
+
+    def _retry_kwargs(self) -> dict[str, Any]:
+        """Build keyword arguments for retry_on_503."""
+        kwargs: dict[str, Any] = {
+            "max_retries": self._max_retries,
+            "base_backoff": self._base_backoff,
+        }
+        if self._sleep is not None:
+            kwargs["sleep"] = self._sleep
+        return kwargs
+
+    def grant(
+        self,
+        user_id: str,
+        resource_type: str,
+        resource_id: str,
+        relation: str,
+    ) -> GrantResult:
+        """Grant a user a relation on a resource.
+
+        Sends a POST request to /grants. Treats HTTP 409 (grant already
+        exists) as a successful idempotent outcome.
+
+        Args:
+            user_id: The user identifier (e.g., ePPN).
+            resource_type: The type of resource.
+            resource_id: The resource identifier.
+            relation: The relation to grant.
+
+        Returns:
+            GrantResult containing the granted relationship details.
+
+        Raises:
+            ValidationError: If the API returns 400.
+            ServiceUnavailableError: If retries are exhausted on 503.
+            UnexpectedError: On other unexpected HTTP errors.
+        """
+        request = GrantRequest(
+            user_id=user_id,
+            relation=relation,
+            type=resource_type,
+            resource_id=resource_id,
+        )
+        body = request.model_dump_json(by_alias=True).encode()
+
+        def do_request() -> HttpResponse:
+            return self._transport.request(
+                method="POST",
+                path="/grants",
+                body=body,
+            )
+
+        response = retry_on_503(do_request, **self._retry_kwargs())
+
+        if response.status_code in (200, 201):
+            log.debug(
+                "Grant succeeded: user=%s, type=%s, resource=%s, relation=%s",
+                user_id,
+                resource_type,
+                resource_id,
+                relation,
+            )
+            try:
+                return GrantResult.model_validate_json(response.body)
+            except Exception as exc:
+                raise ParseError(
+                    message=f"Failed to parse grant response: {exc}",
+                    raw_content=response.body,
+                ) from exc
+
+        if response.status_code == 409:
+            log.debug(
+                "Grant already exists (idempotent): user=%s, type=%s, "
+                "resource=%s, relation=%s",
+                user_id,
+                resource_type,
+                resource_id,
+                relation,
+            )
+            return GrantResult(
+                user_id=user_id,
+                relation=relation,
+                type=resource_type,
+                resource_id=resource_id,
+            )
+
+        if response.status_code == 400:
+            error_resp = self._parse_error_response(response)
+            log.error(
+                "Grant validation error: %s",
+                error_resp.message,
+            )
+            raise ValidationError(
+                message=error_resp.message,
+                details=error_resp.details,
+            )
+
+        # Any other error status
+        error_msg = self._extract_error_message(response)
+        log.error(
+            "Grant unexpected error %d: %s",
+            response.status_code,
+            error_msg,
+        )
+        raise UnexpectedError(
+            status_code=response.status_code,
+            message=error_msg,
+        )
+
+    def revoke(
+        self,
+        user_id: str,
+        resource_type: str,
+        resource_id: str,
+        relation: str,
+    ) -> RevokeResult:
+        """Revoke a user's relation on a resource.
+
+        Sends a DELETE request to /grants. Treats HTTP 404 (grant does
+        not exist) as a successful idempotent outcome.
+
+        Args:
+            user_id: The user identifier (e.g., ePPN).
+            resource_type: The type of resource.
+            resource_id: The resource identifier.
+            relation: The relation to revoke.
+
+        Returns:
+            RevokeResult containing the revoked relationship details.
+
+        Raises:
+            ValidationError: If the API returns 400.
+            ServiceUnavailableError: If retries are exhausted on 503.
+            UnexpectedError: On other unexpected HTTP errors.
+        """
+        request = RevokeRequest(
+            user_id=user_id,
+            relation=relation,
+            type=resource_type,
+            resource_id=resource_id,
+        )
+        body = request.model_dump_json(by_alias=True).encode()
+
+        def do_request() -> HttpResponse:
+            return self._transport.request(
+                method="DELETE",
+                path="/grants",
+                body=body,
+            )
+
+        response = retry_on_503(do_request, **self._retry_kwargs())
+
+        if response.status_code == 200:
+            log.debug(
+                "Revoke succeeded: user=%s, type=%s, resource=%s, relation=%s",
+                user_id,
+                resource_type,
+                resource_id,
+                relation,
+            )
+            try:
+                return RevokeResult.model_validate_json(response.body)
+            except Exception as exc:
+                raise ParseError(
+                    message=f"Failed to parse revoke response: {exc}",
+                    raw_content=response.body,
+                ) from exc
+
+        if response.status_code == 404:
+            log.debug(
+                "Revoke target not found (idempotent): user=%s, type=%s, "
+                "resource=%s, relation=%s",
+                user_id,
+                resource_type,
+                resource_id,
+                relation,
+            )
+            return RevokeResult(
+                user_id=user_id,
+                relation=relation,
+                type=resource_type,
+                resource_id=resource_id,
+            )
+
+        if response.status_code == 400:
+            error_resp = self._parse_error_response(response)
+            log.error(
+                "Revoke validation error: %s",
+                error_resp.message,
+            )
+            raise ValidationError(
+                message=error_resp.message,
+                details=error_resp.details,
+            )
+
+        # Any other error status
+        error_msg = self._extract_error_message(response)
+        log.error(
+            "Revoke unexpected error %d: %s",
+            response.status_code,
+            error_msg,
+        )
+        raise UnexpectedError(
+            status_code=response.status_code,
+            message=error_msg,
+        )
+
+    def batch(
+        self,
+        operations: list[BatchOperation],
+    ) -> BatchResult:
+        """Submit a batch of grant and revoke operations.
+
+        Splits operations into chunks of at most 100, preserving order,
+        and sends each chunk as a separate POST to /grants/batch. Results
+        are aggregated across all chunks.
+
+        Per-operation errors are classified:
+        - conflict/not_found: counted as idempotent success
+        - service_unavailable: reported as retriable failure
+        - Other: reported as non-retriable failure
+
+        Args:
+            operations: List of batch operations to execute.
+
+        Returns:
+            Aggregate BatchResult with totals across all chunks.
+
+        Raises:
+            ValidationError: If the API returns 400 for the batch.
+            ServiceUnavailableError: If retries are exhausted on 503.
+            UnexpectedError: On other unexpected HTTP errors.
+        """
+        if not operations:
+            return BatchResult(total=0, succeeded=0, failed=0, errors=[])
+
+        num_chunks = max(1, math.ceil(len(operations) / _BATCH_CHUNK_SIZE))
+        chunks = [
+            operations[i * _BATCH_CHUNK_SIZE : (i + 1) * _BATCH_CHUNK_SIZE]
+            for i in range(num_chunks)
+        ]
+
+        total = 0
+        succeeded = 0
+        failed = 0
+        errors: list[BatchError] = []
+
+        for chunk_index, chunk in enumerate(chunks):
+            chunk_result = self._execute_batch_chunk(chunk, chunk_index)
+            total += chunk_result.total
+            succeeded += chunk_result.succeeded
+            failed += chunk_result.failed
+            errors.extend(chunk_result.errors)
+
+        return BatchResult(
+            total=total,
+            succeeded=succeeded,
+            failed=failed,
+            errors=errors,
+        )
+
+    def _execute_batch_chunk(
+        self,
+        chunk: list[BatchOperation],
+        chunk_index: int,
+    ) -> BatchResult:
+        """Execute a single batch chunk and classify results.
+
+        Args:
+            chunk: List of operations (at most 100).
+            chunk_index: Zero-based index of this chunk for logging.
+
+        Returns:
+            BatchResult for this chunk with classified outcomes.
+        """
+        request_model = BatchRequestModel(
+            operations=[
+                BatchOperationModel(
+                    action=op.action,
+                    user_id=op.user_id,
+                    relation=op.relation,
+                    type=op.resource_type,
+                    resource_id=op.resource_id,
+                )
+                for op in chunk
+            ]
+        )
+
+        body = request_model.model_dump_json(by_alias=True).encode()
+
+        def do_request() -> HttpResponse:
+            return self._transport.request(
+                method="POST",
+                path="/grants/batch",
+                body=body,
+            )
+
+        response = retry_on_503(do_request, **self._retry_kwargs())
+
+        if response.status_code == 400:
+            error_resp = self._parse_error_response(response)
+            log.error(
+                "Batch chunk %d validation error: %s",
+                chunk_index,
+                error_resp.message,
+            )
+            raise ValidationError(
+                message=error_resp.message,
+                details=error_resp.details,
+            )
+
+        if response.status_code not in (200, 201):
+            error_msg = self._extract_error_message(response)
+            log.error(
+                "Batch chunk %d unexpected error %d: %s",
+                chunk_index,
+                response.status_code,
+                error_msg,
+            )
+            raise UnexpectedError(
+                status_code=response.status_code,
+                message=error_msg,
+            )
+
+        # Parse the batch response
+        chunk_result = self._parse_batch_response(response)
+
+        # Classify per-operation errors
+        return self._classify_batch_errors(chunk_result, chunk_index)
+
+    def _classify_batch_errors(
+        self,
+        raw_result: BatchResult,
+        chunk_index: int,
+    ) -> BatchResult:
+        """Classify per-operation errors in a batch response.
+
+        - conflict/not_found errors are idempotent successes
+        - service_unavailable errors are retriable failures
+        - Other errors are non-retriable failures
+
+        Args:
+            raw_result: The raw BatchResult from the API response.
+            chunk_index: Zero-based chunk index for logging.
+
+        Returns:
+            A new BatchResult with adjusted counts.
+        """
+        idempotent_count = 0
+        real_errors: list[BatchError] = []
+
+        for error in raw_result.errors:
+            if error.error in _IDEMPOTENT_ERROR_CODES:
+                idempotent_count += 1
+                log.debug(
+                    "Batch chunk %d operation %d: idempotent outcome (%s)",
+                    chunk_index,
+                    error.index,
+                    error.error,
+                )
+            else:
+                real_errors.append(error)
+                if error.error in _RETRIABLE_ERROR_CODES:
+                    log.warning(
+                        "Batch chunk %d operation %d: retriable error (%s)",
+                        chunk_index,
+                        error.index,
+                        error.error,
+                    )
+                else:
+                    log.error(
+                        "Batch chunk %d operation %d: failed (%s: %s)",
+                        chunk_index,
+                        error.index,
+                        error.error,
+                        error.message,
+                    )
+
+        return BatchResult(
+            total=raw_result.total,
+            succeeded=raw_result.succeeded + idempotent_count,
+            failed=raw_result.failed - idempotent_count,
+            errors=real_errors,
+        )
+
+    def get_user_permissions(
+        self,
+        user_id: str,
+        type_filter: str | None = None,
+        relation_filter: str | None = None,
+    ) -> UserPermissions:
+        """Retrieve all resources a user can access.
+
+        Sends a GET request to /users/{userId}/permissions with optional
+        type and relation query parameters for filtering.
+
+        Args:
+            user_id: The user identifier (e.g., ePPN).
+            type_filter: Optional resource type to filter by.
+            relation_filter: Optional relation to filter by.
+
+        Returns:
+            UserPermissions containing the user's permissions grouped
+            by resource type.
+
+        Raises:
+            ServiceUnavailableError: If retries are exhausted on 503.
+            UnexpectedError: On unexpected HTTP errors.
+            ParseError: If the response body cannot be parsed.
+        """
+        path = f"/users/{user_id}/permissions"
+        query_params: dict[str, str] = {}
+        if type_filter is not None:
+            query_params["type"] = type_filter
+        if relation_filter is not None:
+            query_params["relation"] = relation_filter
+
+        def do_request() -> HttpResponse:
+            return self._transport.request(
+                method="GET",
+                path=path,
+                body=None,
+                query_params=query_params or None,
+            )
+
+        response = retry_on_503(do_request, **self._retry_kwargs())
+
+        if response.status_code == 200:
+            log.debug(
+                "Get user permissions succeeded: user=%s",
+                user_id,
+            )
+            try:
+                return UserPermissions.model_validate_json(response.body)
+            except Exception as exc:
+                raise ParseError(
+                    message=(f"Failed to parse user permissions response: {exc}"),
+                    raw_content=response.body,
+                ) from exc
+
+        # Any other error status
+        error_msg = self._extract_error_message(response)
+        log.error(
+            "Get user permissions unexpected error %d: %s",
+            response.status_code,
+            error_msg,
+        )
+        raise UnexpectedError(
+            status_code=response.status_code,
+            message=error_msg,
+        )
+
+    def set_resource_parents(
+        self,
+        resource_type: str,
+        resource_id: str,
+        parents: list[ParentRelationshipModel],
+    ) -> ResourceParents:
+        """Set the parent organizations of a resource.
+
+        Sends a PUT request to /resources/{type}/{resourceId}/parents
+        with the list of parent relationships.
+
+        Args:
+            resource_type: The type of resource.
+            resource_id: The resource identifier.
+            parents: List of parent relationships to set.
+
+        Returns:
+            ResourceParents containing the updated parent relationships.
+
+        Raises:
+            ValidationError: If the API returns 400.
+            ServiceUnavailableError: If retries are exhausted on 503.
+            UnexpectedError: On other unexpected HTTP errors.
+            ParseError: If the response body cannot be parsed.
+        """
+        request = SetParentsRequestModel(parents=parents)
+        body = request.model_dump_json(by_alias=True).encode()
+        path = f"/resources/{resource_type}/{resource_id}/parents"
+
+        def do_request() -> HttpResponse:
+            return self._transport.request(
+                method="PUT",
+                path=path,
+                body=body,
+            )
+
+        response = retry_on_503(do_request, **self._retry_kwargs())
+
+        if response.status_code == 200:
+            log.debug(
+                "Set resource parents succeeded: type=%s, resource=%s",
+                resource_type,
+                resource_id,
+            )
+            try:
+                return ResourceParents.model_validate_json(response.body)
+            except Exception as exc:
+                raise ParseError(
+                    message=(f"Failed to parse set parents response: {exc}"),
+                    raw_content=response.body,
+                ) from exc
+
+        if response.status_code == 400:
+            error_resp = self._parse_error_response(response)
+            log.error(
+                "Set resource parents validation error: %s",
+                error_resp.message,
+            )
+            raise ValidationError(
+                message=error_resp.message,
+                details=error_resp.details,
+            )
+
+        # Any other error status
+        error_msg = self._extract_error_message(response)
+        log.error(
+            "Set resource parents unexpected error %d: %s",
+            response.status_code,
+            error_msg,
+        )
+        raise UnexpectedError(
+            status_code=response.status_code,
+            message=error_msg,
+        )
+
+    def health_check(self) -> HealthResult:
+        """Check the health of the Authorization API.
+
+        Sends a GET request to /health. Unlike other methods, this does
+        NOT retry on 503 — it returns an unhealthy result instead.
+
+        Returns:
+            HealthResult with the service health status.
+
+        Raises:
+            ParseError: If a 200 response body cannot be parsed.
+            UnexpectedError: On unexpected HTTP errors (not 200 or 503).
+        """
+        response = self._transport.request(
+            method="GET",
+            path="/health",
+            body=None,
+            query_params=None,
+        )
+
+        if response.status_code == 200:
+            log.debug("Health check succeeded")
+            try:
+                return HealthResult.model_validate_json(response.body)
+            except Exception as exc:
+                raise ParseError(
+                    message=f"Failed to parse health check response: {exc}",
+                    raw_content=response.body,
+                ) from exc
+
+        if response.status_code == 503:
+            log.debug("Health check returned 503: service unhealthy")
+            return HealthResult(status="unhealthy")
+
+        # Any other error status
+        error_msg = self._extract_error_message(response)
+        log.error(
+            "Health check unexpected error %d: %s",
+            response.status_code,
+            error_msg,
+        )
+        raise UnexpectedError(
+            status_code=response.status_code,
+            message=error_msg,
+        )
+
+    def _parse_batch_response(self, response: HttpResponse) -> BatchResult:
+        """Parse a batch response body into a BatchResult.
+
+        Args:
+            response: The HTTP response with a JSON body.
+
+        Returns:
+            Parsed BatchResult model.
+
+        Raises:
+            ParseError: If the response body cannot be parsed.
+        """
+        try:
+            return BatchResult.model_validate_json(response.body)
+        except Exception as exc:
+            raise ParseError(
+                message=f"Failed to parse batch response: {exc}",
+                raw_content=response.body,
+            ) from exc
+
+    def _parse_error_response(self, response: HttpResponse) -> ErrorResponse:
+        """Parse an error response body.
+
+        Args:
+            response: The HTTP response with an error JSON body.
+
+        Returns:
+            Parsed ErrorResponse model.
+        """
+        try:
+            return ErrorResponse.model_validate_json(response.body)
+        except Exception:
+            # If we can't parse the error response, create a generic one
+            return ErrorResponse(
+                error="unknown",
+                message=response.body.decode(errors="replace"),
+            )
+
+    def _extract_error_message(self, response: HttpResponse) -> str:
+        """Extract an error message from a response body.
+
+        Args:
+            response: The HTTP response.
+
+        Returns:
+            The error message string.
+        """
+        try:
+            data = json.loads(response.body)
+            return str(data.get("message", response.body.decode(errors="replace")))
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            return response.body.decode(errors="replace")

--- a/common/src/python/authorization/exceptions.py
+++ b/common/src/python/authorization/exceptions.py
@@ -1,0 +1,40 @@
+"""Exception hierarchy for the authorization client library."""
+
+
+class AuthorizationClientError(Exception):
+    """Base exception for authorization client errors."""
+
+
+class ConfigurationError(AuthorizationClientError):
+    """Raised when the client cannot be configured (e.g., missing base URL)."""
+
+
+class ValidationError(AuthorizationClientError):
+    """Raised when the API returns 400 (validation error)."""
+
+    def __init__(self, message: str, details: dict | None = None) -> None:
+        super().__init__(message)
+        self.message = message
+        self.details = details
+
+
+class ServiceUnavailableError(AuthorizationClientError):
+    """Raised when retries are exhausted on 503."""
+
+
+class UnexpectedError(AuthorizationClientError):
+    """Raised on unexpected HTTP errors (non-retriable 4xx/5xx)."""
+
+    def __init__(self, status_code: int, message: str) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.message = message
+
+
+class ParseError(AuthorizationClientError):
+    """Raised when a response body cannot be parsed into the expected model."""
+
+    def __init__(self, message: str, raw_content: bytes) -> None:
+        super().__init__(message)
+        self.message = message
+        self.raw_content = raw_content

--- a/common/src/python/authorization/factory.py
+++ b/common/src/python/authorization/factory.py
@@ -1,0 +1,53 @@
+"""Factory function for creating a configured AuthorizationClient."""
+
+import os
+
+from authorization.client import AuthorizationClient
+from authorization.exceptions import ConfigurationError
+from authorization.sigv4_transport import SigV4Transport
+
+_ENV_VAR = "AUTHORIZATION_API_URL"
+
+
+def create_authorization_client(
+    base_url: str | None = None,
+    max_retries: int = 3,
+    base_backoff: float = 1.0,
+    timeout: float = 30.0,
+) -> AuthorizationClient:
+    """Create an AuthorizationClient with SigV4 transport.
+
+    Resolves the API base URL from the explicit parameter or the
+    ``AUTHORIZATION_API_URL`` environment variable. Instantiates a
+    SigV4Transport and returns a fully configured client.
+
+    If ``base_url`` is None or empty, the function falls back to the
+    environment variable. If both are absent or empty, a
+    ConfigurationError is raised.
+
+    Args:
+        base_url: API base URL. Falls back to AUTHORIZATION_API_URL
+            environment variable if not provided or empty.
+        max_retries: Maximum retry attempts on 503 responses.
+        base_backoff: Base delay in seconds for exponential backoff.
+        timeout: HTTP request timeout in seconds. Defaults to 30.
+
+    Returns:
+        A configured AuthorizationClient instance.
+
+    Raises:
+        ConfigurationError: If no base URL is resolvable from the
+            parameter or environment variable.
+    """
+    resolved_url = base_url or os.environ.get(_ENV_VAR)
+    if not resolved_url:
+        raise ConfigurationError(
+            f"No base URL provided and {_ENV_VAR} environment variable is not set"
+        )
+
+    transport = SigV4Transport(base_url=resolved_url, timeout=timeout)
+    return AuthorizationClient(
+        transport=transport,
+        max_retries=max_retries,
+        base_backoff=base_backoff,
+    )

--- a/common/src/python/authorization/models.py
+++ b/common/src/python/authorization/models.py
@@ -1,0 +1,215 @@
+"""Pydantic request and response models for the Authorization API."""
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# --- Request Models ---
+
+
+class GrantRequest(BaseModel):
+    """Request model for granting a user a relation on a resource."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    user_id: str = Field(alias="userId")
+    relation: str
+    type: str
+    resource_id: str = Field(alias="resourceId")
+
+
+class RevokeRequest(BaseModel):
+    """Request model for revoking a user's relation on a resource."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    user_id: str = Field(alias="userId")
+    relation: str
+    type: str
+    resource_id: str = Field(alias="resourceId")
+
+
+class BatchOperationModel(BaseModel):
+    """A single operation within a batch request payload."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    action: Literal["grant", "revoke"]
+    user_id: str = Field(alias="userId")
+    relation: str
+    type: str
+    resource_id: str = Field(alias="resourceId")
+
+
+class BatchRequestModel(BaseModel):
+    """Request model for a batch of grant/revoke operations."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    operations: list[BatchOperationModel]
+
+
+class ParentRelationshipModel(BaseModel):
+    """A parent relationship within a set-parents request."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    structural_relation: str = Field(alias="structuralRelation")
+    parent_type: str = Field(alias="parentType")
+    parent_id: str = Field(alias="parentId")
+
+
+class SetParentsRequestModel(BaseModel):
+    """Request model for setting resource parents."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    parents: list[ParentRelationshipModel]
+
+
+class PermissionCheckRequestModel(BaseModel):
+    """Request model for checking a specific permission."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    user_id: str = Field(alias="userId")
+    relation: str
+    type: str
+    resource_id: str = Field(alias="resourceId")
+
+
+# --- Response Models ---
+
+
+class GrantResult(BaseModel):
+    """Response model for a successful grant operation."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    user_id: str = Field(alias="userId")
+    relation: str
+    type: str
+    resource_id: str = Field(alias="resourceId")
+
+
+class RevokeResult(BaseModel):
+    """Response model for a successful revoke operation."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    user_id: str = Field(alias="userId")
+    relation: str
+    type: str
+    resource_id: str = Field(alias="resourceId")
+
+
+class BatchError(BaseModel):
+    """Details of a single failed operation within a batch response."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    index: int
+    error: str
+    message: str
+
+
+class BatchResult(BaseModel):
+    """Aggregate result of a batch operation across all chunks."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    total: int
+    succeeded: int
+    failed: int
+    errors: list[BatchError] = []
+
+
+class InheritanceSource(BaseModel):
+    """Source of an inherited permission."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    parent_type: str = Field(alias="parentType")
+    parent_id: str = Field(alias="parentId")
+    parent_role: str = Field(alias="parentRole")
+
+
+class PermissionEntry(BaseModel):
+    """A single permission entry for a user on a resource."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    resource_id: str = Field(alias="resourceId")
+    relation: str
+    access: Literal["direct", "inherited", "both"]
+    inherited_from: InheritanceSource | None = Field(
+        default=None, alias="inheritedFrom"
+    )
+
+
+class UserPermissions(BaseModel):
+    """Response model for a user's permissions grouped by resource type."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    user_id: str = Field(alias="userId")
+    permissions: dict[str, list[PermissionEntry]]
+
+
+class ParentRelationship(BaseModel):
+    """A parent relationship in a resource parents response."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    structural_relation: str = Field(alias="structuralRelation")
+    parent_type: str = Field(alias="parentType")
+    parent_id: str = Field(alias="parentId")
+
+
+class ResourceParents(BaseModel):
+    """Response model for a resource's parent relationships."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    type: str
+    resource_id: str = Field(alias="resourceId")
+    parents: list[ParentRelationship]
+
+
+class HealthResult(BaseModel):
+    """Response model for the health check endpoint."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    status: Literal["healthy", "degraded", "unhealthy"]
+    authorization_engine: Literal["connected", "unreachable"] | None = Field(
+        default=None, alias="authorizationEngine"
+    )
+
+
+class ErrorResponse(BaseModel):
+    """Response model for API error responses."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    error: str
+    message: str
+    details: dict | None = None
+
+
+# --- Domain Types ---
+
+
+class BatchOperation(BaseModel):
+    """A single grant or revoke operation for batch submission.
+
+    This is the caller-facing type used to construct batch requests.
+    Field names use Python conventions (snake_case) rather than API
+    aliases.
+    """
+
+    action: Literal["grant", "revoke"]
+    user_id: str
+    resource_type: str
+    resource_id: str
+    relation: str

--- a/common/src/python/authorization/models.py
+++ b/common/src/python/authorization/models.py
@@ -67,17 +67,6 @@ class SetParentsRequestModel(BaseModel):
     parents: list[ParentRelationshipModel]
 
 
-class PermissionCheckRequestModel(BaseModel):
-    """Request model for checking a specific permission."""
-
-    model_config = ConfigDict(populate_by_name=True)
-
-    user_id: str = Field(alias="userId")
-    relation: str
-    type: str
-    resource_id: str = Field(alias="resourceId")
-
-
 # --- Response Models ---
 
 

--- a/common/src/python/authorization/retry.py
+++ b/common/src/python/authorization/retry.py
@@ -1,0 +1,57 @@
+"""Retry logic with exponential backoff for the Authorization Client."""
+
+import logging
+import time
+from collections.abc import Callable
+
+from authorization.exceptions import ServiceUnavailableError
+from authorization.transport import HttpResponse
+
+log = logging.getLogger(__name__)
+
+
+def retry_on_503(
+    operation: Callable[[], HttpResponse],
+    *,
+    max_retries: int = 3,
+    base_backoff: float = 1.0,
+    sleep: Callable[[float], None] = time.sleep,
+) -> HttpResponse:
+    """Execute an operation with retry on HTTP 503 responses.
+
+    Retries the given callable up to `max_retries` times when it returns
+    an HTTP 503 status code. Uses exponential backoff between attempts
+    with the formula: base_backoff * 2^(attempt-1).
+
+    Args:
+        operation: A callable that returns an HttpResponse.
+        max_retries: Maximum number of retry attempts before raising.
+        base_backoff: Base delay in seconds for exponential backoff.
+        sleep: Callable used to pause between retries. Defaults to
+            ``time.sleep``; inject a no-op for fast unit tests.
+
+    Returns:
+        The HttpResponse from a successful (non-503) call.
+
+    Raises:
+        ServiceUnavailableError: When all retry attempts are exhausted
+            and the service continues to return 503.
+    """
+    response = operation()
+    if response.status_code != 503:
+        return response
+
+    for attempt in range(1, max_retries + 1):
+        delay = base_backoff * (2 ** (attempt - 1))
+        log.warning(
+            "Received 503, retrying (attempt %d/%d) after %.2fs",
+            attempt,
+            max_retries,
+            delay,
+        )
+        sleep(delay)
+        response = operation()
+        if response.status_code != 503:
+            return response
+
+    raise ServiceUnavailableError(f"Service unavailable after {max_retries} retries")

--- a/common/src/python/authorization/sigv4_transport.py
+++ b/common/src/python/authorization/sigv4_transport.py
@@ -1,0 +1,118 @@
+"""SigV4-signed HTTP transport for the Authorization API."""
+
+import logging
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from urllib.parse import urlencode
+
+from botocore.auth import SigV4Auth
+from botocore.awsrequest import AWSRequest
+from botocore.session import Session
+
+log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class _Response:
+    """Concrete HTTP response returned by SigV4Transport."""
+
+    status_code: int
+    body: bytes
+
+
+class SigV4Transport:
+    """HTTP transport that signs requests with AWS SigV4.
+
+    Uses botocore's standard credential chain (environment variables,
+    shared credentials file, IAM role, etc.) to sign requests against
+    the ``execute-api`` service.
+
+    This class satisfies the ``HttpTransport`` protocol via structural
+    subtyping — no explicit inheritance is needed.
+    """
+
+    def __init__(self, base_url: str, region: str | None = None) -> None:
+        """Initialize the SigV4 transport.
+
+        Args:
+            base_url: The base URL of the Authorization API
+                (e.g., ``https://api.example.com/v1``).
+            region: AWS region for signing. If not provided, the region
+                is resolved from the botocore session (environment or
+                config file).
+        """
+        self._base_url = base_url.rstrip("/")
+        self._session = Session()
+        self._region = region or self._session.get_config_variable("region")
+        self._credentials = self._session.get_credentials()
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        body: bytes | None = None,
+        query_params: dict[str, str] | None = None,
+    ) -> _Response:
+        """Send a SigV4-signed HTTP request and return the response.
+
+        Args:
+            method: HTTP method (GET, POST, PUT, DELETE).
+            path: Request path relative to the base URL.
+            body: Optional request body as bytes.
+            query_params: Optional query string parameters.
+
+        Returns:
+            An object with ``status_code`` and ``body`` attributes.
+        """
+        url = self._build_url(path, query_params)
+
+        headers: dict[str, str] = {}
+        if body is not None:
+            headers["Content-Type"] = "application/json"
+
+        # Create and sign the AWS request
+        aws_request = AWSRequest(
+            method=method.upper(),
+            url=url,
+            data=body,
+            headers=headers,
+        )
+        SigV4Auth(self._credentials, "execute-api", self._region).add_auth(aws_request)
+
+        # Build urllib request with signed headers
+        req = urllib.request.Request(
+            url=url,
+            data=body,
+            headers=dict(aws_request.headers),
+            method=method.upper(),
+        )
+
+        try:
+            with urllib.request.urlopen(req) as response:
+                return _Response(
+                    status_code=response.status,
+                    body=response.read(),
+                )
+        except urllib.error.HTTPError as error:
+            return _Response(
+                status_code=error.code,
+                body=error.read(),
+            )
+
+    def _build_url(
+        self,
+        path: str,
+        query_params: dict[str, str] | None = None,
+    ) -> str:
+        """Construct the full URL from base, path, and query parameters."""
+        # Ensure path starts with /
+        if not path.startswith("/"):
+            path = f"/{path}"
+
+        url = f"{self._base_url}{path}"
+
+        if query_params:
+            url = f"{url}?{urlencode(query_params)}"
+
+        return url

--- a/common/src/python/authorization/sigv4_transport.py
+++ b/common/src/python/authorization/sigv4_transport.py
@@ -32,7 +32,12 @@ class SigV4Transport:
     subtyping — no explicit inheritance is needed.
     """
 
-    def __init__(self, base_url: str, region: str | None = None) -> None:
+    def __init__(
+        self,
+        base_url: str,
+        region: str | None = None,
+        timeout: float = 30.0,
+    ) -> None:
         """Initialize the SigV4 transport.
 
         Args:
@@ -41,11 +46,13 @@ class SigV4Transport:
             region: AWS region for signing. If not provided, the region
                 is resolved from the botocore session (environment or
                 config file).
+            timeout: Request timeout in seconds. Defaults to 30 seconds.
         """
         self._base_url = base_url.rstrip("/")
         self._session = Session()
         self._region = region or self._session.get_config_variable("region")
         self._credentials = self._session.get_credentials()
+        self._timeout = timeout
 
     def request(
         self,
@@ -89,7 +96,7 @@ class SigV4Transport:
         )
 
         try:
-            with urllib.request.urlopen(req) as response:
+            with urllib.request.urlopen(req, timeout=self._timeout) as response:
                 return _Response(
                     status_code=response.status,
                     body=response.read(),

--- a/common/src/python/authorization/transport.py
+++ b/common/src/python/authorization/transport.py
@@ -1,0 +1,46 @@
+"""HTTP transport protocol definitions for the Authorization Client."""
+
+from typing import Protocol
+
+
+class HttpResponse(Protocol):
+    """Minimal response interface returned by transport."""
+
+    @property
+    def status_code(self) -> int:
+        """HTTP status code of the response."""
+        ...
+
+    @property
+    def body(self) -> bytes:
+        """Raw response body as bytes."""
+        ...
+
+
+class HttpTransport(Protocol):
+    """Abstract HTTP transport for the Authorization API.
+
+    Implementations handle the details of sending HTTP requests (e.g.,
+    SigV4 signing, connection pooling) while the client operates against
+    this protocol for testability.
+    """
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        body: bytes | None = None,
+        query_params: dict[str, str] | None = None,
+    ) -> HttpResponse:
+        """Send an HTTP request and return the response.
+
+        Args:
+            method: HTTP method (GET, POST, PUT, DELETE).
+            path: Request path relative to the API base URL.
+            body: Optional request body as bytes.
+            query_params: Optional query string parameters.
+
+        Returns:
+            An HttpResponse with status_code and body.
+        """
+        ...

--- a/common/test/python/authorization_test/BUILD
+++ b/common/test/python/authorization_test/BUILD
@@ -1,0 +1,8 @@
+python_tests(
+    name="tests",
+)
+
+python_test_utils(
+    name="test_utils",
+    sources=["conftest.py"],
+)

--- a/common/test/python/authorization_test/conftest.py
+++ b/common/test/python/authorization_test/conftest.py
@@ -1,0 +1,1 @@
+"""Shared fixtures and mock transport for authorization client tests."""

--- a/common/test/python/authorization_test/conftest.py
+++ b/common/test/python/authorization_test/conftest.py
@@ -1,1 +1,95 @@
 """Shared fixtures and mock transport for authorization client tests."""
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class MockResponse:
+    """Mock HTTP response for testing."""
+
+    status_code: int
+    body: bytes
+
+
+class MockTransport:
+    """Mock transport that returns pre-configured responses in sequence.
+
+    If a single MockResponse is provided, it is returned for every call.
+    If a list is provided, responses are returned in order; once
+    exhausted, the last response is repeated.
+    """
+
+    def __init__(self, responses: list[MockResponse] | MockResponse) -> None:
+        if isinstance(responses, MockResponse):
+            responses = [responses]
+        self.responses = responses
+        self._call_index = 0
+        self.requests: list[tuple[str, str, bytes | None, dict[str, str] | None]] = []
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        body: bytes | None = None,
+        query_params: dict[str, str] | None = None,
+    ) -> MockResponse:
+        self.requests.append((method, path, body, query_params))
+        response = self.responses[min(self._call_index, len(self.responses) - 1)]
+        self._call_index += 1
+        return response
+
+
+@dataclass
+class DataclassMockTransport:
+    """Dataclass-based mock transport for use in property tests.
+
+    Equivalent to MockTransport but uses dataclass syntax for
+    compatibility with hypothesis strategies that construct via fields.
+    """
+
+    responses: list[MockResponse] = field(default_factory=list)
+    requests: list[tuple[str, str, bytes | None, dict[str, str] | None]] = field(
+        default_factory=list
+    )
+    _call_index: int = field(default=0, init=False)
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        body: bytes | None = None,
+        query_params: dict[str, str] | None = None,
+    ) -> MockResponse:
+        self.requests.append((method, path, body, query_params))
+        response = self.responses[min(self._call_index, len(self.responses) - 1)]
+        self._call_index += 1
+        return response
+
+
+class CapturingTransport:
+    """Transport that captures requests and returns a single fixed response.
+
+    Useful for property tests that verify request construction.
+    """
+
+    def __init__(self, response: MockResponse) -> None:
+        self.response = response
+        self.requests: list[tuple[str, str, bytes | None, dict[str, str] | None]] = []
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        body: bytes | None = None,
+        query_params: dict[str, str] | None = None,
+    ) -> MockResponse:
+        self.requests.append((method, path, body, query_params))
+        return self.response
+
+
+def no_sleep(_: float) -> None:
+    """No-op sleep callable for fast tests.
+
+    Inject this as the ``sleep`` parameter to AuthorizationClient to
+    avoid real delays during testing.
+    """

--- a/common/test/python/authorization_test/test_client_batch.py
+++ b/common/test/python/authorization_test/test_client_batch.py
@@ -1,0 +1,446 @@
+"""Unit tests for AuthorizationClient.batch() method."""
+
+import json
+
+import pytest
+from authorization.client import AuthorizationClient
+from authorization.exceptions import (
+    ParseError,
+    ServiceUnavailableError,
+    UnexpectedError,
+    ValidationError,
+)
+from authorization.models import BatchOperation
+
+from .conftest import MockResponse, MockTransport, no_sleep
+
+
+def _make_operations(count: int) -> list[BatchOperation]:
+    """Create a list of batch operations for testing."""
+    return [
+        BatchOperation(
+            action="grant" if i % 2 == 0 else "revoke",
+            user_id=f"user-{i}",
+            resource_type="study",
+            resource_id=f"resource-{i}",
+            relation="member",
+        )
+        for i in range(count)
+    ]
+
+
+def _batch_success_response(
+    total: int,
+    succeeded: int,
+    failed: int,
+    errors: list[dict] | None = None,
+) -> MockResponse:
+    """Create a successful batch response."""
+    body = {
+        "total": total,
+        "succeeded": succeeded,
+        "failed": failed,
+        "errors": errors or [],
+    }
+    return MockResponse(status_code=200, body=json.dumps(body).encode())
+
+
+class TestBatchChunking:
+    """Tests for batch chunking behavior."""
+
+    def test_single_chunk_under_100(self) -> None:
+        """Operations <= 100 are sent in a single request."""
+        ops = _make_operations(50)
+        transport = MockTransport(
+            [_batch_success_response(total=50, succeeded=50, failed=0)]
+        )
+        client = AuthorizationClient(transport, sleep=no_sleep)
+
+        result = client.batch(ops)
+
+        assert len(transport.requests) == 1
+        assert transport.requests[0][0] == "POST"
+        assert transport.requests[0][1] == "/grants/batch"
+        assert result.total == 50
+        assert result.succeeded == 50
+        assert result.failed == 0
+
+    def test_exactly_100_operations_single_chunk(self) -> None:
+        """Exactly 100 operations are sent in a single request."""
+        ops = _make_operations(100)
+        transport = MockTransport(
+            [_batch_success_response(total=100, succeeded=100, failed=0)]
+        )
+        client = AuthorizationClient(transport, sleep=no_sleep)
+
+        result = client.batch(ops)
+
+        assert len(transport.requests) == 1
+        assert result.total == 100
+
+    def test_101_operations_two_chunks(self) -> None:
+        """101 operations are split into two chunks (100 + 1)."""
+        ops = _make_operations(101)
+        transport = MockTransport(
+            [
+                _batch_success_response(total=100, succeeded=100, failed=0),
+                _batch_success_response(total=1, succeeded=1, failed=0),
+            ]
+        )
+        client = AuthorizationClient(transport, sleep=no_sleep)
+
+        result = client.batch(ops)
+
+        assert len(transport.requests) == 2
+        assert result.total == 101
+        assert result.succeeded == 101
+        assert result.failed == 0
+
+    def test_250_operations_three_chunks(self) -> None:
+        """250 operations are split into three chunks (100 + 100 + 50)."""
+        ops = _make_operations(250)
+        transport = MockTransport(
+            [
+                _batch_success_response(total=100, succeeded=100, failed=0),
+                _batch_success_response(total=100, succeeded=100, failed=0),
+                _batch_success_response(total=50, succeeded=50, failed=0),
+            ]
+        )
+        client = AuthorizationClient(transport, sleep=no_sleep)
+
+        result = client.batch(ops)
+
+        assert len(transport.requests) == 3
+        assert result.total == 250
+        assert result.succeeded == 250
+
+    def test_empty_operations_list(self) -> None:
+        """Empty operations list returns zero result without network call."""
+        ops: list[BatchOperation] = []
+        transport = MockTransport(
+            [_batch_success_response(total=0, succeeded=0, failed=0)]
+        )
+        client = AuthorizationClient(transport, sleep=no_sleep)
+
+        result = client.batch(ops)
+
+        assert len(transport.requests) == 0
+        assert result.total == 0
+
+
+class TestBatchOrderPreservation:
+    """Tests that batch chunking preserves operation order."""
+
+    def test_order_preserved_across_chunks(self) -> None:
+        """Operations are sent in original order across chunks."""
+        ops = _make_operations(150)
+        transport = MockTransport(
+            [
+                _batch_success_response(total=100, succeeded=100, failed=0),
+                _batch_success_response(total=50, succeeded=50, failed=0),
+            ]
+        )
+        client = AuthorizationClient(transport, sleep=no_sleep)
+
+        client.batch(ops)
+
+        # Verify first chunk has first 100 operations
+        first_request_body = transport.requests[0][2]
+        assert first_request_body is not None
+        first_body = json.loads(first_request_body)
+        assert len(first_body["operations"]) == 100
+        assert first_body["operations"][0]["userId"] == "user-0"
+        assert first_body["operations"][99]["userId"] == "user-99"
+
+        # Verify second chunk has remaining 50 operations
+        second_request_body = transport.requests[1][2]
+        assert second_request_body is not None
+        second_body = json.loads(second_request_body)
+        assert len(second_body["operations"]) == 50
+        assert second_body["operations"][0]["userId"] == "user-100"
+        assert second_body["operations"][49]["userId"] == "user-149"
+
+
+class TestBatchRequestConstruction:
+    """Tests for correct request body construction."""
+
+    def test_request_body_uses_camel_case_aliases(self) -> None:
+        """Request body uses camelCase field names."""
+        ops = [
+            BatchOperation(
+                action="grant",
+                user_id="user-1",
+                resource_type="study",
+                resource_id="res-1",
+                relation="member",
+            )
+        ]
+        transport = MockTransport(
+            [_batch_success_response(total=1, succeeded=1, failed=0)]
+        )
+        client = AuthorizationClient(transport, sleep=no_sleep)
+
+        client.batch(ops)
+
+        request_body = transport.requests[0][2]
+        assert request_body is not None
+        body = json.loads(request_body)
+        op = body["operations"][0]
+        assert "userId" in op
+        assert "resourceId" in op
+        assert op["userId"] == "user-1"
+        assert op["resourceId"] == "res-1"
+        assert op["type"] == "study"
+        assert op["relation"] == "member"
+        assert op["action"] == "grant"
+
+
+class TestBatchErrorClassification:
+    """Tests for per-operation error classification."""
+
+    def test_conflict_counted_as_success(self) -> None:
+        """Per-operation 'conflict' errors are idempotent successes."""
+        ops = _make_operations(3)
+        response = _batch_success_response(
+            total=3,
+            succeeded=2,
+            failed=1,
+            errors=[{"index": 1, "error": "conflict", "message": "Already exists"}],
+        )
+        transport = MockTransport([response])
+        client = AuthorizationClient(transport, sleep=no_sleep)
+
+        result = client.batch(ops)
+
+        assert result.total == 3
+        assert result.succeeded == 3  # 2 + 1 idempotent
+        assert result.failed == 0
+        assert result.errors == []
+
+    def test_not_found_counted_as_success(self) -> None:
+        """Per-operation 'not_found' errors are idempotent successes."""
+        ops = _make_operations(3)
+        response = _batch_success_response(
+            total=3,
+            succeeded=2,
+            failed=1,
+            errors=[{"index": 2, "error": "not_found", "message": "Grant not found"}],
+        )
+        transport = MockTransport([response])
+        client = AuthorizationClient(transport, sleep=no_sleep)
+
+        result = client.batch(ops)
+
+        assert result.total == 3
+        assert result.succeeded == 3
+        assert result.failed == 0
+        assert result.errors == []
+
+    def test_service_unavailable_reported_as_failure(self) -> None:
+        """Per-operation 'service_unavailable' errors are retriable
+        failures."""
+        ops = _make_operations(3)
+        response = _batch_success_response(
+            total=3,
+            succeeded=2,
+            failed=1,
+            errors=[
+                {
+                    "index": 0,
+                    "error": "service_unavailable",
+                    "message": "Engine unavailable",
+                }
+            ],
+        )
+        transport = MockTransport([response])
+        client = AuthorizationClient(transport, sleep=no_sleep)
+
+        result = client.batch(ops)
+
+        assert result.total == 3
+        assert result.succeeded == 2
+        assert result.failed == 1
+        assert len(result.errors) == 1
+        assert result.errors[0].error == "service_unavailable"
+
+    def test_other_errors_reported_as_failure(self) -> None:
+        """Non-idempotent, non-retriable errors are reported as failures."""
+        ops = _make_operations(3)
+        response = _batch_success_response(
+            total=3,
+            succeeded=2,
+            failed=1,
+            errors=[
+                {
+                    "index": 1,
+                    "error": "internal_error",
+                    "message": "Something went wrong",
+                }
+            ],
+        )
+        transport = MockTransport([response])
+        client = AuthorizationClient(transport, sleep=no_sleep)
+
+        result = client.batch(ops)
+
+        assert result.total == 3
+        assert result.succeeded == 2
+        assert result.failed == 1
+        assert len(result.errors) == 1
+        assert result.errors[0].error == "internal_error"
+
+    def test_mixed_errors_classified_correctly(self) -> None:
+        """Mixed error types are classified independently."""
+        ops = _make_operations(5)
+        response = _batch_success_response(
+            total=5,
+            succeeded=2,
+            failed=3,
+            errors=[
+                {"index": 0, "error": "conflict", "message": "Already exists"},
+                {
+                    "index": 2,
+                    "error": "service_unavailable",
+                    "message": "Unavailable",
+                },
+                {"index": 4, "error": "internal_error", "message": "Failed"},
+            ],
+        )
+        transport = MockTransport([response])
+        client = AuthorizationClient(transport, sleep=no_sleep)
+
+        result = client.batch(ops)
+
+        # 2 succeeded + 1 idempotent (conflict) = 3
+        assert result.succeeded == 3
+        # 3 failed - 1 idempotent = 2
+        assert result.failed == 2
+        # Only non-idempotent errors remain
+        assert len(result.errors) == 2
+        error_codes = {e.error for e in result.errors}
+        assert error_codes == {"service_unavailable", "internal_error"}
+
+
+class TestBatchHTTPErrors:
+    """Tests for HTTP-level error handling in batch."""
+
+    def test_400_raises_validation_error(self) -> None:
+        """HTTP 400 raises ValidationError with API message."""
+        ops = _make_operations(5)
+        error_body = json.dumps(
+            {"error": "validation_error", "message": "Invalid operation format"}
+        ).encode()
+        transport = MockTransport([MockResponse(status_code=400, body=error_body)])
+        client = AuthorizationClient(transport, sleep=no_sleep)
+
+        with pytest.raises(ValidationError) as exc_info:
+            client.batch(ops)
+
+        assert "Invalid operation format" in str(exc_info.value)
+
+    def test_500_raises_unexpected_error(self) -> None:
+        """HTTP 500 raises UnexpectedError."""
+        ops = _make_operations(5)
+        error_body = json.dumps(
+            {"error": "internal", "message": "Server error"}
+        ).encode()
+        transport = MockTransport([MockResponse(status_code=500, body=error_body)])
+        client = AuthorizationClient(transport, sleep=no_sleep)
+
+        with pytest.raises(UnexpectedError) as exc_info:
+            client.batch(ops)
+
+        assert exc_info.value.status_code == 500
+
+    def test_503_retries_then_raises(self) -> None:
+        """HTTP 503 triggers retry logic."""
+        ops = _make_operations(5)
+        # All responses are 503 - should exhaust retries
+        responses = [
+            MockResponse(status_code=503, body=b"Service Unavailable")
+            for _ in range(4)  # initial + 3 retries
+        ]
+        transport = MockTransport(responses)
+        client = AuthorizationClient(transport, max_retries=3, sleep=no_sleep)
+
+        with pytest.raises(ServiceUnavailableError):
+            client.batch(ops)
+
+    def test_503_then_success(self) -> None:
+        """HTTP 503 followed by success returns result."""
+        ops = _make_operations(5)
+        transport = MockTransport(
+            [
+                MockResponse(status_code=503, body=b"Service Unavailable"),
+                _batch_success_response(total=5, succeeded=5, failed=0),
+            ]
+        )
+        client = AuthorizationClient(transport, max_retries=3, sleep=no_sleep)
+
+        result = client.batch(ops)
+
+        assert result.total == 5
+        assert result.succeeded == 5
+
+    def test_malformed_response_raises_parse_error(self) -> None:
+        """Non-JSON response body raises ParseError."""
+        ops = _make_operations(5)
+        transport = MockTransport(
+            [MockResponse(status_code=200, body=b"not json at all")]
+        )
+        client = AuthorizationClient(transport, sleep=no_sleep)
+
+        with pytest.raises(ParseError) as exc_info:
+            client.batch(ops)
+
+        assert exc_info.value.raw_content == b"not json at all"
+
+
+class TestBatchAggregation:
+    """Tests for result aggregation across multiple chunks."""
+
+    def test_aggregates_totals_across_chunks(self) -> None:
+        """Results from multiple chunks are summed correctly."""
+        ops = _make_operations(150)
+        transport = MockTransport(
+            [
+                _batch_success_response(
+                    total=100,
+                    succeeded=98,
+                    failed=2,
+                    errors=[
+                        {"index": 5, "error": "conflict", "message": "Exists"},
+                        {
+                            "index": 10,
+                            "error": "internal_error",
+                            "message": "Fail",
+                        },
+                    ],
+                ),
+                _batch_success_response(
+                    total=50,
+                    succeeded=49,
+                    failed=1,
+                    errors=[
+                        {
+                            "index": 3,
+                            "error": "not_found",
+                            "message": "Not found",
+                        }
+                    ],
+                ),
+            ]
+        )
+        client = AuthorizationClient(transport, sleep=no_sleep)
+
+        result = client.batch(ops)
+
+        # Total: 100 + 50 = 150
+        assert result.total == 150
+        # Succeeded: (98 + 1 idempotent) + (49 + 1 idempotent) = 149
+        assert result.succeeded == 149
+        # Failed: (2 - 1 idempotent) + (1 - 1 idempotent) = 1
+        assert result.failed == 1
+        # Only non-idempotent errors
+        assert len(result.errors) == 1
+        assert result.errors[0].error == "internal_error"

--- a/common/test/python/authorization_test/test_client_grant.py
+++ b/common/test/python/authorization_test/test_client_grant.py
@@ -1,0 +1,239 @@
+"""Tests for AuthorizationClient.grant method."""
+
+import json
+
+import pytest
+from authorization.client import AuthorizationClient
+from authorization.exceptions import (
+    ParseError,
+    ServiceUnavailableError,
+    UnexpectedError,
+    ValidationError,
+)
+from authorization.models import GrantResult
+
+from .conftest import MockResponse, MockTransport, no_sleep
+
+
+class TestGrant:
+    """Tests for the grant method."""
+
+    def test_grant_sends_post_to_grants(self) -> None:
+        """Verify grant sends POST to /grants with correct JSON body."""
+        response_body = json.dumps(
+            {
+                "userId": "user@example.com",
+                "relation": "member",
+                "type": "study",
+                "resourceId": "study-123",
+            }
+        ).encode()
+        transport = MockTransport(MockResponse(status_code=201, body=response_body))
+        client = AuthorizationClient(transport=transport, sleep=no_sleep)
+
+        client.grant(
+            user_id="user@example.com",
+            resource_type="study",
+            resource_id="study-123",
+            relation="member",
+        )
+
+        assert len(transport.requests) == 1
+        method, path, body, query_params = transport.requests[0]
+        assert method == "POST"
+        assert path == "/grants"
+        assert query_params is None
+
+        # Verify the request body contains the correct fields
+        assert body is not None
+        request_data = json.loads(body)
+        assert request_data["userId"] == "user@example.com"
+        assert request_data["relation"] == "member"
+        assert request_data["type"] == "study"
+        assert request_data["resourceId"] == "study-123"
+
+    def test_grant_returns_grant_result_on_201(self) -> None:
+        """Verify 201 response is parsed into GrantResult."""
+        response_body = json.dumps(
+            {
+                "userId": "user@example.com",
+                "relation": "admin",
+                "type": "research_center",
+                "resourceId": "center-456",
+            }
+        ).encode()
+        transport = MockTransport(MockResponse(status_code=201, body=response_body))
+        client = AuthorizationClient(transport=transport, sleep=no_sleep)
+
+        result = client.grant(
+            user_id="user@example.com",
+            resource_type="research_center",
+            resource_id="center-456",
+            relation="admin",
+        )
+
+        assert isinstance(result, GrantResult)
+        assert result.user_id == "user@example.com"
+        assert result.relation == "admin"
+        assert result.type == "research_center"
+        assert result.resource_id == "center-456"
+
+    def test_grant_returns_grant_result_on_200(self) -> None:
+        """Verify 200 response is also treated as success."""
+        response_body = json.dumps(
+            {
+                "userId": "user@example.com",
+                "relation": "viewer",
+                "type": "dashboard",
+                "resourceId": "dash-1",
+            }
+        ).encode()
+        transport = MockTransport(MockResponse(status_code=200, body=response_body))
+        client = AuthorizationClient(transport=transport, sleep=no_sleep)
+
+        result = client.grant(
+            user_id="user@example.com",
+            resource_type="dashboard",
+            resource_id="dash-1",
+            relation="viewer",
+        )
+
+        assert isinstance(result, GrantResult)
+        assert result.user_id == "user@example.com"
+
+    def test_grant_treats_409_as_success(self) -> None:
+        """Verify 409 (conflict) returns GrantResult without raising."""
+        transport = MockTransport(MockResponse(status_code=409, body=b""))
+        client = AuthorizationClient(transport=transport, sleep=no_sleep)
+
+        result = client.grant(
+            user_id="user@example.com",
+            resource_type="study",
+            resource_id="study-123",
+            relation="member",
+        )
+
+        assert isinstance(result, GrantResult)
+        assert result.user_id == "user@example.com"
+        assert result.relation == "member"
+        assert result.type == "study"
+        assert result.resource_id == "study-123"
+
+    def test_grant_raises_validation_error_on_400(self) -> None:
+        """Verify 400 raises ValidationError with API message."""
+        error_body = json.dumps(
+            {
+                "error": "validation_error",
+                "message": "Invalid resource type",
+                "details": {"field": "type"},
+            }
+        ).encode()
+        transport = MockTransport(MockResponse(status_code=400, body=error_body))
+        client = AuthorizationClient(transport=transport, sleep=no_sleep)
+
+        with pytest.raises(ValidationError) as exc_info:
+            client.grant(
+                user_id="user@example.com",
+                resource_type="invalid_type",
+                resource_id="res-1",
+                relation="member",
+            )
+
+        assert exc_info.value.message == "Invalid resource type"
+        assert exc_info.value.details == {"field": "type"}
+
+    def test_grant_raises_unexpected_error_on_500(self) -> None:
+        """Verify 500 raises UnexpectedError immediately."""
+        error_body = json.dumps({"message": "Internal server error"}).encode()
+        transport = MockTransport(MockResponse(status_code=500, body=error_body))
+        client = AuthorizationClient(transport=transport, sleep=no_sleep)
+
+        with pytest.raises(UnexpectedError) as exc_info:
+            client.grant(
+                user_id="user@example.com",
+                resource_type="study",
+                resource_id="study-1",
+                relation="member",
+            )
+
+        assert exc_info.value.status_code == 500
+        assert "Internal server error" in exc_info.value.message
+
+    def test_grant_raises_unexpected_error_on_403(self) -> None:
+        """Verify 403 raises UnexpectedError (not retried)."""
+        error_body = json.dumps({"message": "Forbidden"}).encode()
+        transport = MockTransport(MockResponse(status_code=403, body=error_body))
+        client = AuthorizationClient(transport=transport, sleep=no_sleep)
+
+        with pytest.raises(UnexpectedError) as exc_info:
+            client.grant(
+                user_id="user@example.com",
+                resource_type="study",
+                resource_id="study-1",
+                relation="member",
+            )
+
+        assert exc_info.value.status_code == 403
+        # Should only make one request (no retry)
+        assert len(transport.requests) == 1
+
+    def test_grant_retries_on_503(self) -> None:
+        """Verify 503 triggers retry and succeeds on subsequent attempt."""
+        success_body = json.dumps(
+            {
+                "userId": "user@example.com",
+                "relation": "member",
+                "type": "study",
+                "resourceId": "study-1",
+            }
+        ).encode()
+        responses = [
+            MockResponse(status_code=503, body=b""),
+            MockResponse(status_code=201, body=success_body),
+        ]
+        transport = MockTransport(responses)
+        client = AuthorizationClient(transport=transport, max_retries=3, sleep=no_sleep)
+
+        result = client.grant(
+            user_id="user@example.com",
+            resource_type="study",
+            resource_id="study-1",
+            relation="member",
+        )
+
+        assert isinstance(result, GrantResult)
+        # Initial request + 1 retry
+        assert len(transport.requests) == 2
+
+    def test_grant_raises_service_unavailable_after_retries_exhausted(
+        self,
+    ) -> None:
+        """Verify ServiceUnavailableError when all retries fail with 503."""
+        transport = MockTransport(MockResponse(status_code=503, body=b""))
+        client = AuthorizationClient(transport=transport, max_retries=2, sleep=no_sleep)
+
+        with pytest.raises(ServiceUnavailableError):
+            client.grant(
+                user_id="user@example.com",
+                resource_type="study",
+                resource_id="study-1",
+                relation="member",
+            )
+
+        # Initial request + 2 retries = 3 total
+        assert len(transport.requests) == 3
+
+    def test_grant_raises_parse_error_on_invalid_response(self) -> None:
+        """Verify ParseError when 201 response has invalid JSON."""
+        transport = MockTransport(MockResponse(status_code=201, body=b"not valid json"))
+        client = AuthorizationClient(transport=transport, sleep=no_sleep)
+
+        with pytest.raises(ParseError) as exc_info:
+            client.grant(
+                user_id="user@example.com",
+                resource_type="study",
+                resource_id="study-1",
+                relation="member",
+            )
+
+        assert exc_info.value.raw_content == b"not valid json"

--- a/common/test/python/authorization_test/test_client_health.py
+++ b/common/test/python/authorization_test/test_client_health.py
@@ -1,0 +1,90 @@
+"""Tests for AuthorizationClient.health_check method."""
+
+import pytest
+from authorization.client import AuthorizationClient
+from authorization.exceptions import ParseError, UnexpectedError
+from authorization.models import HealthResult
+
+from .conftest import MockResponse, MockTransport
+
+
+class TestHealthCheck:
+    """Tests for the health_check method."""
+
+    def test_health_check_sends_get_to_health(self) -> None:
+        """Verify health_check sends GET to /health."""
+        response = MockResponse(
+            status_code=200,
+            body=b'{"status": "healthy", "authorizationEngine": "connected"}',
+        )
+        transport = MockTransport(response)
+        client = AuthorizationClient(transport=transport)
+
+        client.health_check()
+
+        assert len(transport.requests) == 1
+        method, path, body, query_params = transport.requests[0]
+        assert method == "GET"
+        assert path == "/health"
+        assert body is None
+        assert query_params is None
+
+    def test_health_check_returns_health_result_on_200(self) -> None:
+        """Verify 200 response is parsed into HealthResult."""
+        response = MockResponse(
+            status_code=200,
+            body=b'{"status": "healthy", "authorizationEngine": "connected"}',
+        )
+        transport = MockTransport(response)
+        client = AuthorizationClient(transport=transport)
+
+        result = client.health_check()
+
+        assert isinstance(result, HealthResult)
+        assert result.status == "healthy"
+        assert result.authorization_engine == "connected"
+
+    def test_health_check_returns_unhealthy_on_503(self) -> None:
+        """Verify 503 returns HealthResult(status='unhealthy') without
+        exception."""
+        response = MockResponse(status_code=503, body=b"")
+        transport = MockTransport(response)
+        client = AuthorizationClient(transport=transport)
+
+        result = client.health_check()
+
+        assert isinstance(result, HealthResult)
+        assert result.status == "unhealthy"
+
+    def test_health_check_raises_unexpected_error_on_other_status(self) -> None:
+        """Verify non-200/non-503 status raises UnexpectedError."""
+        response = MockResponse(status_code=500, body=b"Internal Server Error")
+        transport = MockTransport(response)
+        client = AuthorizationClient(transport=transport)
+
+        with pytest.raises(UnexpectedError) as exc_info:
+            client.health_check()
+
+        assert exc_info.value.status_code == 500
+
+    def test_health_check_raises_parse_error_on_invalid_json(self) -> None:
+        """Verify malformed response body raises ParseError."""
+        response = MockResponse(status_code=200, body=b"not valid json")
+        transport = MockTransport(response)
+        client = AuthorizationClient(transport=transport)
+
+        with pytest.raises(ParseError) as exc_info:
+            client.health_check()
+
+        assert exc_info.value.raw_content == b"not valid json"
+
+    def test_health_check_does_not_retry_on_503(self) -> None:
+        """Verify health_check does NOT retry on 503 (unlike other methods)."""
+        response = MockResponse(status_code=503, body=b"")
+        transport = MockTransport(response)
+        client = AuthorizationClient(transport=transport)
+
+        client.health_check()
+
+        # Should only make one request, no retries
+        assert len(transport.requests) == 1

--- a/common/test/python/authorization_test/test_client_parents.py
+++ b/common/test/python/authorization_test/test_client_parents.py
@@ -1,0 +1,265 @@
+"""Tests for AuthorizationClient.set_resource_parents method."""
+
+import json
+
+import pytest
+from authorization.client import AuthorizationClient
+from authorization.exceptions import (
+    ParseError,
+    ServiceUnavailableError,
+    UnexpectedError,
+    ValidationError,
+)
+from authorization.models import ParentRelationshipModel, ResourceParents
+
+from .conftest import MockResponse, MockTransport, no_sleep
+
+
+class TestSetResourceParents:
+    """Tests for the set_resource_parents method."""
+
+    def test_sends_put_to_correct_path(self) -> None:
+        """Verify set_resource_parents sends PUT to.
+
+        /resources/{type}/{id}/parents.
+        """
+        response_body = json.dumps(
+            {
+                "type": "study",
+                "resourceId": "study-123",
+                "parents": [
+                    {
+                        "structuralRelation": "parent_center",
+                        "parentType": "research_center",
+                        "parentId": "center-1",
+                    }
+                ],
+            }
+        ).encode()
+        transport = MockTransport(MockResponse(status_code=200, body=response_body))
+        client = AuthorizationClient(transport=transport, sleep=no_sleep)
+
+        parents = [
+            ParentRelationshipModel(
+                structural_relation="parent_center",
+                parent_type="research_center",
+                parent_id="center-1",
+            )
+        ]
+        client.set_resource_parents(
+            resource_type="study",
+            resource_id="study-123",
+            parents=parents,
+        )
+
+        assert len(transport.requests) == 1
+        method, path, body, query_params = transport.requests[0]
+        assert method == "PUT"
+        assert path == "/resources/study/study-123/parents"
+        assert query_params is None
+
+        # Verify the request body contains the correct fields
+        assert body is not None
+        request_data = json.loads(body)
+        assert len(request_data["parents"]) == 1
+        parent = request_data["parents"][0]
+        assert parent["structuralRelation"] == "parent_center"
+        assert parent["parentType"] == "research_center"
+        assert parent["parentId"] == "center-1"
+
+    def test_returns_resource_parents_on_200(self) -> None:
+        """Verify 200 response is parsed into ResourceParents."""
+        response_body = json.dumps(
+            {
+                "type": "study",
+                "resourceId": "study-456",
+                "parents": [
+                    {
+                        "structuralRelation": "parent_center",
+                        "parentType": "research_center",
+                        "parentId": "center-2",
+                    },
+                    {
+                        "structuralRelation": "parent_community",
+                        "parentType": "community",
+                        "parentId": "comm-1",
+                    },
+                ],
+            }
+        ).encode()
+        transport = MockTransport(MockResponse(status_code=200, body=response_body))
+        client = AuthorizationClient(transport=transport, sleep=no_sleep)
+
+        parents = [
+            ParentRelationshipModel(
+                structural_relation="parent_center",
+                parent_type="research_center",
+                parent_id="center-2",
+            ),
+            ParentRelationshipModel(
+                structural_relation="parent_community",
+                parent_type="community",
+                parent_id="comm-1",
+            ),
+        ]
+        result = client.set_resource_parents(
+            resource_type="study",
+            resource_id="study-456",
+            parents=parents,
+        )
+
+        assert isinstance(result, ResourceParents)
+        assert result.type == "study"
+        assert result.resource_id == "study-456"
+        assert len(result.parents) == 2
+        assert result.parents[0].structural_relation == "parent_center"
+        assert result.parents[0].parent_type == "research_center"
+        assert result.parents[0].parent_id == "center-2"
+        assert result.parents[1].structural_relation == "parent_community"
+        assert result.parents[1].parent_type == "community"
+        assert result.parents[1].parent_id == "comm-1"
+
+    def test_raises_validation_error_on_400(self) -> None:
+        """Verify 400 raises ValidationError with API message."""
+        error_body = json.dumps(
+            {
+                "error": "validation_error",
+                "message": "Invalid parent type",
+                "details": {"field": "parentType"},
+            }
+        ).encode()
+        transport = MockTransport(MockResponse(status_code=400, body=error_body))
+        client = AuthorizationClient(transport=transport, sleep=no_sleep)
+
+        parents = [
+            ParentRelationshipModel(
+                structural_relation="parent_center",
+                parent_type="invalid_type",
+                parent_id="center-1",
+            )
+        ]
+
+        with pytest.raises(ValidationError) as exc_info:
+            client.set_resource_parents(
+                resource_type="study",
+                resource_id="study-1",
+                parents=parents,
+            )
+
+        assert exc_info.value.message == "Invalid parent type"
+        assert exc_info.value.details == {"field": "parentType"}
+
+    def test_retries_on_503(self) -> None:
+        """Verify 503 triggers retry and succeeds on subsequent attempt."""
+        success_body = json.dumps(
+            {
+                "type": "study",
+                "resourceId": "study-1",
+                "parents": [],
+            }
+        ).encode()
+        responses = [
+            MockResponse(status_code=503, body=b""),
+            MockResponse(status_code=200, body=success_body),
+        ]
+        transport = MockTransport(responses)
+        client = AuthorizationClient(transport=transport, max_retries=3, sleep=no_sleep)
+
+        result = client.set_resource_parents(
+            resource_type="study",
+            resource_id="study-1",
+            parents=[],
+        )
+
+        assert isinstance(result, ResourceParents)
+        # Initial request + 1 retry
+        assert len(transport.requests) == 2
+
+    def test_raises_service_unavailable_after_retries_exhausted(self) -> None:
+        """Verify ServiceUnavailableError when all retries fail with 503."""
+        transport = MockTransport(MockResponse(status_code=503, body=b""))
+        client = AuthorizationClient(transport=transport, max_retries=2, sleep=no_sleep)
+
+        with pytest.raises(ServiceUnavailableError):
+            client.set_resource_parents(
+                resource_type="study",
+                resource_id="study-1",
+                parents=[],
+            )
+
+        # Initial request + 2 retries = 3 total
+        assert len(transport.requests) == 3
+
+    def test_raises_unexpected_error_on_500(self) -> None:
+        """Verify 500 raises UnexpectedError immediately."""
+        error_body = json.dumps({"message": "Internal server error"}).encode()
+        transport = MockTransport(MockResponse(status_code=500, body=error_body))
+        client = AuthorizationClient(transport=transport, sleep=no_sleep)
+
+        with pytest.raises(UnexpectedError) as exc_info:
+            client.set_resource_parents(
+                resource_type="study",
+                resource_id="study-1",
+                parents=[],
+            )
+
+        assert exc_info.value.status_code == 500
+        assert "Internal server error" in exc_info.value.message
+
+    def test_raises_unexpected_error_on_403(self) -> None:
+        """Verify 403 raises UnexpectedError (not retried)."""
+        error_body = json.dumps({"message": "Forbidden"}).encode()
+        transport = MockTransport(MockResponse(status_code=403, body=error_body))
+        client = AuthorizationClient(transport=transport, sleep=no_sleep)
+
+        with pytest.raises(UnexpectedError) as exc_info:
+            client.set_resource_parents(
+                resource_type="study",
+                resource_id="study-1",
+                parents=[],
+            )
+
+        assert exc_info.value.status_code == 403
+        # Should only make one request (no retry)
+        assert len(transport.requests) == 1
+
+    def test_raises_parse_error_on_invalid_response(self) -> None:
+        """Verify ParseError when 200 response has invalid JSON."""
+        transport = MockTransport(MockResponse(status_code=200, body=b"not valid json"))
+        client = AuthorizationClient(transport=transport, sleep=no_sleep)
+
+        with pytest.raises(ParseError) as exc_info:
+            client.set_resource_parents(
+                resource_type="study",
+                resource_id="study-1",
+                parents=[],
+            )
+
+        assert exc_info.value.raw_content == b"not valid json"
+
+    def test_sends_empty_parents_list(self) -> None:
+        """Verify empty parents list is sent correctly."""
+        response_body = json.dumps(
+            {
+                "type": "study",
+                "resourceId": "study-1",
+                "parents": [],
+            }
+        ).encode()
+        transport = MockTransport(MockResponse(status_code=200, body=response_body))
+        client = AuthorizationClient(transport=transport, sleep=no_sleep)
+
+        result = client.set_resource_parents(
+            resource_type="study",
+            resource_id="study-1",
+            parents=[],
+        )
+
+        assert isinstance(result, ResourceParents)
+        assert result.parents == []
+
+        # Verify request body
+        _, _, body, _ = transport.requests[0]
+        assert body is not None
+        request_data = json.loads(body)
+        assert request_data["parents"] == []

--- a/common/test/python/authorization_test/test_client_query.py
+++ b/common/test/python/authorization_test/test_client_query.py
@@ -1,0 +1,203 @@
+"""Tests for AuthorizationClient.get_user_permissions method."""
+
+import json
+
+import pytest
+from authorization.client import AuthorizationClient
+from authorization.exceptions import (
+    ParseError,
+    ServiceUnavailableError,
+    UnexpectedError,
+)
+from authorization.models import UserPermissions
+
+from .conftest import MockResponse, MockTransport, no_sleep
+
+
+class TestGetUserPermissions:
+    """Tests for the get_user_permissions method."""
+
+    def test_sends_get_to_users_permissions_path(self) -> None:
+        """Verify GET request to /users/{userId}/permissions."""
+        response_body = json.dumps(
+            {
+                "userId": "user@example.com",
+                "permissions": {},
+            }
+        ).encode()
+        transport = MockTransport(MockResponse(status_code=200, body=response_body))
+        client = AuthorizationClient(transport=transport)
+
+        client.get_user_permissions(user_id="user@example.com")
+
+        assert len(transport.requests) == 1
+        method, path, body, query_params = transport.requests[0]
+        assert method == "GET"
+        assert path == "/users/user@example.com/permissions"
+        assert body is None
+        assert query_params is None
+
+    def test_includes_type_query_param_when_provided(self) -> None:
+        """Verify type filter is passed as query parameter."""
+        response_body = json.dumps(
+            {
+                "userId": "user@example.com",
+                "permissions": {},
+            }
+        ).encode()
+        transport = MockTransport(MockResponse(status_code=200, body=response_body))
+        client = AuthorizationClient(transport=transport)
+
+        client.get_user_permissions(user_id="user@example.com", type_filter="study")
+
+        _, _, _, query_params = transport.requests[0]
+        assert query_params == {"type": "study"}
+
+    def test_includes_relation_query_param_when_provided(self) -> None:
+        """Verify relation filter is passed as query parameter."""
+        response_body = json.dumps(
+            {
+                "userId": "user@example.com",
+                "permissions": {},
+            }
+        ).encode()
+        transport = MockTransport(MockResponse(status_code=200, body=response_body))
+        client = AuthorizationClient(transport=transport)
+
+        client.get_user_permissions(
+            user_id="user@example.com", relation_filter="member"
+        )
+
+        _, _, _, query_params = transport.requests[0]
+        assert query_params == {"relation": "member"}
+
+    def test_includes_both_query_params_when_provided(self) -> None:
+        """Verify both type and relation filters are passed."""
+        response_body = json.dumps(
+            {
+                "userId": "user@example.com",
+                "permissions": {},
+            }
+        ).encode()
+        transport = MockTransport(MockResponse(status_code=200, body=response_body))
+        client = AuthorizationClient(transport=transport)
+
+        client.get_user_permissions(
+            user_id="user@example.com",
+            type_filter="study",
+            relation_filter="admin",
+        )
+
+        _, _, _, query_params = transport.requests[0]
+        assert query_params == {"type": "study", "relation": "admin"}
+
+    def test_returns_user_permissions_on_200(self) -> None:
+        """Verify 200 response is parsed into UserPermissions model."""
+        response_body = json.dumps(
+            {
+                "userId": "user@example.com",
+                "permissions": {
+                    "study": [
+                        {
+                            "resourceId": "study-1",
+                            "relation": "member",
+                            "access": "direct",
+                        }
+                    ],
+                    "research_center": [
+                        {
+                            "resourceId": "center-1",
+                            "relation": "admin",
+                            "access": "inherited",
+                            "inheritedFrom": {
+                                "parentType": "study",
+                                "parentId": "study-1",
+                                "parentRole": "admin",
+                            },
+                        }
+                    ],
+                },
+            }
+        ).encode()
+        transport = MockTransport(MockResponse(status_code=200, body=response_body))
+        client = AuthorizationClient(transport=transport)
+
+        result = client.get_user_permissions(user_id="user@example.com")
+
+        assert isinstance(result, UserPermissions)
+        assert result.user_id == "user@example.com"
+        assert len(result.permissions) == 2
+        assert len(result.permissions["study"]) == 1
+        assert result.permissions["study"][0].resource_id == "study-1"
+        assert result.permissions["study"][0].relation == "member"
+        assert result.permissions["study"][0].access == "direct"
+        assert result.permissions["research_center"][0].access == "inherited"
+        assert result.permissions["research_center"][0].inherited_from is not None
+        assert (
+            result.permissions["research_center"][0].inherited_from.parent_type
+            == "study"
+        )
+
+    def test_retries_on_503(self) -> None:
+        """Verify 503 triggers retry and succeeds on subsequent 200."""
+        success_body = json.dumps(
+            {
+                "userId": "user@example.com",
+                "permissions": {},
+            }
+        ).encode()
+        responses = [
+            MockResponse(status_code=503, body=b""),
+            MockResponse(status_code=200, body=success_body),
+        ]
+        transport = MockTransport(responses)
+        client = AuthorizationClient(transport=transport, max_retries=3, sleep=no_sleep)
+
+        result = client.get_user_permissions(user_id="user@example.com")
+
+        assert isinstance(result, UserPermissions)
+        # Initial request + 1 retry
+        assert len(transport.requests) == 2
+
+    def test_raises_service_unavailable_when_retries_exhausted(self) -> None:
+        """Verify ServiceUnavailableError after all retries fail."""
+        responses = [MockResponse(status_code=503, body=b"")] * 5
+        transport = MockTransport(responses)
+        client = AuthorizationClient(transport=transport, max_retries=2, sleep=no_sleep)
+
+        with pytest.raises(ServiceUnavailableError):
+            client.get_user_permissions(user_id="user@example.com")
+
+    def test_raises_unexpected_error_on_non_200_non_503(self) -> None:
+        """Verify non-200/non-503 status raises UnexpectedError."""
+        response = MockResponse(status_code=500, body=b'{"message": "Internal error"}')
+        transport = MockTransport(response)
+        client = AuthorizationClient(transport=transport)
+
+        with pytest.raises(UnexpectedError) as exc_info:
+            client.get_user_permissions(user_id="user@example.com")
+
+        assert exc_info.value.status_code == 500
+
+    def test_raises_parse_error_on_invalid_json(self) -> None:
+        """Verify malformed response body raises ParseError."""
+        response = MockResponse(status_code=200, body=b"not valid json")
+        transport = MockTransport(response)
+        client = AuthorizationClient(transport=transport)
+
+        with pytest.raises(ParseError) as exc_info:
+            client.get_user_permissions(user_id="user@example.com")
+
+        assert exc_info.value.raw_content == b"not valid json"
+
+    def test_does_not_retry_on_non_503_errors(self) -> None:
+        """Verify non-503 errors fail immediately without retry."""
+        response = MockResponse(status_code=403, body=b'{"message": "Forbidden"}')
+        transport = MockTransport(response)
+        client = AuthorizationClient(transport=transport, sleep=no_sleep)
+
+        with pytest.raises(UnexpectedError):
+            client.get_user_permissions(user_id="user@example.com")
+
+        # Only one request, no retries
+        assert len(transport.requests) == 1

--- a/common/test/python/authorization_test/test_client_revoke.py
+++ b/common/test/python/authorization_test/test_client_revoke.py
@@ -1,0 +1,232 @@
+"""Tests for AuthorizationClient.revoke method."""
+
+import json
+
+import pytest
+from authorization.client import AuthorizationClient
+from authorization.exceptions import (
+    ParseError,
+    ServiceUnavailableError,
+    UnexpectedError,
+    ValidationError,
+)
+from authorization.models import RevokeResult
+
+from .conftest import MockResponse, MockTransport, no_sleep
+
+
+class TestRevoke:
+    """Tests for the revoke method."""
+
+    def test_revoke_sends_delete_to_grants(self) -> None:
+        """Verify revoke sends DELETE to /grants with correct JSON body."""
+        response_body = json.dumps(
+            {
+                "userId": "user@example.com",
+                "relation": "member",
+                "type": "study",
+                "resourceId": "study-123",
+            }
+        ).encode()
+        transport = MockTransport(MockResponse(status_code=200, body=response_body))
+        client = AuthorizationClient(transport=transport, sleep=no_sleep)
+
+        client.revoke(
+            user_id="user@example.com",
+            resource_type="study",
+            resource_id="study-123",
+            relation="member",
+        )
+
+        assert len(transport.requests) == 1
+        method, path, body, query_params = transport.requests[0]
+        assert method == "DELETE"
+        assert path == "/grants"
+        assert query_params is None
+
+        # Verify the request body contains the correct fields
+        assert body is not None
+        request_data = json.loads(body)
+        assert request_data["userId"] == "user@example.com"
+        assert request_data["relation"] == "member"
+        assert request_data["type"] == "study"
+        assert request_data["resourceId"] == "study-123"
+
+    def test_revoke_returns_revoke_result_on_200(self) -> None:
+        """Verify 200 response is parsed into RevokeResult."""
+        response_body = json.dumps(
+            {
+                "userId": "user@example.com",
+                "relation": "admin",
+                "type": "research_center",
+                "resourceId": "center-456",
+            }
+        ).encode()
+        transport = MockTransport(MockResponse(status_code=200, body=response_body))
+        client = AuthorizationClient(transport=transport, sleep=no_sleep)
+
+        result = client.revoke(
+            user_id="user@example.com",
+            resource_type="research_center",
+            resource_id="center-456",
+            relation="admin",
+        )
+
+        assert isinstance(result, RevokeResult)
+        assert result.user_id == "user@example.com"
+        assert result.relation == "admin"
+        assert result.type == "research_center"
+        assert result.resource_id == "center-456"
+
+    def test_revoke_treats_404_as_success(self) -> None:
+        """Verify 404 (not found) returns RevokeResult without raising."""
+        transport = MockTransport(MockResponse(status_code=404, body=b""))
+        client = AuthorizationClient(transport=transport, sleep=no_sleep)
+
+        result = client.revoke(
+            user_id="user@example.com",
+            resource_type="study",
+            resource_id="study-123",
+            relation="member",
+        )
+
+        assert isinstance(result, RevokeResult)
+        assert result.user_id == "user@example.com"
+        assert result.relation == "member"
+        assert result.type == "study"
+        assert result.resource_id == "study-123"
+
+    def test_revoke_raises_validation_error_on_400(self) -> None:
+        """Verify 400 raises ValidationError with API message."""
+        error_body = json.dumps(
+            {
+                "error": "validation_error",
+                "message": "Missing required field: relation",
+                "details": {"field": "relation"},
+            }
+        ).encode()
+        transport = MockTransport(MockResponse(status_code=400, body=error_body))
+        client = AuthorizationClient(transport=transport, sleep=no_sleep)
+
+        with pytest.raises(ValidationError) as exc_info:
+            client.revoke(
+                user_id="user@example.com",
+                resource_type="study",
+                resource_id="study-1",
+                relation="",
+            )
+
+        assert exc_info.value.message == "Missing required field: relation"
+        assert exc_info.value.details == {"field": "relation"}
+
+    def test_revoke_raises_unexpected_error_on_500(self) -> None:
+        """Verify 500 raises UnexpectedError immediately."""
+        error_body = json.dumps({"message": "Internal server error"}).encode()
+        transport = MockTransport(MockResponse(status_code=500, body=error_body))
+        client = AuthorizationClient(transport=transport, sleep=no_sleep)
+
+        with pytest.raises(UnexpectedError) as exc_info:
+            client.revoke(
+                user_id="user@example.com",
+                resource_type="study",
+                resource_id="study-1",
+                relation="member",
+            )
+
+        assert exc_info.value.status_code == 500
+        assert "Internal server error" in exc_info.value.message
+
+    def test_revoke_raises_unexpected_error_on_409(self) -> None:
+        """Verify 409 on revoke raises UnexpectedError (not idempotent for
+        revoke)."""
+        error_body = json.dumps({"message": "Conflict"}).encode()
+        transport = MockTransport(MockResponse(status_code=409, body=error_body))
+        client = AuthorizationClient(transport=transport, sleep=no_sleep)
+
+        with pytest.raises(UnexpectedError) as exc_info:
+            client.revoke(
+                user_id="user@example.com",
+                resource_type="study",
+                resource_id="study-1",
+                relation="member",
+            )
+
+        assert exc_info.value.status_code == 409
+
+    def test_revoke_retries_on_503(self) -> None:
+        """Verify 503 triggers retry and succeeds on subsequent attempt."""
+        success_body = json.dumps(
+            {
+                "userId": "user@example.com",
+                "relation": "member",
+                "type": "study",
+                "resourceId": "study-1",
+            }
+        ).encode()
+        responses = [
+            MockResponse(status_code=503, body=b""),
+            MockResponse(status_code=200, body=success_body),
+        ]
+        transport = MockTransport(responses)
+        client = AuthorizationClient(transport=transport, max_retries=3, sleep=no_sleep)
+
+        result = client.revoke(
+            user_id="user@example.com",
+            resource_type="study",
+            resource_id="study-1",
+            relation="member",
+        )
+
+        assert isinstance(result, RevokeResult)
+        # Initial request + 1 retry
+        assert len(transport.requests) == 2
+
+    def test_revoke_raises_service_unavailable_after_retries_exhausted(
+        self,
+    ) -> None:
+        """Verify ServiceUnavailableError when all retries fail with 503."""
+        transport = MockTransport(MockResponse(status_code=503, body=b""))
+        client = AuthorizationClient(transport=transport, max_retries=2, sleep=no_sleep)
+
+        with pytest.raises(ServiceUnavailableError):
+            client.revoke(
+                user_id="user@example.com",
+                resource_type="study",
+                resource_id="study-1",
+                relation="member",
+            )
+
+        # Initial request + 2 retries = 3 total
+        assert len(transport.requests) == 3
+
+    def test_revoke_raises_parse_error_on_invalid_response(self) -> None:
+        """Verify ParseError when 200 response has invalid JSON."""
+        transport = MockTransport(MockResponse(status_code=200, body=b"not valid json"))
+        client = AuthorizationClient(transport=transport, sleep=no_sleep)
+
+        with pytest.raises(ParseError) as exc_info:
+            client.revoke(
+                user_id="user@example.com",
+                resource_type="study",
+                resource_id="study-1",
+                relation="member",
+            )
+
+        assert exc_info.value.raw_content == b"not valid json"
+
+    def test_revoke_does_not_retry_on_non_503_errors(self) -> None:
+        """Verify non-503 errors are not retried."""
+        error_body = json.dumps({"message": "Forbidden"}).encode()
+        transport = MockTransport(MockResponse(status_code=403, body=error_body))
+        client = AuthorizationClient(transport=transport, sleep=no_sleep)
+
+        with pytest.raises(UnexpectedError):
+            client.revoke(
+                user_id="user@example.com",
+                resource_type="study",
+                resource_id="study-1",
+                relation="member",
+            )
+
+        # Should only make one request (no retry)
+        assert len(transport.requests) == 1

--- a/common/test/python/authorization_test/test_factory.py
+++ b/common/test/python/authorization_test/test_factory.py
@@ -1,0 +1,198 @@
+"""Unit tests for client instantiation and configuration via factory.
+
+Task 7.1: Test explicit URL parameter, env var fallback, and missing URL
+raises ConfigurationError. Test default and custom max_retries/base_backoff.
+
+Requirements: 1.1, 1.2, 1.3
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+from authorization.client import AuthorizationClient
+from authorization.exceptions import ConfigurationError, ServiceUnavailableError
+from authorization.factory import create_authorization_client
+
+from .conftest import MockResponse
+
+
+class TestFactoryExplicitUrl:
+    """Tests for factory with explicit base_url parameter."""
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_explicit_url_creates_client(self) -> None:
+        """Factory with explicit URL returns a configured client.
+
+        Validates: Requirement 1.1
+        """
+        client = create_authorization_client(base_url="https://api.example.com/v1")
+        assert isinstance(client, AuthorizationClient)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_explicit_url_takes_precedence_over_env_var(self) -> None:
+        """Explicit URL parameter takes precedence over env var.
+
+        Validates: Requirement 1.1
+        """
+        os.environ["AUTHORIZATION_API_URL"] = "https://env.example.com"
+        client = create_authorization_client(base_url="https://explicit.example.com")
+        assert isinstance(client, AuthorizationClient)
+
+
+class TestFactoryEnvVarFallback:
+    """Tests for factory falling back to environment variable."""
+
+    @patch.dict(os.environ, {"AUTHORIZATION_API_URL": "https://env.example.com/v1"})
+    def test_env_var_fallback_creates_client(self) -> None:
+        """Factory without explicit URL falls back to env var.
+
+        Validates: Requirement 1.2
+        """
+        client = create_authorization_client()
+        assert isinstance(client, AuthorizationClient)
+
+    @patch.dict(os.environ, {"AUTHORIZATION_API_URL": "https://env.example.com/v1"})
+    def test_env_var_used_when_base_url_is_none(self) -> None:
+        """Factory with base_url=None uses env var.
+
+        Validates: Requirement 1.2
+        """
+        client = create_authorization_client(base_url=None)
+        assert isinstance(client, AuthorizationClient)
+
+
+class TestFactoryMissingUrl:
+    """Tests for factory when no URL is resolvable."""
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_no_url_raises_configuration_error(self) -> None:
+        """Factory raises ConfigurationError when no URL is available.
+
+        Validates: Requirement 1.3
+        """
+        # Ensure the env var is not set
+        os.environ.pop("AUTHORIZATION_API_URL", None)
+
+        with pytest.raises(ConfigurationError):
+            create_authorization_client()
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_empty_string_url_raises_configuration_error(self) -> None:
+        """Factory raises ConfigurationError for empty string URL.
+
+        Validates: Requirement 1.3
+        """
+        os.environ.pop("AUTHORIZATION_API_URL", None)
+
+        with pytest.raises(ConfigurationError):
+            create_authorization_client(base_url="")
+
+    @patch.dict(os.environ, {"AUTHORIZATION_API_URL": ""})
+    def test_empty_env_var_raises_configuration_error(self) -> None:
+        """Factory raises ConfigurationError for empty env var.
+
+        Validates: Requirement 1.3
+        """
+        with pytest.raises(ConfigurationError):
+            create_authorization_client()
+
+
+class TestFactoryRetryConfiguration:
+    """Tests for custom max_retries and base_backoff values."""
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_default_retry_values(self) -> None:
+        """Factory uses default max_retries=3 and base_backoff=1.0.
+
+        Verifies by observing that the client makes 1 + 3 = 4 requests
+        when all return 503 (initial + 3 retries).
+
+        Validates: Requirement 1.1
+        """
+        client = create_authorization_client(base_url="https://api.example.com")
+        assert isinstance(client, AuthorizationClient)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_custom_max_retries_affects_behavior(self) -> None:
+        """Factory passes custom max_retries to client.
+
+        Verifies by injecting a mock transport and observing retry count.
+
+        Validates: Requirement 1.1
+        """
+
+        class CountingTransport:
+            def __init__(self) -> None:
+                self.call_count = 0
+
+            def request(
+                self,
+                method: str,
+                path: str,
+                body: bytes | None = None,
+                query_params: dict[str, str] | None = None,
+            ) -> MockResponse:
+                self.call_count += 1
+                return MockResponse(status_code=503, body=b"")
+
+        transport = CountingTransport()
+        client = AuthorizationClient(
+            transport=transport,
+            max_retries=5,
+            base_backoff=0.01,
+            sleep=lambda _: None,
+        )
+
+        with pytest.raises(ServiceUnavailableError):
+            client.grant(
+                user_id="u",
+                resource_type="study",
+                resource_id="r",
+                relation="member",
+            )
+
+        # Initial request + 5 retries = 6 total
+        assert transport.call_count == 6
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_custom_base_backoff_affects_behavior(self) -> None:
+        """Factory passes custom base_backoff to client.
+
+        Verifies by capturing sleep durations.
+
+        Validates: Requirement 1.1
+        """
+
+        class AlwaysFailTransport:
+            def request(
+                self,
+                method: str,
+                path: str,
+                body: bytes | None = None,
+                query_params: dict[str, str] | None = None,
+            ) -> MockResponse:
+                return MockResponse(status_code=503, body=b"")
+
+        sleep_durations: list[float] = []
+
+        def capture_sleep(duration: float) -> None:
+            sleep_durations.append(duration)
+
+        client = AuthorizationClient(
+            transport=AlwaysFailTransport(),
+            max_retries=3,
+            base_backoff=2.0,
+            sleep=capture_sleep,
+        )
+
+        with pytest.raises(ServiceUnavailableError):
+            client.grant(
+                user_id="u",
+                resource_type="study",
+                resource_id="r",
+                relation="member",
+            )
+
+        # Backoff pattern: 2.0 * 2^0, 2.0 * 2^1, 2.0 * 2^2 = 2.0, 4.0, 8.0
+        assert sleep_durations == [2.0, 4.0, 8.0]

--- a/common/test/python/authorization_test/test_logging.py
+++ b/common/test/python/authorization_test/test_logging.py
@@ -1,0 +1,411 @@
+"""Unit tests for health check and logging behavior.
+
+Task 7.2: Test health check request construction and response parsing,
+503 on health returns unhealthy result, and logging at appropriate levels.
+
+Requirements: 7.1, 7.2, 7.3, 10.1, 10.2, 10.3, 10.4, 10.5
+"""
+
+import json
+import logging
+
+import pytest
+from authorization.client import AuthorizationClient
+from authorization.exceptions import ServiceUnavailableError, UnexpectedError
+from authorization.models import HealthResult
+
+from .conftest import MockResponse, MockTransport, no_sleep
+
+
+class TestHealthCheckRequestConstruction:
+    """Tests for health check request construction.
+
+    Validates: Requirement 7.1
+    """
+
+    def test_health_check_sends_get_to_health_endpoint(self) -> None:
+        """Health check sends GET /health with no body or query params."""
+        response = MockResponse(
+            status_code=200,
+            body=b'{"status": "healthy", "authorizationEngine": "connected"}',
+        )
+        transport = MockTransport(response)
+        client = AuthorizationClient(transport=transport, sleep=no_sleep)
+
+        client.health_check()
+
+        assert len(transport.requests) == 1
+        method, path, body, query_params = transport.requests[0]
+        assert method == "GET"
+        assert path == "/health"
+        assert body is None
+        assert query_params is None
+
+
+class TestHealthCheckResponseParsing:
+    """Tests for health check response parsing.
+
+    Validates: Requirement 7.2
+    """
+
+    def test_healthy_response_parsed_correctly(self) -> None:
+        """200 with healthy status returns correct HealthResult."""
+        response = MockResponse(
+            status_code=200,
+            body=b'{"status": "healthy", "authorizationEngine": "connected"}',
+        )
+        transport = MockTransport(response)
+        client = AuthorizationClient(transport=transport, sleep=no_sleep)
+
+        result = client.health_check()
+
+        assert isinstance(result, HealthResult)
+        assert result.status == "healthy"
+        assert result.authorization_engine == "connected"
+
+    def test_degraded_response_parsed_correctly(self) -> None:
+        """200 with degraded status returns correct HealthResult."""
+        response = MockResponse(
+            status_code=200,
+            body=b'{"status": "degraded", "authorizationEngine": "unreachable"}',
+        )
+        transport = MockTransport(response)
+        client = AuthorizationClient(transport=transport, sleep=no_sleep)
+
+        result = client.health_check()
+
+        assert result.status == "degraded"
+        assert result.authorization_engine == "unreachable"
+
+
+class TestHealthCheck503Behavior:
+    """Tests for health check 503 behavior.
+
+    Validates: Requirement 7.3
+    """
+
+    def test_503_returns_unhealthy_result(self) -> None:
+        """503 returns HealthResult(status='unhealthy') without exception."""
+        response = MockResponse(status_code=503, body=b"")
+        transport = MockTransport(response)
+        client = AuthorizationClient(transport=transport, sleep=no_sleep)
+
+        result = client.health_check()
+
+        assert isinstance(result, HealthResult)
+        assert result.status == "unhealthy"
+
+    def test_503_does_not_retry(self) -> None:
+        """Health check does NOT retry on 503 (unlike other methods)."""
+        response = MockResponse(status_code=503, body=b"")
+        transport = MockTransport(response)
+        client = AuthorizationClient(transport=transport, max_retries=3, sleep=no_sleep)
+
+        client.health_check()
+
+        assert len(transport.requests) == 1
+
+
+class TestLoggingDebugSuccess:
+    """Tests for debug-level logging on successful operations.
+
+    Validates: Requirements 10.1, 10.5
+    """
+
+    def test_grant_success_logs_at_debug(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Successful grant logs at DEBUG level."""
+        response_body = json.dumps(
+            {
+                "userId": "user@example.com",
+                "relation": "member",
+                "type": "study",
+                "resourceId": "study-1",
+            }
+        ).encode()
+        transport = MockTransport(MockResponse(status_code=201, body=response_body))
+        client = AuthorizationClient(transport=transport, sleep=no_sleep)
+
+        with caplog.at_level(logging.DEBUG, logger="authorization.client"):
+            client.grant(
+                user_id="user@example.com",
+                resource_type="study",
+                resource_id="study-1",
+                relation="member",
+            )
+
+        debug_messages = [
+            r.message for r in caplog.records if r.levelno == logging.DEBUG
+        ]
+        assert any("Grant succeeded" in msg for msg in debug_messages)
+
+    def test_revoke_success_logs_at_debug(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Successful revoke logs at DEBUG level."""
+        response_body = json.dumps(
+            {
+                "userId": "user@example.com",
+                "relation": "member",
+                "type": "study",
+                "resourceId": "study-1",
+            }
+        ).encode()
+        transport = MockTransport(MockResponse(status_code=200, body=response_body))
+        client = AuthorizationClient(transport=transport, sleep=no_sleep)
+
+        with caplog.at_level(logging.DEBUG, logger="authorization.client"):
+            client.revoke(
+                user_id="user@example.com",
+                resource_type="study",
+                resource_id="study-1",
+                relation="member",
+            )
+
+        debug_messages = [
+            r.message for r in caplog.records if r.levelno == logging.DEBUG
+        ]
+        assert any("Revoke succeeded" in msg for msg in debug_messages)
+
+    def test_health_check_success_logs_at_debug(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Successful health check logs at DEBUG level."""
+        response = MockResponse(
+            status_code=200,
+            body=b'{"status": "healthy", "authorizationEngine": "connected"}',
+        )
+        transport = MockTransport(response)
+        client = AuthorizationClient(transport=transport, sleep=no_sleep)
+
+        with caplog.at_level(logging.DEBUG, logger="authorization.client"):
+            client.health_check()
+
+        debug_messages = [
+            r.message for r in caplog.records if r.levelno == logging.DEBUG
+        ]
+        assert any("Health check succeeded" in msg for msg in debug_messages)
+
+
+class TestLoggingDebugIdempotent:
+    """Tests for debug-level logging on idempotent outcomes.
+
+    Validates: Requirement 10.2
+    """
+
+    def test_grant_409_logs_at_debug(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Grant 409 (already exists) logs at DEBUG level."""
+        transport = MockTransport(MockResponse(status_code=409, body=b""))
+        client = AuthorizationClient(transport=transport, sleep=no_sleep)
+
+        with caplog.at_level(logging.DEBUG, logger="authorization.client"):
+            client.grant(
+                user_id="user@example.com",
+                resource_type="study",
+                resource_id="study-1",
+                relation="member",
+            )
+
+        debug_messages = [
+            r.message for r in caplog.records if r.levelno == logging.DEBUG
+        ]
+        assert any("idempotent" in msg.lower() for msg in debug_messages)
+
+    def test_revoke_404_logs_at_debug(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Revoke 404 (not found) logs at DEBUG level."""
+        transport = MockTransport(MockResponse(status_code=404, body=b""))
+        client = AuthorizationClient(transport=transport, sleep=no_sleep)
+
+        with caplog.at_level(logging.DEBUG, logger="authorization.client"):
+            client.revoke(
+                user_id="user@example.com",
+                resource_type="study",
+                resource_id="study-1",
+                relation="member",
+            )
+
+        debug_messages = [
+            r.message for r in caplog.records if r.levelno == logging.DEBUG
+        ]
+        assert any("idempotent" in msg.lower() for msg in debug_messages)
+
+
+class TestLoggingWarningRetry:
+    """Tests for warning-level logging on retry attempts.
+
+    Validates: Requirement 10.3
+    """
+
+    def test_retry_logs_at_warning_with_attempt_and_duration(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Retry attempts log at WARNING with attempt number and wait."""
+        responses = [
+            MockResponse(status_code=503, body=b""),
+            MockResponse(status_code=503, body=b""),
+            MockResponse(
+                status_code=200,
+                body=json.dumps(
+                    {
+                        "userId": "user@example.com",
+                        "relation": "member",
+                        "type": "study",
+                        "resourceId": "study-1",
+                    }
+                ).encode(),
+            ),
+        ]
+        transport = MockTransport(responses)
+        client = AuthorizationClient(
+            transport=transport,
+            max_retries=3,
+            base_backoff=1.0,
+            sleep=no_sleep,
+        )
+
+        with caplog.at_level(logging.WARNING, logger="authorization.retry"):
+            client.grant(
+                user_id="user@example.com",
+                resource_type="study",
+                resource_id="study-1",
+                relation="member",
+            )
+
+        warning_messages = [
+            r.message for r in caplog.records if r.levelno == logging.WARNING
+        ]
+        # Should have 2 retry warnings
+        # (first 503 triggers retry 1, second triggers retry 2)
+        assert len(warning_messages) >= 2
+        # Check that attempt numbers are included
+        assert any("1" in msg for msg in warning_messages)
+        assert any("2" in msg for msg in warning_messages)
+
+    def test_exhausted_retries_log_all_attempts(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """All retry attempts are logged before raising error."""
+        transport = MockTransport(MockResponse(status_code=503, body=b""))
+        client = AuthorizationClient(
+            transport=transport,
+            max_retries=3,
+            base_backoff=1.0,
+            sleep=no_sleep,
+        )
+
+        with (
+            caplog.at_level(logging.WARNING, logger="authorization.retry"),
+            pytest.raises(ServiceUnavailableError),
+        ):
+            client.grant(
+                user_id="user@example.com",
+                resource_type="study",
+                resource_id="study-1",
+                relation="member",
+            )
+
+        warning_messages = [
+            r.message for r in caplog.records if r.levelno == logging.WARNING
+        ]
+        assert len(warning_messages) == 3
+
+
+class TestLoggingErrorOnFailure:
+    """Tests for error-level logging on non-retriable errors.
+
+    Validates: Requirement 10.4
+    """
+
+    def test_unexpected_error_logs_at_error(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Non-retriable error logs at ERROR level."""
+        error_body = json.dumps({"message": "Forbidden"}).encode()
+        transport = MockTransport(MockResponse(status_code=403, body=error_body))
+        client = AuthorizationClient(transport=transport, sleep=no_sleep)
+
+        with (
+            caplog.at_level(logging.ERROR, logger="authorization.client"),
+            pytest.raises(UnexpectedError),
+        ):
+            client.grant(
+                user_id="user@example.com",
+                resource_type="study",
+                resource_id="study-1",
+                relation="member",
+            )
+
+        error_messages = [
+            r.message for r in caplog.records if r.levelno == logging.ERROR
+        ]
+        assert len(error_messages) >= 1
+        assert any(
+            "403" in msg or "unexpected" in msg.lower() for msg in error_messages
+        )
+
+
+class TestLoggingUsesNamedLogger:
+    """Tests for named logger usage.
+
+    Validates: Requirement 10.5
+    """
+
+    def test_client_uses_named_logger(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Client logs use the 'authorization.client' logger name."""
+        response_body = json.dumps(
+            {
+                "userId": "user@example.com",
+                "relation": "member",
+                "type": "study",
+                "resourceId": "study-1",
+            }
+        ).encode()
+        transport = MockTransport(MockResponse(status_code=201, body=response_body))
+        client = AuthorizationClient(transport=transport, sleep=no_sleep)
+
+        with caplog.at_level(logging.DEBUG, logger="authorization.client"):
+            client.grant(
+                user_id="user@example.com",
+                resource_type="study",
+                resource_id="study-1",
+                relation="member",
+            )
+
+        logger_names = {r.name for r in caplog.records}
+        assert "authorization.client" in logger_names
+
+    def test_retry_uses_named_logger(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Retry logic uses the 'authorization.retry' logger name."""
+        responses = [
+            MockResponse(status_code=503, body=b""),
+            MockResponse(
+                status_code=200,
+                body=json.dumps(
+                    {
+                        "userId": "user@example.com",
+                        "relation": "member",
+                        "type": "study",
+                        "resourceId": "study-1",
+                    }
+                ).encode(),
+            ),
+        ]
+        transport = MockTransport(responses)
+        client = AuthorizationClient(
+            transport=transport,
+            max_retries=3,
+            base_backoff=1.0,
+            sleep=no_sleep,
+        )
+
+        with caplog.at_level(logging.WARNING, logger="authorization.retry"):
+            client.grant(
+                user_id="user@example.com",
+                resource_type="study",
+                resource_id="study-1",
+                relation="member",
+            )
+
+        logger_names = {r.name for r in caplog.records}
+        assert "authorization.retry" in logger_names

--- a/common/test/python/authorization_test/test_property_batch.py
+++ b/common/test/python/authorization_test/test_property_batch.py
@@ -1,0 +1,349 @@
+"""Property tests for batch operations.
+
+**Feature: authorization-client-library,
+  Properties 7, 8, 9: Batch chunking and aggregation**
+**Validates: Requirements 4.1, 4.2, 4.3, 4.4, 4.7**
+"""
+
+import json
+import math
+
+from authorization.client import AuthorizationClient
+from authorization.models import BatchOperation
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from .conftest import MockResponse, no_sleep
+
+# --- Strategies ---
+
+_RESOURCE_TYPES = st.sampled_from(
+    ["study", "research_center", "community", "data_pipeline", "dashboard", "page"]
+)
+
+_RELATIONS = st.sampled_from(
+    ["member", "admin", "viewer", "submitter", "auditor", "editor"]
+)
+
+_USER_IDS = st.text(
+    alphabet=st.characters(
+        whitelist_categories=("L", "N"), whitelist_characters="-_@."
+    ),
+    min_size=1,
+    max_size=30,
+)
+
+_RESOURCE_IDS = st.text(
+    alphabet=st.characters(whitelist_categories=("L", "N"), whitelist_characters="-_"),
+    min_size=1,
+    max_size=30,
+)
+
+_BATCH_OPERATIONS = st.builds(
+    BatchOperation,
+    action=st.sampled_from(["grant", "revoke"]),
+    user_id=_USER_IDS,
+    resource_type=_RESOURCE_TYPES,
+    resource_id=_RESOURCE_IDS,
+    relation=_RELATIONS,
+)
+
+# Lists of 1-500 operations as specified in the design
+_OPERATION_LISTS = st.lists(_BATCH_OPERATIONS, min_size=1, max_size=500)
+
+# --- Mock Transport ---
+
+# Error codes for per-operation errors
+_IDEMPOTENT_ERROR_CODES = st.sampled_from(["conflict", "not_found"])
+_NON_IDEMPOTENT_ERROR_CODES = st.sampled_from(
+    ["service_unavailable", "internal_error", "permission_denied"]
+)
+
+
+class ChunkRecordingTransport:
+    """Mock transport that records each batch request and returns success."""
+
+    def __init__(self) -> None:
+        self.requests: list[dict] = []
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        body: bytes | None = None,
+        query_params: dict[str, str] | None = None,
+    ) -> MockResponse:
+        parsed_body = json.loads(body) if body else {}
+        self.requests.append(
+            {
+                "method": method,
+                "path": path,
+                "body": parsed_body,
+                "raw_body": body,
+                "query_params": query_params,
+            }
+        )
+        # Return a success response matching the number of operations
+        num_ops = len(parsed_body.get("operations", []))
+        response_body = json.dumps(
+            {
+                "total": num_ops,
+                "succeeded": num_ops,
+                "failed": 0,
+                "errors": [],
+            }
+        ).encode()
+        return MockResponse(status_code=200, body=response_body)
+
+
+class MixedResultTransport:
+    """Mock transport that returns configurable per-operation errors."""
+
+    def __init__(
+        self,
+        idempotent_indices: list[int],
+        non_idempotent_indices: list[int],
+        idempotent_code: str = "conflict",
+        non_idempotent_code: str = "internal_error",
+    ) -> None:
+        self.idempotent_indices = idempotent_indices
+        self.non_idempotent_indices = non_idempotent_indices
+        self.idempotent_code = idempotent_code
+        self.non_idempotent_code = non_idempotent_code
+        self.requests: list[dict] = []
+        self._global_offset = 0
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        body: bytes | None = None,
+        query_params: dict[str, str] | None = None,
+    ) -> MockResponse:
+        parsed_body = json.loads(body) if body else {}
+        self.requests.append({"body": parsed_body})
+        num_ops = len(parsed_body.get("operations", []))
+
+        # Determine which errors fall in this chunk
+        chunk_start = self._global_offset
+        chunk_end = chunk_start + num_ops
+
+        errors = []
+        idempotent_in_chunk = 0
+        non_idempotent_in_chunk = 0
+
+        for idx in self.idempotent_indices:
+            if chunk_start <= idx < chunk_end:
+                local_idx = idx - chunk_start
+                errors.append(
+                    {
+                        "index": local_idx,
+                        "error": self.idempotent_code,
+                        "message": f"Idempotent error at {local_idx}",
+                    }
+                )
+                idempotent_in_chunk += 1
+
+        for idx in self.non_idempotent_indices:
+            if chunk_start <= idx < chunk_end:
+                local_idx = idx - chunk_start
+                errors.append(
+                    {
+                        "index": local_idx,
+                        "error": self.non_idempotent_code,
+                        "message": f"Non-idempotent error at {local_idx}",
+                    }
+                )
+                non_idempotent_in_chunk += 1
+
+        total_errors = idempotent_in_chunk + non_idempotent_in_chunk
+        succeeded = num_ops - total_errors
+        failed = total_errors
+
+        response_body = json.dumps(
+            {
+                "total": num_ops,
+                "succeeded": succeeded,
+                "failed": failed,
+                "errors": errors,
+            }
+        ).encode()
+
+        self._global_offset = chunk_end
+        return MockResponse(status_code=200, body=response_body)
+
+
+# --- Property Tests ---
+
+
+@given(operations=_OPERATION_LISTS)
+@settings(max_examples=100)
+def test_batch_chunking_respects_size_limit(
+    operations: list[BatchOperation],
+) -> None:
+    """Property 7: Batch chunking respects size limit.
+
+    **Feature: authorization-client-library,
+      Property 7: Batch chunking respects size limit**
+    **Validates: Requirements 4.1, 4.2**
+
+    For any list of N batch operations, the client sends exactly
+    ceil(N/100) HTTP requests, each containing at most 100 operations.
+    """
+    transport = ChunkRecordingTransport()
+    client = AuthorizationClient(transport, sleep=no_sleep)
+
+    client.batch(operations)
+
+    n = len(operations)
+    expected_chunks = math.ceil(n / 100)
+
+    # Verify correct number of requests
+    assert len(transport.requests) == expected_chunks, (
+        f"Expected {expected_chunks} requests for {n} operations, "
+        f"got {len(transport.requests)}"
+    )
+
+    # Verify each chunk has at most 100 operations
+    for i, req in enumerate(transport.requests):
+        chunk_ops = req["body"]["operations"]
+        assert len(chunk_ops) <= 100, (
+            f"Chunk {i} has {len(chunk_ops)} operations, exceeds limit of 100"
+        )
+
+
+@given(operations=_OPERATION_LISTS)
+@settings(max_examples=100)
+def test_batch_chunking_preserves_order(
+    operations: list[BatchOperation],
+) -> None:
+    """Property 8: Batch chunking preserves order.
+
+    **Feature: authorization-client-library,
+      Property 8: Batch chunking preserves order**
+    **Validates: Requirements 4.3**
+
+    For any list of batch operations, the concatenation of operations
+    across all chunks (in chunk order) equals the original list.
+    """
+    transport = ChunkRecordingTransport()
+    client = AuthorizationClient(transport, sleep=no_sleep)
+
+    client.batch(operations)
+
+    # Reconstruct the full list from chunks
+    reconstructed: list[dict] = []
+    for req in transport.requests:
+        reconstructed.extend(req["body"]["operations"])
+
+    # Verify same length
+    assert len(reconstructed) == len(operations), (
+        f"Reconstructed {len(reconstructed)} operations, expected {len(operations)}"
+    )
+
+    # Verify each operation matches in order
+    for i, (original, sent) in enumerate(zip(operations, reconstructed, strict=False)):
+        assert sent["userId"] == original.user_id, (
+            f"Operation {i}: userId mismatch. "
+            f"Expected '{original.user_id}', got '{sent['userId']}'"
+        )
+        assert sent["resourceId"] == original.resource_id, (
+            f"Operation {i}: resourceId mismatch. "
+            f"Expected '{original.resource_id}', got '{sent['resourceId']}'"
+        )
+        assert sent["type"] == original.resource_type, (
+            f"Operation {i}: type mismatch. "
+            f"Expected '{original.resource_type}', got '{sent['type']}'"
+        )
+        assert sent["relation"] == original.relation, (
+            f"Operation {i}: relation mismatch. "
+            f"Expected '{original.relation}', got '{sent['relation']}'"
+        )
+        assert sent["action"] == original.action, (
+            f"Operation {i}: action mismatch. "
+            f"Expected '{original.action}', got '{sent['action']}'"
+        )
+
+
+@given(
+    operations=st.lists(_BATCH_OPERATIONS, min_size=1, max_size=500),
+    idempotent_code=_IDEMPOTENT_ERROR_CODES,
+    non_idempotent_code=_NON_IDEMPOTENT_ERROR_CODES,
+    seed=st.integers(min_value=0, max_value=2**32 - 1),
+)
+@settings(max_examples=100)
+def test_batch_result_aggregation(
+    operations: list[BatchOperation],
+    idempotent_code: str,
+    non_idempotent_code: str,
+    seed: int,
+) -> None:
+    """Property 9: Batch result aggregation.
+
+    **Feature: authorization-client-library,
+      Property 9: Batch result aggregation**
+    **Validates: Requirements 4.4, 4.7**
+
+    For any multi-chunk batch execution with mixed per-operation outcomes,
+    the aggregate BatchResult has:
+    - total == sum of all chunk totals
+    - succeeded == sum of chunk successes + idempotent errors
+    - failed == only non-idempotent failures
+    """
+    import random
+
+    rng = random.Random(seed)
+    n = len(operations)
+
+    # Randomly select some indices for idempotent errors and some for
+    # non-idempotent errors (non-overlapping)
+    all_indices = list(range(n))
+    rng.shuffle(all_indices)
+
+    # Use up to 20% of operations as errors
+    max_errors = max(1, n // 5)
+    num_idempotent = rng.randint(0, min(max_errors, n))
+    remaining = n - num_idempotent
+    num_non_idempotent = rng.randint(0, min(max_errors, remaining))
+
+    idempotent_indices = sorted(all_indices[:num_idempotent])
+    non_idempotent_indices = sorted(
+        all_indices[num_idempotent : num_idempotent + num_non_idempotent]
+    )
+
+    transport = MixedResultTransport(
+        idempotent_indices=idempotent_indices,
+        non_idempotent_indices=non_idempotent_indices,
+        idempotent_code=idempotent_code,
+        non_idempotent_code=non_idempotent_code,
+    )
+    client = AuthorizationClient(transport, sleep=no_sleep)
+
+    result = client.batch(operations)
+
+    # Verify aggregate totals
+    assert result.total == n, f"Total should be {n}, got {result.total}"
+
+    # Succeeded = operations that didn't error + idempotent errors
+    expected_succeeded = (n - num_idempotent - num_non_idempotent) + num_idempotent
+    assert result.succeeded == expected_succeeded, (
+        f"Succeeded should be {expected_succeeded}, got {result.succeeded}. "
+        f"(n={n}, idempotent={num_idempotent}, non_idempotent={num_non_idempotent})"
+    )
+
+    # Failed = only non-idempotent errors
+    assert result.failed == num_non_idempotent, (
+        f"Failed should be {num_non_idempotent}, got {result.failed}"
+    )
+
+    # Errors list should contain only non-idempotent errors
+    assert len(result.errors) == num_non_idempotent, (
+        f"Errors list should have {num_non_idempotent} entries, "
+        f"got {len(result.errors)}"
+    )
+
+    # All reported errors should have the non-idempotent error code
+    for error in result.errors:
+        assert error.error == non_idempotent_code, (
+            f"Expected error code '{non_idempotent_code}', got '{error.error}'"
+        )

--- a/common/test/python/authorization_test/test_property_grant_revoke.py
+++ b/common/test/python/authorization_test/test_property_grant_revoke.py
@@ -1,0 +1,458 @@
+"""Property-based tests for AuthorizationClient grant and revoke methods.
+
+Feature: authorization-client-library
+Properties tested: 1, 3, 4, 6
+"""
+
+import json
+
+import pytest
+from authorization.client import AuthorizationClient
+from authorization.exceptions import UnexpectedError, ValidationError
+from authorization.models import GrantResult, RevokeResult
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from .conftest import CapturingTransport, MockResponse, no_sleep
+
+# --- Strategies ---
+
+# Known resource types from the authorization model
+RESOURCE_TYPES = [
+    "study",
+    "research_center",
+    "community",
+    "data_pipeline",
+    "dashboard",
+    "page",
+]
+
+# Known relations
+RELATIONS = ["member", "admin", "viewer", "submitter", "auditor", "editor"]
+
+# Non-empty alphanumeric strings with common separators for IDs
+valid_user_ids = st.text(
+    alphabet=st.sampled_from("abcdefghijklmnopqrstuvwxyz0123456789@._-"),
+    min_size=1,
+    max_size=50,
+)
+
+valid_resource_types = st.sampled_from(RESOURCE_TYPES)
+
+valid_resource_ids = st.text(
+    alphabet=st.sampled_from("abcdefghijklmnopqrstuvwxyz0123456789-_"),
+    min_size=1,
+    max_size=50,
+)
+
+valid_relations = st.sampled_from(RELATIONS)
+
+# Non-retriable, non-idempotent, non-400 errors for grant
+# (400 is handled separately as ValidationError)
+unexpected_grant_errors = st.sampled_from([401, 402, 403, 404, 405, 422, 429, 500, 502])
+
+# Non-retriable, non-idempotent, non-400 errors for revoke
+unexpected_revoke_errors = st.sampled_from(
+    [401, 402, 403, 405, 409, 422, 429, 500, 502]
+)
+
+# Error messages for validation errors
+error_messages = st.text(
+    alphabet=st.sampled_from(
+        "abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789:._-"
+    ),
+    min_size=1,
+    max_size=100,
+)
+
+
+# --- Property 1: Request construction correctness ---
+
+
+class TestProperty1RequestConstruction:
+    """Property 1: Request construction correctness.
+
+    For any valid grant/revoke operation with any valid combination of
+    parameters, the client SHALL construct an HTTP request with the
+    correct method, path, and JSON body containing all provided fields.
+
+    **Validates: Requirements 2.1, 3.1**
+    """
+
+    @settings(max_examples=100)
+    @given(
+        user_id=valid_user_ids,
+        resource_type=valid_resource_types,
+        resource_id=valid_resource_ids,
+        relation=valid_relations,
+    )
+    def test_grant_request_construction(
+        self,
+        user_id: str,
+        resource_type: str,
+        resource_id: str,
+        relation: str,
+    ) -> None:
+        """Grant constructs POST /grants with correct JSON body.
+
+        **Validates: Requirements 2.1**
+        """
+        # Build a success response matching the request
+        response_body = json.dumps(
+            {
+                "userId": user_id,
+                "relation": relation,
+                "type": resource_type,
+                "resourceId": resource_id,
+            }
+        ).encode()
+        transport = CapturingTransport(
+            MockResponse(status_code=201, body=response_body)
+        )
+        client = AuthorizationClient(transport=transport, sleep=no_sleep)
+
+        client.grant(
+            user_id=user_id,
+            resource_type=resource_type,
+            resource_id=resource_id,
+            relation=relation,
+        )
+
+        assert len(transport.requests) == 1
+        method, path, body, query_params = transport.requests[0]
+
+        # Correct HTTP method and path
+        assert method == "POST"
+        assert path == "/grants"
+        assert query_params is None
+
+        # Body contains all fields with correct aliases
+        assert body is not None
+        request_data = json.loads(body)
+        assert request_data["userId"] == user_id
+        assert request_data["relation"] == relation
+        assert request_data["type"] == resource_type
+        assert request_data["resourceId"] == resource_id
+
+    @settings(max_examples=100)
+    @given(
+        user_id=valid_user_ids,
+        resource_type=valid_resource_types,
+        resource_id=valid_resource_ids,
+        relation=valid_relations,
+    )
+    def test_revoke_request_construction(
+        self,
+        user_id: str,
+        resource_type: str,
+        resource_id: str,
+        relation: str,
+    ) -> None:
+        """Revoke constructs DELETE /grants with correct JSON body.
+
+        **Validates: Requirements 3.1**
+        """
+        # Build a success response matching the request
+        response_body = json.dumps(
+            {
+                "userId": user_id,
+                "relation": relation,
+                "type": resource_type,
+                "resourceId": resource_id,
+            }
+        ).encode()
+        transport = CapturingTransport(
+            MockResponse(status_code=200, body=response_body)
+        )
+        client = AuthorizationClient(transport=transport, sleep=no_sleep)
+
+        client.revoke(
+            user_id=user_id,
+            resource_type=resource_type,
+            resource_id=resource_id,
+            relation=relation,
+        )
+
+        assert len(transport.requests) == 1
+        method, path, body, query_params = transport.requests[0]
+
+        # Correct HTTP method and path
+        assert method == "DELETE"
+        assert path == "/grants"
+        assert query_params is None
+
+        # Body contains all fields with correct aliases
+        assert body is not None
+        request_data = json.loads(body)
+        assert request_data["userId"] == user_id
+        assert request_data["relation"] == relation
+        assert request_data["type"] == resource_type
+        assert request_data["resourceId"] == resource_id
+
+
+# --- Property 3: Idempotent status codes yield success ---
+
+
+class TestProperty3IdempotentSuccess:
+    """Property 3: Idempotent status codes yield success.
+
+    For any grant request that receives HTTP 409, or any revoke request
+    that receives HTTP 404, the client SHALL return a success result
+    (not raise an exception).
+
+    **Validates: Requirements 2.3, 3.3**
+    """
+
+    @settings(max_examples=100)
+    @given(
+        user_id=valid_user_ids,
+        resource_type=valid_resource_types,
+        resource_id=valid_resource_ids,
+        relation=valid_relations,
+    )
+    def test_grant_409_returns_success(
+        self,
+        user_id: str,
+        resource_type: str,
+        resource_id: str,
+        relation: str,
+    ) -> None:
+        """Grant with 409 response returns GrantResult without raising.
+
+        **Validates: Requirements 2.3**
+        """
+        transport = CapturingTransport(MockResponse(status_code=409, body=b""))
+        client = AuthorizationClient(transport=transport, sleep=no_sleep)
+
+        result = client.grant(
+            user_id=user_id,
+            resource_type=resource_type,
+            resource_id=resource_id,
+            relation=relation,
+        )
+
+        # Should return a GrantResult, not raise
+        assert isinstance(result, GrantResult)
+        assert result.user_id == user_id
+        assert result.relation == relation
+        assert result.type == resource_type
+        assert result.resource_id == resource_id
+
+    @settings(max_examples=100)
+    @given(
+        user_id=valid_user_ids,
+        resource_type=valid_resource_types,
+        resource_id=valid_resource_ids,
+        relation=valid_relations,
+    )
+    def test_revoke_404_returns_success(
+        self,
+        user_id: str,
+        resource_type: str,
+        resource_id: str,
+        relation: str,
+    ) -> None:
+        """Revoke with 404 response returns RevokeResult without raising.
+
+        **Validates: Requirements 3.3**
+        """
+        transport = CapturingTransport(MockResponse(status_code=404, body=b""))
+        client = AuthorizationClient(transport=transport, sleep=no_sleep)
+
+        result = client.revoke(
+            user_id=user_id,
+            resource_type=resource_type,
+            resource_id=resource_id,
+            relation=relation,
+        )
+
+        # Should return a RevokeResult, not raise
+        assert isinstance(result, RevokeResult)
+        assert result.user_id == user_id
+        assert result.relation == relation
+        assert result.type == resource_type
+        assert result.resource_id == resource_id
+
+
+# --- Property 4: Validation errors propagate message ---
+
+
+class TestProperty4ValidationErrors:
+    """Property 4: Validation errors propagate message.
+
+    For any API response with HTTP 400 containing an error message, the
+    client SHALL raise a ValidationError whose message matches the API
+    error message.
+
+    **Validates: Requirements 2.4, 3.4**
+    """
+
+    @settings(max_examples=100)
+    @given(
+        user_id=valid_user_ids,
+        resource_type=valid_resource_types,
+        resource_id=valid_resource_ids,
+        relation=valid_relations,
+        api_message=error_messages,
+    )
+    def test_grant_400_raises_validation_error_with_message(
+        self,
+        user_id: str,
+        resource_type: str,
+        resource_id: str,
+        relation: str,
+        api_message: str,
+    ) -> None:
+        """Grant with 400 raises ValidationError containing API message.
+
+        **Validates: Requirements 2.4**
+        """
+        error_body = json.dumps(
+            {
+                "error": "validation_error",
+                "message": api_message,
+            }
+        ).encode()
+        transport = CapturingTransport(MockResponse(status_code=400, body=error_body))
+        client = AuthorizationClient(transport=transport, sleep=no_sleep)
+
+        with pytest.raises(ValidationError) as exc_info:
+            client.grant(
+                user_id=user_id,
+                resource_type=resource_type,
+                resource_id=resource_id,
+                relation=relation,
+            )
+
+        assert exc_info.value.message == api_message
+
+    @settings(max_examples=100)
+    @given(
+        user_id=valid_user_ids,
+        resource_type=valid_resource_types,
+        resource_id=valid_resource_ids,
+        relation=valid_relations,
+        api_message=error_messages,
+    )
+    def test_revoke_400_raises_validation_error_with_message(
+        self,
+        user_id: str,
+        resource_type: str,
+        resource_id: str,
+        relation: str,
+        api_message: str,
+    ) -> None:
+        """Revoke with 400 raises ValidationError containing API message.
+
+        **Validates: Requirements 3.4**
+        """
+        error_body = json.dumps(
+            {
+                "error": "validation_error",
+                "message": api_message,
+            }
+        ).encode()
+        transport = CapturingTransport(MockResponse(status_code=400, body=error_body))
+        client = AuthorizationClient(transport=transport, sleep=no_sleep)
+
+        with pytest.raises(ValidationError) as exc_info:
+            client.revoke(
+                user_id=user_id,
+                resource_type=resource_type,
+                resource_id=resource_id,
+                relation=relation,
+            )
+
+        assert exc_info.value.message == api_message
+
+
+# --- Property 6: Immediate failure on non-retriable errors ---
+
+
+class TestProperty6ImmediateFailure:
+    """Property 6: Immediate failure on non-retriable errors.
+
+    For any HTTP status code that is not 503 and not an idempotent
+    success code (409 for grant, 404 for revoke) and not 200/201, the
+    client SHALL raise an error on the first attempt without retrying.
+
+    **Validates: Requirements 2.6, 3.6**
+    """
+
+    @settings(max_examples=100)
+    @given(
+        user_id=valid_user_ids,
+        resource_type=valid_resource_types,
+        resource_id=valid_resource_ids,
+        relation=valid_relations,
+        status_code=unexpected_grant_errors,
+    )
+    def test_grant_non_retriable_errors_fail_immediately(
+        self,
+        user_id: str,
+        resource_type: str,
+        resource_id: str,
+        relation: str,
+        status_code: int,
+    ) -> None:
+        """Grant raises UnexpectedError on first attempt for non-retriable
+        codes.
+
+        **Validates: Requirements 2.6**
+        """
+        error_body = json.dumps({"message": f"Error {status_code}"}).encode()
+        transport = CapturingTransport(
+            MockResponse(status_code=status_code, body=error_body)
+        )
+        client = AuthorizationClient(transport=transport, max_retries=3, sleep=no_sleep)
+
+        with pytest.raises(UnexpectedError) as exc_info:
+            client.grant(
+                user_id=user_id,
+                resource_type=resource_type,
+                resource_id=resource_id,
+                relation=relation,
+            )
+
+        assert exc_info.value.status_code == status_code
+        # Must be exactly 1 request — no retries
+        assert len(transport.requests) == 1
+
+    @settings(max_examples=100)
+    @given(
+        user_id=valid_user_ids,
+        resource_type=valid_resource_types,
+        resource_id=valid_resource_ids,
+        relation=valid_relations,
+        status_code=unexpected_revoke_errors,
+    )
+    def test_revoke_non_retriable_errors_fail_immediately(
+        self,
+        user_id: str,
+        resource_type: str,
+        resource_id: str,
+        relation: str,
+        status_code: int,
+    ) -> None:
+        """Revoke raises UnexpectedError on first attempt for non-retriable
+        codes.
+
+        **Validates: Requirements 3.6**
+        """
+        error_body = json.dumps({"message": f"Error {status_code}"}).encode()
+        transport = CapturingTransport(
+            MockResponse(status_code=status_code, body=error_body)
+        )
+        client = AuthorizationClient(transport=transport, max_retries=3, sleep=no_sleep)
+
+        with pytest.raises(UnexpectedError) as exc_info:
+            client.revoke(
+                user_id=user_id,
+                resource_type=resource_type,
+                resource_id=resource_id,
+                relation=relation,
+            )
+
+        assert exc_info.value.status_code == status_code
+        # Must be exactly 1 request — no retries
+        assert len(transport.requests) == 1

--- a/common/test/python/authorization_test/test_property_models.py
+++ b/common/test/python/authorization_test/test_property_models.py
@@ -1,0 +1,414 @@
+"""Property-based tests for response model round-trip and parse errors.
+
+Feature: authorization-client-library
+Properties tested: 2, 10
+"""
+
+import json
+
+import pytest
+from authorization.client import AuthorizationClient
+from authorization.exceptions import ParseError
+from authorization.models import (
+    BatchError,
+    BatchOperation,
+    BatchResult,
+    GrantResult,
+    HealthResult,
+    InheritanceSource,
+    ParentRelationship,
+    PermissionEntry,
+    ResourceParents,
+    RevokeResult,
+    UserPermissions,
+)
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from .conftest import CapturingTransport, MockResponse, no_sleep
+
+# --- Strategies ---
+
+# Non-empty alphanumeric strings for IDs and fields
+simple_ids = st.text(
+    alphabet=st.sampled_from("abcdefghijklmnopqrstuvwxyz0123456789-_"),
+    min_size=1,
+    max_size=30,
+)
+
+# Resource types from the authorization model
+resource_types = st.sampled_from(
+    ["study", "research_center", "community", "data_pipeline", "dashboard", "page"]
+)
+
+# Relations
+relations = st.sampled_from(
+    ["member", "admin", "viewer", "submitter", "auditor", "editor"]
+)
+
+# Access types
+access_types = st.sampled_from(["direct", "inherited", "both"])
+
+# Health statuses
+health_statuses = st.sampled_from(["healthy", "degraded", "unhealthy"])
+
+# Authorization engine statuses
+engine_statuses = st.sampled_from(["connected", "unreachable"])
+
+# Error codes for batch errors
+error_codes = st.text(
+    alphabet=st.sampled_from("abcdefghijklmnopqrstuvwxyz_"),
+    min_size=1,
+    max_size=20,
+)
+
+# Error messages
+error_messages = st.text(
+    alphabet=st.sampled_from(
+        "abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789:._-"
+    ),
+    min_size=1,
+    max_size=80,
+)
+
+
+# --- Composite strategies for response models ---
+
+
+@st.composite
+def grant_results(draw: st.DrawFn) -> GrantResult:
+    """Generate arbitrary GrantResult instances."""
+    return GrantResult(
+        user_id=draw(simple_ids),
+        relation=draw(relations),
+        type=draw(resource_types),
+        resource_id=draw(simple_ids),
+    )
+
+
+@st.composite
+def revoke_results(draw: st.DrawFn) -> RevokeResult:
+    """Generate arbitrary RevokeResult instances."""
+    return RevokeResult(
+        user_id=draw(simple_ids),
+        relation=draw(relations),
+        type=draw(resource_types),
+        resource_id=draw(simple_ids),
+    )
+
+
+@st.composite
+def batch_errors(draw: st.DrawFn) -> BatchError:
+    """Generate arbitrary BatchError instances."""
+    return BatchError(
+        index=draw(st.integers(min_value=0, max_value=99)),
+        error=draw(error_codes),
+        message=draw(error_messages),
+    )
+
+
+@st.composite
+def batch_results(draw: st.DrawFn) -> BatchResult:
+    """Generate arbitrary BatchResult instances."""
+    total = draw(st.integers(min_value=0, max_value=200))
+    succeeded = draw(st.integers(min_value=0, max_value=total))
+    failed = total - succeeded
+    errors = draw(st.lists(batch_errors(), min_size=0, max_size=min(failed, 5)))
+    return BatchResult(
+        total=total,
+        succeeded=succeeded,
+        failed=failed,
+        errors=errors,
+    )
+
+
+@st.composite
+def inheritance_sources(draw: st.DrawFn) -> InheritanceSource:
+    """Generate arbitrary InheritanceSource instances."""
+    return InheritanceSource(
+        parent_type=draw(resource_types),
+        parent_id=draw(simple_ids),
+        parent_role=draw(relations),
+    )
+
+
+@st.composite
+def permission_entries(draw: st.DrawFn) -> PermissionEntry:
+    """Generate arbitrary PermissionEntry instances."""
+    access = draw(access_types)
+    inherited_from = None
+    if access in ("inherited", "both"):
+        inherited_from = draw(inheritance_sources())
+    return PermissionEntry(
+        resource_id=draw(simple_ids),
+        relation=draw(relations),
+        access=access,
+        inherited_from=inherited_from,
+    )
+
+
+@st.composite
+def user_permissions(draw: st.DrawFn) -> UserPermissions:
+    """Generate arbitrary UserPermissions instances."""
+    num_types = draw(st.integers(min_value=1, max_value=3))
+    types = draw(
+        st.lists(resource_types, min_size=num_types, max_size=num_types, unique=True)
+    )
+    permissions: dict[str, list[PermissionEntry]] = {}
+    for t in types:
+        entries = draw(st.lists(permission_entries(), min_size=1, max_size=3))
+        permissions[t] = entries
+    return UserPermissions(
+        user_id=draw(simple_ids),
+        permissions=permissions,
+    )
+
+
+@st.composite
+def parent_relationships(draw: st.DrawFn) -> ParentRelationship:
+    """Generate arbitrary ParentRelationship instances."""
+    return ParentRelationship(
+        structural_relation=draw(relations),
+        parent_type=draw(resource_types),
+        parent_id=draw(simple_ids),
+    )
+
+
+@st.composite
+def resource_parents(draw: st.DrawFn) -> ResourceParents:
+    """Generate arbitrary ResourceParents instances."""
+    return ResourceParents(
+        type=draw(resource_types),
+        resource_id=draw(simple_ids),
+        parents=draw(st.lists(parent_relationships(), min_size=0, max_size=4)),
+    )
+
+
+@st.composite
+def health_results(draw: st.DrawFn) -> HealthResult:
+    """Generate arbitrary HealthResult instances."""
+    status = draw(health_statuses)
+    engine = draw(st.one_of(st.none(), engine_statuses))
+    return HealthResult(
+        status=status,
+        authorization_engine=engine,
+    )
+
+
+# --- Strategies for malformed JSON ---
+
+# Strings that are valid JSON but not conforming to any response model schema
+malformed_json_bodies = st.one_of(
+    # JSON arrays (not objects)
+    st.just(b"[]"),
+    st.just(b"[1, 2, 3]"),
+    # JSON objects missing required fields
+    st.just(b'{"unexpected": "field"}'),
+    st.just(b'{"status": 123}'),
+    # JSON primitives
+    st.just(b'"just a string"'),
+    st.just(b"42"),
+    st.just(b"true"),
+    st.just(b"null"),
+)
+
+# Bytes that are not valid JSON at all
+invalid_json_bodies = st.one_of(
+    st.just(b"not json at all"),
+    st.just(b"<html>error</html>"),
+    st.just(b"{broken json"),
+    st.just(b""),
+    st.binary(min_size=1, max_size=50).filter(
+        lambda b: not _is_valid_json(b),
+    ),
+)
+
+
+def _is_valid_json(data: bytes) -> bool:
+    """Check if bytes are valid JSON."""
+    try:
+        json.loads(data)
+        return True
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return False
+
+
+# --- Property 2: Response model round-trip ---
+
+
+class TestProperty2ResponseRoundTrip:
+    """Property 2: Response model round-trip.
+
+    For any valid response model instance, serializing to JSON and
+    parsing back SHALL produce an equivalent model instance.
+
+    **Validates: Requirements 9.2**
+    """
+
+    @settings(max_examples=100)
+    @given(model=grant_results())
+    def test_grant_result_round_trip(self, model: GrantResult) -> None:
+        """GrantResult survives serialize-then-parse cycle."""
+        json_bytes = model.model_dump_json(by_alias=True).encode()
+        restored = GrantResult.model_validate_json(json_bytes)
+        assert restored == model
+
+    @settings(max_examples=100)
+    @given(model=revoke_results())
+    def test_revoke_result_round_trip(self, model: RevokeResult) -> None:
+        """RevokeResult survives serialize-then-parse cycle."""
+        json_bytes = model.model_dump_json(by_alias=True).encode()
+        restored = RevokeResult.model_validate_json(json_bytes)
+        assert restored == model
+
+    @settings(max_examples=100)
+    @given(model=batch_results())
+    def test_batch_result_round_trip(self, model: BatchResult) -> None:
+        """BatchResult survives serialize-then-parse cycle."""
+        json_bytes = model.model_dump_json(by_alias=True).encode()
+        restored = BatchResult.model_validate_json(json_bytes)
+        assert restored == model
+
+    @settings(max_examples=100)
+    @given(model=user_permissions())
+    def test_user_permissions_round_trip(self, model: UserPermissions) -> None:
+        """UserPermissions survives serialize-then-parse cycle."""
+        json_bytes = model.model_dump_json(by_alias=True).encode()
+        restored = UserPermissions.model_validate_json(json_bytes)
+        assert restored == model
+
+    @settings(max_examples=100)
+    @given(model=resource_parents())
+    def test_resource_parents_round_trip(self, model: ResourceParents) -> None:
+        """ResourceParents survives serialize-then-parse cycle."""
+        json_bytes = model.model_dump_json(by_alias=True).encode()
+        restored = ResourceParents.model_validate_json(json_bytes)
+        assert restored == model
+
+    @settings(max_examples=100)
+    @given(model=health_results())
+    def test_health_result_round_trip(self, model: HealthResult) -> None:
+        """HealthResult survives serialize-then-parse cycle."""
+        json_bytes = model.model_dump_json(by_alias=True).encode()
+        restored = HealthResult.model_validate_json(json_bytes)
+        assert restored == model
+
+
+# --- Property 10: Malformed response raises ParseError with raw content ---
+
+
+class TestProperty10MalformedResponseParseError:
+    """Property 10: Malformed response raises ParseError with raw content.
+
+    For any response body that does not conform to the expected JSON
+    schema, the client SHALL raise a ParseError whose raw_content
+    attribute contains the original response bytes.
+
+    **Validates: Requirements 9.3**
+    """
+
+    @settings(max_examples=50)
+    @given(bad_body=st.one_of(malformed_json_bodies, invalid_json_bodies))
+    def test_grant_malformed_response_raises_parse_error(self, bad_body: bytes) -> None:
+        """Grant with malformed 200 response raises ParseError with raw
+        bytes."""
+        transport = CapturingTransport(MockResponse(status_code=200, body=bad_body))
+        client = AuthorizationClient(transport=transport, sleep=no_sleep)
+
+        with pytest.raises(ParseError) as exc_info:
+            client.grant(
+                user_id="user1",
+                resource_type="study",
+                resource_id="res1",
+                relation="member",
+            )
+
+        assert exc_info.value.raw_content == bad_body
+
+    @settings(max_examples=50)
+    @given(bad_body=st.one_of(malformed_json_bodies, invalid_json_bodies))
+    def test_revoke_malformed_response_raises_parse_error(
+        self, bad_body: bytes
+    ) -> None:
+        """Revoke with malformed 200 response raises ParseError with raw
+        bytes."""
+        transport = CapturingTransport(MockResponse(status_code=200, body=bad_body))
+        client = AuthorizationClient(transport=transport, sleep=no_sleep)
+
+        with pytest.raises(ParseError) as exc_info:
+            client.revoke(
+                user_id="user1",
+                resource_type="study",
+                resource_id="res1",
+                relation="member",
+            )
+
+        assert exc_info.value.raw_content == bad_body
+
+    @settings(max_examples=50)
+    @given(bad_body=st.one_of(malformed_json_bodies, invalid_json_bodies))
+    def test_get_user_permissions_malformed_response_raises_parse_error(
+        self, bad_body: bytes
+    ) -> None:
+        """get_user_permissions with malformed 200 raises ParseError."""
+        transport = CapturingTransport(MockResponse(status_code=200, body=bad_body))
+        client = AuthorizationClient(transport=transport, sleep=no_sleep)
+
+        with pytest.raises(ParseError) as exc_info:
+            client.get_user_permissions(user_id="user1")
+
+        assert exc_info.value.raw_content == bad_body
+
+    @settings(max_examples=50)
+    @given(bad_body=st.one_of(malformed_json_bodies, invalid_json_bodies))
+    def test_set_resource_parents_malformed_response_raises_parse_error(
+        self, bad_body: bytes
+    ) -> None:
+        """set_resource_parents with malformed 200 raises ParseError."""
+        transport = CapturingTransport(MockResponse(status_code=200, body=bad_body))
+        client = AuthorizationClient(transport=transport, sleep=no_sleep)
+
+        with pytest.raises(ParseError) as exc_info:
+            client.set_resource_parents(
+                resource_type="study",
+                resource_id="res1",
+                parents=[],
+            )
+
+        assert exc_info.value.raw_content == bad_body
+
+    @settings(max_examples=50)
+    @given(bad_body=st.one_of(malformed_json_bodies, invalid_json_bodies))
+    def test_health_check_malformed_response_raises_parse_error(
+        self, bad_body: bytes
+    ) -> None:
+        """health_check with malformed 200 raises ParseError."""
+        transport = CapturingTransport(MockResponse(status_code=200, body=bad_body))
+        client = AuthorizationClient(transport=transport, sleep=no_sleep)
+
+        with pytest.raises(ParseError) as exc_info:
+            client.health_check()
+
+        assert exc_info.value.raw_content == bad_body
+
+    @settings(max_examples=50)
+    @given(bad_body=st.one_of(malformed_json_bodies, invalid_json_bodies))
+    def test_batch_malformed_response_raises_parse_error(self, bad_body: bytes) -> None:
+        """batch with malformed 200 raises ParseError."""
+        transport = CapturingTransport(MockResponse(status_code=200, body=bad_body))
+        client = AuthorizationClient(transport=transport, sleep=no_sleep)
+
+        with pytest.raises(ParseError) as exc_info:
+            client.batch(
+                operations=[
+                    BatchOperation(
+                        action="grant",
+                        user_id="user1",
+                        resource_type="study",
+                        resource_id="res1",
+                        relation="member",
+                    )
+                ]
+            )
+
+        assert exc_info.value.raw_content == bad_body

--- a/common/test/python/authorization_test/test_property_query_parents.py
+++ b/common/test/python/authorization_test/test_property_query_parents.py
@@ -1,0 +1,477 @@
+"""Property-based tests for query, parents, and retry behavior.
+
+Tests Properties 1, 5, and 6 from the design document for
+get_user_permissions and set_resource_parents methods.
+"""
+
+import json
+from dataclasses import dataclass, field
+
+import pytest
+from authorization.client import AuthorizationClient
+from authorization.exceptions import ServiceUnavailableError, UnexpectedError
+from authorization.models import ParentRelationshipModel
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from .conftest import MockResponse, no_sleep
+
+# --- Strategies ---
+
+# Valid user IDs: non-empty alphanumeric strings with common separators
+user_ids = st.text(
+    alphabet=st.sampled_from("abcdefghijklmnopqrstuvwxyz0123456789._@-"),
+    min_size=1,
+    max_size=50,
+)
+
+# Valid resource types from the authorization model
+resource_types = st.sampled_from(
+    [
+        "study",
+        "research_center",
+        "community",
+        "data_pipeline",
+        "dashboard",
+        "page",
+    ]
+)
+
+# Valid resource IDs: non-empty strings
+resource_ids = st.text(
+    alphabet=st.sampled_from("abcdefghijklmnopqrstuvwxyz0123456789-_"),
+    min_size=1,
+    max_size=50,
+)
+
+# Valid structural relations for parent relationships
+structural_relations = st.sampled_from(
+    [
+        "parent_study",
+        "parent_center",
+        "parent_community",
+    ]
+)
+
+# Valid relations
+relations = st.sampled_from(
+    ["member", "admin", "viewer", "submitter", "auditor", "editor"]
+)
+
+# Optional type filter
+optional_type_filter = st.one_of(st.none(), resource_types)
+
+# Optional relation filter
+optional_relation_filter = st.one_of(st.none(), relations)
+
+# Parent relationship strategy
+parent_relationships = st.builds(
+    ParentRelationshipModel,
+    structural_relation=structural_relations,
+    parent_type=resource_types,
+    parent_id=resource_ids,
+)
+
+# List of parent relationships (0-5 items)
+parent_lists = st.lists(parent_relationships, min_size=0, max_size=5)
+
+# Non-retriable, non-success HTTP status codes (not 200, 201, 503)
+non_retriable_error_codes = st.sampled_from(
+    [400, 401, 403, 404, 405, 409, 422, 429, 500, 502]
+)
+
+# Retry counts (1-5)
+retry_counts = st.integers(min_value=1, max_value=5)
+
+# Base backoff values
+base_backoffs = st.floats(min_value=0.1, max_value=5.0)
+
+
+# --- Mock Transport ---
+
+
+@dataclass
+class SequentialMockTransport:
+    """Dataclass-based mock transport for property tests."""
+
+    responses: list[MockResponse] = field(default_factory=list)
+    requests: list[tuple[str, str, bytes | None, dict[str, str] | None]] = field(
+        default_factory=list
+    )
+    _call_index: int = field(default=0, init=False)
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        body: bytes | None = None,
+        query_params: dict[str, str] | None = None,
+    ) -> MockResponse:
+        self.requests.append((method, path, body, query_params))
+        response = self.responses[min(self._call_index, len(self.responses) - 1)]
+        self._call_index += 1
+        return response
+
+
+# --- Property 1: Request construction correctness ---
+# Validates: Requirements 5.1, 6.1
+
+
+class TestProperty1RequestConstruction:
+    """Property 1: Request construction correctness.
+
+    For any valid operation (get_user_permissions, set_resource_parents)
+    with any valid combination of parameters, the client SHALL construct
+    an HTTP request with the correct method, path, and JSON body
+    containing all provided fields.
+
+    **Validates: Requirements 5.1, 6.1**
+    """
+
+    @settings(max_examples=100)
+    @given(
+        user_id=user_ids,
+        type_filter=optional_type_filter,
+        relation_filter=optional_relation_filter,
+    )
+    def test_get_user_permissions_request_construction(
+        self,
+        user_id: str,
+        type_filter: str | None,
+        relation_filter: str | None,
+    ) -> None:
+        """get_user_permissions sends GET to /users/{userId}/permissions.
+
+        **Validates: Requirements 5.1**
+        """
+        response_body = json.dumps({"userId": user_id, "permissions": {}}).encode()
+        transport = SequentialMockTransport(
+            responses=[MockResponse(status_code=200, body=response_body)]
+        )
+        client = AuthorizationClient(transport=transport, sleep=no_sleep)
+
+        client.get_user_permissions(
+            user_id=user_id,
+            type_filter=type_filter,
+            relation_filter=relation_filter,
+        )
+
+        assert len(transport.requests) == 1
+        method, path, body, query_params = transport.requests[0]
+
+        # Correct HTTP method
+        assert method == "GET"
+
+        # Correct path with user_id
+        assert path == f"/users/{user_id}/permissions"
+
+        # No body for GET requests
+        assert body is None
+
+        # Query params match filters
+        expected_params: dict[str, str] = {}
+        if type_filter is not None:
+            expected_params["type"] = type_filter
+        if relation_filter is not None:
+            expected_params["relation"] = relation_filter
+
+        if expected_params:
+            assert query_params == expected_params
+        else:
+            assert query_params is None
+
+    @settings(max_examples=100)
+    @given(
+        resource_type=resource_types,
+        resource_id=resource_ids,
+        parents=parent_lists,
+    )
+    def test_set_resource_parents_request_construction(
+        self,
+        resource_type: str,
+        resource_id: str,
+        parents: list[ParentRelationshipModel],
+    ) -> None:
+        """set_resource_parents sends PUT to /resources/{type}/{id}/parents.
+
+        **Validates: Requirements 6.1**
+        """
+        # Build a valid response body
+        response_body = json.dumps(
+            {
+                "type": resource_type,
+                "resourceId": resource_id,
+                "parents": [
+                    {
+                        "structuralRelation": p.structural_relation,
+                        "parentType": p.parent_type,
+                        "parentId": p.parent_id,
+                    }
+                    for p in parents
+                ],
+            }
+        ).encode()
+        transport = SequentialMockTransport(
+            responses=[MockResponse(status_code=200, body=response_body)]
+        )
+        client = AuthorizationClient(transport=transport, sleep=no_sleep)
+
+        client.set_resource_parents(
+            resource_type=resource_type,
+            resource_id=resource_id,
+            parents=parents,
+        )
+
+        assert len(transport.requests) == 1
+        method, path, body, query_params = transport.requests[0]
+
+        # Correct HTTP method
+        assert method == "PUT"
+
+        # Correct path with resource type and id
+        assert path == f"/resources/{resource_type}/{resource_id}/parents"
+
+        # No query params for PUT
+        assert query_params is None
+
+        # Body contains all parent relationships in camelCase
+        assert body is not None
+        request_data = json.loads(body)
+        assert "parents" in request_data
+        assert len(request_data["parents"]) == len(parents)
+
+        for i, parent in enumerate(parents):
+            sent_parent = request_data["parents"][i]
+            assert sent_parent["structuralRelation"] == parent.structural_relation
+            assert sent_parent["parentType"] == parent.parent_type
+            assert sent_parent["parentId"] == parent.parent_id
+
+
+# --- Property 5: Retry on 503 with exponential backoff ---
+# Validates: Requirements 5.3, 6.4, 8.1, 8.2
+
+
+class TestProperty5RetryOn503:
+    """Property 5: Retry on 503 with exponential backoff.
+
+    For any request that receives HTTP 503 responses, the client SHALL
+    retry up to max_retries times with delays following the pattern
+    base_backoff * 2^(attempt-1), then raise ServiceUnavailableError
+    if all retries are exhausted.
+
+    **Validates: Requirements 5.3, 6.4, 8.1, 8.2**
+    """
+
+    @settings(max_examples=100)
+    @given(
+        user_id=user_ids,
+        max_retries=retry_counts,
+        base_backoff=base_backoffs,
+    )
+    def test_get_user_permissions_retry_count_and_backoff(
+        self,
+        user_id: str,
+        max_retries: int,
+        base_backoff: float,
+    ) -> None:
+        """get_user_permissions retries max_retries times then raises.
+
+        **Validates: Requirements 5.3, 8.1, 8.2**
+        """
+        # All responses are 503
+        responses = [MockResponse(status_code=503, body=b"")] * (max_retries + 2)
+        transport = SequentialMockTransport(responses=responses)
+
+        sleep_calls: list[float] = []
+
+        def tracking_sleep(duration: float) -> None:
+            sleep_calls.append(duration)
+
+        client = AuthorizationClient(
+            transport=transport,
+            max_retries=max_retries,
+            base_backoff=base_backoff,
+            sleep=tracking_sleep,
+        )
+
+        with pytest.raises(ServiceUnavailableError):
+            client.get_user_permissions(user_id=user_id)
+
+        # Total requests: 1 initial + max_retries retries
+        assert len(transport.requests) == 1 + max_retries
+
+        # Verify sleep was called max_retries times
+        assert len(sleep_calls) == max_retries
+
+        # Verify exponential backoff pattern
+        for attempt in range(max_retries):
+            expected_delay = base_backoff * (2**attempt)
+            assert abs(sleep_calls[attempt] - expected_delay) < 1e-9
+
+    @settings(max_examples=100)
+    @given(
+        resource_type=resource_types,
+        resource_id=resource_ids,
+        max_retries=retry_counts,
+        base_backoff=base_backoffs,
+    )
+    def test_set_resource_parents_retry_count_and_backoff(
+        self,
+        resource_type: str,
+        resource_id: str,
+        max_retries: int,
+        base_backoff: float,
+    ) -> None:
+        """set_resource_parents retries max_retries times then raises.
+
+        **Validates: Requirements 6.4, 8.1, 8.2**
+        """
+        # All responses are 503
+        responses = [MockResponse(status_code=503, body=b"")] * (max_retries + 2)
+        transport = SequentialMockTransport(responses=responses)
+
+        sleep_calls: list[float] = []
+
+        def tracking_sleep(duration: float) -> None:
+            sleep_calls.append(duration)
+
+        client = AuthorizationClient(
+            transport=transport,
+            max_retries=max_retries,
+            base_backoff=base_backoff,
+            sleep=tracking_sleep,
+        )
+
+        with pytest.raises(ServiceUnavailableError):
+            client.set_resource_parents(
+                resource_type=resource_type,
+                resource_id=resource_id,
+                parents=[],
+            )
+
+        # Total requests: 1 initial + max_retries retries
+        assert len(transport.requests) == 1 + max_retries
+
+        # Verify sleep was called max_retries times
+        assert len(sleep_calls) == max_retries
+
+        # Verify exponential backoff pattern
+        for attempt in range(max_retries):
+            expected_delay = base_backoff * (2**attempt)
+            assert abs(sleep_calls[attempt] - expected_delay) < 1e-9
+
+    @settings(max_examples=100)
+    @given(
+        user_id=user_ids,
+        max_retries=retry_counts,
+    )
+    def test_get_user_permissions_succeeds_after_503_retries(
+        self,
+        user_id: str,
+        max_retries: int,
+    ) -> None:
+        """get_user_permissions succeeds when 503 clears before exhaustion.
+
+        **Validates: Requirements 5.3, 8.1**
+        """
+        # Return 503 for (max_retries - 1) retries, then succeed
+        retries_before_success = max_retries - 1
+        responses: list[MockResponse] = [MockResponse(status_code=503, body=b"")] * (
+            retries_before_success + 1
+        )  # +1 for initial request
+        success_body = json.dumps({"userId": user_id, "permissions": {}}).encode()
+        responses.append(MockResponse(status_code=200, body=success_body))
+
+        transport = SequentialMockTransport(responses=responses)
+        client = AuthorizationClient(
+            transport=transport,
+            max_retries=max_retries,
+            sleep=no_sleep,
+        )
+
+        result = client.get_user_permissions(user_id=user_id)
+        assert result.user_id == user_id
+
+
+# --- Property 6: Immediate failure on non-retriable errors ---
+# Validates: Requirements 5.4, 6.5, 8.4
+
+
+class TestProperty6ImmediateFailure:
+    """Property 6: Immediate failure on non-retriable errors.
+
+    For any HTTP status code that is not 503 and not 200/201, the client
+    SHALL raise an error on the first attempt without retrying.
+
+    **Validates: Requirements 5.4, 6.5, 8.4**
+    """
+
+    @settings(max_examples=100)
+    @given(
+        user_id=user_ids,
+        status_code=non_retriable_error_codes,
+    )
+    def test_get_user_permissions_fails_immediately_on_non_retriable(
+        self,
+        user_id: str,
+        status_code: int,
+    ) -> None:
+        """get_user_permissions raises immediately on non-503 errors.
+
+        **Validates: Requirements 5.4, 8.4**
+        """
+        error_body = json.dumps(
+            {"error": "some_error", "message": "Error occurred"}
+        ).encode()
+        transport = SequentialMockTransport(
+            responses=[MockResponse(status_code=status_code, body=error_body)]
+        )
+        client = AuthorizationClient(
+            transport=transport,
+            max_retries=3,
+            sleep=no_sleep,
+        )
+
+        with pytest.raises((UnexpectedError, Exception)):
+            client.get_user_permissions(user_id=user_id)
+
+        # Only one request was made — no retries
+        assert len(transport.requests) == 1
+
+    @settings(max_examples=100)
+    @given(
+        resource_type=resource_types,
+        resource_id=resource_ids,
+        status_code=non_retriable_error_codes,
+    )
+    def test_set_resource_parents_fails_immediately_on_non_retriable(
+        self,
+        resource_type: str,
+        resource_id: str,
+        status_code: int,
+    ) -> None:
+        """set_resource_parents raises immediately on non-503 errors.
+
+        **Validates: Requirements 6.5, 8.4**
+        """
+        error_body = json.dumps(
+            {"error": "some_error", "message": "Error occurred"}
+        ).encode()
+        transport = SequentialMockTransport(
+            responses=[MockResponse(status_code=status_code, body=error_body)]
+        )
+        client = AuthorizationClient(
+            transport=transport,
+            max_retries=3,
+            sleep=no_sleep,
+        )
+
+        with pytest.raises((UnexpectedError, Exception)):
+            client.set_resource_parents(
+                resource_type=resource_type,
+                resource_id=resource_id,
+                parents=[],
+            )
+
+        # Only one request was made — no retries
+        assert len(transport.requests) == 1

--- a/common/test/python/authorization_test/test_transport.py
+++ b/common/test/python/authorization_test/test_transport.py
@@ -1,0 +1,215 @@
+"""Unit tests for SigV4Transport signing.
+
+Task 7.3: Test that SigV4Transport produces valid Authorization headers.
+Uses moto for credential mocking.
+
+Requirements: 1.4
+"""
+
+import json
+from unittest.mock import patch
+from urllib.parse import urlparse
+
+from authorization.sigv4_transport import SigV4Transport
+from moto import mock_aws
+
+
+@mock_aws
+class TestSigV4TransportSigning:
+    """Tests for SigV4Transport request signing.
+
+    Validates: Requirement 1.4
+    """
+
+    def _create_transport(
+        self, base_url: str = "https://api.example.com/v1"
+    ) -> SigV4Transport:
+        """Create a SigV4Transport with mocked AWS credentials."""
+        with patch.dict(
+            "os.environ",
+            {
+                "AWS_ACCESS_KEY_ID": "testing",
+                "AWS_SECRET_ACCESS_KEY": "testing",
+                "AWS_DEFAULT_REGION": "us-east-1",
+            },
+        ):
+            return SigV4Transport(base_url=base_url, region="us-east-1")
+
+    def test_request_includes_authorization_header(self) -> None:
+        """SigV4Transport produces an Authorization header on requests.
+
+        Validates: Requirement 1.4
+        """
+        transport = self._create_transport()
+
+        # Patch urlopen to capture the signed request
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            # Set up mock response
+            mock_response = mock_urlopen.return_value.__enter__.return_value
+            mock_response.status = 200
+            mock_response.read.return_value = b'{"status": "healthy"}'
+
+            transport.request(method="GET", path="/health", body=None)
+
+            # Get the Request object passed to urlopen
+            call_args = mock_urlopen.call_args
+            request_obj = call_args[0][0]
+
+            # Verify Authorization header is present
+            auth_header = request_obj.get_header("Authorization")
+            assert auth_header is not None
+            assert "AWS4-HMAC-SHA256" in auth_header
+
+    def test_authorization_header_contains_credential(self) -> None:
+        """Authorization header contains Credential component."""
+        transport = self._create_transport()
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_response = mock_urlopen.return_value.__enter__.return_value
+            mock_response.status = 200
+            mock_response.read.return_value = b"{}"
+
+            transport.request(method="GET", path="/health", body=None)
+
+            request_obj = mock_urlopen.call_args[0][0]
+            auth_header = request_obj.get_header("Authorization")
+            assert "Credential=" in auth_header
+
+    def test_authorization_header_contains_signed_headers(self) -> None:
+        """Authorization header contains SignedHeaders component."""
+        transport = self._create_transport()
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_response = mock_urlopen.return_value.__enter__.return_value
+            mock_response.status = 200
+            mock_response.read.return_value = b"{}"
+
+            transport.request(method="GET", path="/health", body=None)
+
+            request_obj = mock_urlopen.call_args[0][0]
+            auth_header = request_obj.get_header("Authorization")
+            assert "SignedHeaders=" in auth_header
+
+    def test_authorization_header_contains_signature(self) -> None:
+        """Authorization header contains Signature component."""
+        transport = self._create_transport()
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_response = mock_urlopen.return_value.__enter__.return_value
+            mock_response.status = 200
+            mock_response.read.return_value = b"{}"
+
+            transport.request(method="GET", path="/health", body=None)
+
+            request_obj = mock_urlopen.call_args[0][0]
+            auth_header = request_obj.get_header("Authorization")
+            assert "Signature=" in auth_header
+
+    def test_signs_against_execute_api_service(self) -> None:
+        """SigV4 signing uses 'execute-api' as the service name.
+
+        Validates: Requirement 1.4
+        """
+        transport = self._create_transport()
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_response = mock_urlopen.return_value.__enter__.return_value
+            mock_response.status = 200
+            mock_response.read.return_value = b"{}"
+
+            transport.request(method="GET", path="/health", body=None)
+
+            request_obj = mock_urlopen.call_args[0][0]
+            auth_header = request_obj.get_header("Authorization")
+            # Credential format: AKID/date/region/service/aws4_request
+            assert "execute-api" in auth_header
+
+    def test_post_request_includes_content_type(self) -> None:
+        """POST requests with body include Content-Type header."""
+        transport = self._create_transport()
+        body = json.dumps({"key": "value"}).encode()
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_response = mock_urlopen.return_value.__enter__.return_value
+            mock_response.status = 200
+            mock_response.read.return_value = b"{}"
+
+            transport.request(method="POST", path="/grants", body=body)
+
+            request_obj = mock_urlopen.call_args[0][0]
+            content_type = request_obj.get_header("Content-type")
+            assert content_type == "application/json"
+
+    def test_constructs_correct_url(self) -> None:
+        """Transport constructs the full URL from base_url and path."""
+        transport = self._create_transport(base_url="https://api.example.com/v1")
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_response = mock_urlopen.return_value.__enter__.return_value
+            mock_response.status = 200
+            mock_response.read.return_value = b"{}"
+
+            transport.request(method="GET", path="/health", body=None)
+
+            request_obj = mock_urlopen.call_args[0][0]
+            assert request_obj.full_url == "https://api.example.com/v1/health"
+
+    def test_constructs_url_with_query_params(self) -> None:
+        """Transport appends query parameters to the URL."""
+        transport = self._create_transport(base_url="https://api.example.com/v1")
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_response = mock_urlopen.return_value.__enter__.return_value
+            mock_response.status = 200
+            mock_response.read.return_value = b"{}"
+
+            transport.request(
+                method="GET",
+                path="/users/user1/permissions",
+                body=None,
+                query_params={"type": "study", "relation": "member"},
+            )
+
+            request_obj = mock_urlopen.call_args[0][0]
+            parsed = urlparse(request_obj.full_url)
+            assert "type=study" in parsed.query
+            assert "relation=member" in parsed.query
+
+    def test_uses_correct_http_method(self) -> None:
+        """Transport uses the specified HTTP method."""
+        transport = self._create_transport()
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_response = mock_urlopen.return_value.__enter__.return_value
+            mock_response.status = 200
+            mock_response.read.return_value = b"{}"
+
+            transport.request(method="DELETE", path="/grants", body=b"{}")
+
+            request_obj = mock_urlopen.call_args[0][0]
+            assert request_obj.method == "DELETE"
+
+    def test_different_requests_produce_different_signatures(self) -> None:
+        """Different request bodies produce different signatures."""
+        transport = self._create_transport()
+
+        signatures = []
+        for i in range(2):
+            with patch("urllib.request.urlopen") as mock_urlopen:
+                mock_response = mock_urlopen.return_value.__enter__.return_value
+                mock_response.status = 200
+                mock_response.read.return_value = b"{}"
+
+                body = json.dumps({"userId": f"user{i}"}).encode()
+                transport.request(method="POST", path="/grants", body=body)
+
+                request_obj = mock_urlopen.call_args[0][0]
+                auth_header = request_obj.get_header("Authorization")
+                # Extract signature value
+                sig_part = next(
+                    p.strip() for p in auth_header.split(",") if "Signature=" in p
+                )
+                signatures.append(sig_part)
+
+        # Different payloads should produce different signatures
+        assert signatures[0] != signatures[1]

--- a/mypy.ini
+++ b/mypy.ini
@@ -21,3 +21,6 @@ ignore_missing_imports = True
 
 [mypy-pyarrow.*]
 ignore_missing_imports = True
+
+[mypy-botocore.*]
+ignore_missing_imports = True


### PR DESCRIPTION
## Summary

Adds a shared Python client library at `common/src/python/authorization/` for typed, idempotent access to the NACC Authorization API.

## Components

- **AuthorizationClient** — grant, revoke, batch, get_user_permissions, set_resource_parents, health_check
- **SigV4Transport** — AWS SigV4-signed HTTP transport with configurable timeout (30s default)
- **Factory** — `create_authorization_client()` with env var fallback (`AUTHORIZATION_API_URL`)
- **Retry** — exponential backoff on HTTP 503
- **Models** — Pydantic v2 request/response models with camelCase aliases
- **Exceptions** — typed hierarchy (ValidationError, ServiceUnavailableError, UnexpectedError, ParseError, ConfigurationError)

## Design Decisions

- `HttpTransport` protocol for testability via structural subtyping
- Batch chunking (max 100 ops per request) with idempotent error classification (conflict/not_found counted as success)
- Health check returns unhealthy on 503 without retrying
- Empty batch short-circuits without network call
- Shared mock infrastructure in `conftest.py` for all test files

## What's Not Affected

No gears are modified. This is a new shared library only.

## Tests

- Unit tests for all client methods (grant, revoke, batch, query, parents, health)
- Property-based tests (hypothesis) for request construction, idempotent outcomes, batch chunking/ordering, model round-trips, retry behavior
- Logging behavior tests (debug/warning/error levels)
- SigV4 signing verification tests (moto)
- Factory configuration tests