### PR TITLE
CSV Center Splitter and File Distribution: Check for duplicate files

### DIFF
--- a/common/src/python/utils/files.py
+++ b/common/src/python/utils/files.py
@@ -3,13 +3,50 @@
 import logging
 
 from flywheel import FileEntry, FileSpec
+from flywheel.rest import ApiException
 from flywheel_adaptor.flywheel_proxy import ProjectAdaptor
 
 log = logging.getLogger(__name__)
 
 
+def check_duplicate_project_file(
+    project: ProjectAdaptor,
+    contents: str,
+    filename: str,
+) -> bool:
+    """Check if the uploaded file would be an exact duplicate of an existing
+    project file.
+
+    Args:
+        project: The target project to upload the file to
+        contents: String contents of the file to upload
+        filename: File name of the file to upload
+    Returns:
+        Whether or not the file is a duplicate of an existing file
+            on the target project
+    """
+    project_name = f"{project.group}/{project.label}"
+
+    try:
+        existing_data = project.read_file(filename)
+    except ApiException as e:
+        log.info(f"Could not read {filename} on {project_name}: {e}")
+        return False
+
+    is_duplicate = contents.encode("utf-8") == existing_data
+    log.info(
+        f"Contents for {filename} is {'' if is_duplicate else 'NOT '}"
+        + f"a duplicate on {project_name}"
+    )
+
+    return is_duplicate
+
+
 def copy_file(
-    file: FileEntry, destination: ProjectAdaptor, dry_run: bool = False
+    file: FileEntry,
+    destination: ProjectAdaptor,
+    dry_run: bool = False,
+    replace_duplicates: bool = True,
 ) -> None:
     """Copies the file to the destination project.
 
@@ -17,6 +54,8 @@ def copy_file(
       file: the file entry for the file
       destination: the destination project
       dry_run: whether or not this is a dry run
+      replace_duplicates: Replace a file even if it's an
+        exact duplicate of an existing file
     """
     if dry_run:
         log.info(
@@ -27,14 +66,24 @@ def copy_file(
         )
         return
 
+    raw_contents = file.read()
+    contents = raw_contents.decode("utf-8")
+
+    if not replace_duplicates and check_duplicate_project_file(
+        destination,
+        contents,
+        file.name,
+    ):
+        log.info("Duplicate data, skipping upload of %s", file.name)
+        return
+
     log.info(
         "copying file %s to %s/%s", file.name, destination.group, destination.label
     )
 
-    raw_contents = file.read()
     file_spec = FileSpec(
         name=file.name,
-        contents=raw_contents.decode("utf-8"),
+        contents=contents,
         content_type=file.mimetype,
         size=len(raw_contents),
     )

--- a/docs/csv_center_splitter/CHANGELOG.md
+++ b/docs/csv_center_splitter/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this gear are documented in this file.
 * Updates to output any dropped rows into a `dropped-rows.csv` file
 * Updates to Python 3.12 and switches to use `fw-gear` instead of `flywheel-gear-toolkit` (now deprecated)
 * Moves `generate_project_map` to common code
+* Adds option to check if the uploaded center file would be a duplicate of an existing file - if so, does not replace it
+* Remove `local_run` argument
 
 ## 0.2.3
 

--- a/docs/csv_center_splitter/index.md
+++ b/docs/csv_center_splitter/index.md
@@ -15,7 +15,7 @@ exclude: comma-delimited list of ADCIDs to exclude in the split; will evaluate a
 batch_size: number of centers to batch; will wait for all downstream pipelines to finish running for a given batch before writing others
 downstream_gears: If scheduling, comma-delimited string of downstream gears to wait for
 delimiter: delimiter of the CSV, defaults to ','
-local_run: true if running on a local input file
+replace_duplicates: Replace a center-split file even if it's an exact duplicate of an existing file
 dry_run: whether or not this is a dry run - if so, will do everything except upload to Flywheel
 ```
 

--- a/docs/file_distribution/CHANGELOG.md
+++ b/docs/file_distribution/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this gear are documented in this file.
 
+## 1.1.1
+
+* Adds option to check if the uploaded center file would be a duplicate of an existing file - if so, does not replace it
+
 ## 1.1.0
 
 * Updates to `reference_regex` and `adcid_key` configs: if provided, uses a regex to find a "reference" CSV in the same project to pull ADCIDs from

--- a/gear/csv_center_splitter/src/docker/BUILD
+++ b/gear/csv_center_splitter/src/docker/BUILD
@@ -7,5 +7,5 @@ docker_image(
         ":manifest",
         "gear/csv_center_splitter/src/python/csv_center_splitter_app:bin",
     ],
-    image_tags=["0.3.0b", "latest"],
+    image_tags=["0.3.0", "latest"],
 )

--- a/gear/csv_center_splitter/src/docker/BUILD
+++ b/gear/csv_center_splitter/src/docker/BUILD
@@ -7,5 +7,5 @@ docker_image(
         ":manifest",
         "gear/csv_center_splitter/src/python/csv_center_splitter_app:bin",
     ],
-    image_tags=["0.3.0", "latest"],
+    image_tags=["0.3.0b", "latest"],
 )

--- a/gear/csv_center_splitter/src/docker/manifest.json
+++ b/gear/csv_center_splitter/src/docker/manifest.json
@@ -2,7 +2,7 @@
   "name": "csv-center-splitter",
   "label": "CSV Center Splitter",
   "description": "Splits a CSV by center ID",
-  "version": "0.3.0",
+  "version": "0.3.0b",
   "author": "NACC",
   "maintainer": "NACC <nacchelp@uw.edu>",
   "cite": "",
@@ -15,7 +15,7 @@
   "custom": {
     "gear-builder": {
       "category": "utility",
-      "image": "naccdata/csv-center-splitter:0.3.0"
+      "image": "naccdata/csv-center-splitter:0.3.0b"
     },
     "flywheel": {
       "suite": "Curation",
@@ -91,8 +91,8 @@
       "type": "string",
       "default": ","
     },
-    "local_run": {
-      "description": "Set to true if executing on a local input file",
+    "replace_duplicates": {
+      "description": "Replace a center-split file even if it's an exact duplicate of an existing file",
       "type": "boolean",
       "default": false
     },

--- a/gear/csv_center_splitter/src/docker/manifest.json
+++ b/gear/csv_center_splitter/src/docker/manifest.json
@@ -2,7 +2,7 @@
   "name": "csv-center-splitter",
   "label": "CSV Center Splitter",
   "description": "Splits a CSV by center ID",
-  "version": "0.3.0b",
+  "version": "0.3.0",
   "author": "NACC",
   "maintainer": "NACC <nacchelp@uw.edu>",
   "cite": "",
@@ -15,7 +15,7 @@
   "custom": {
     "gear-builder": {
       "category": "utility",
-      "image": "naccdata/csv-center-splitter:0.3.0b"
+      "image": "naccdata/csv-center-splitter:0.3.0"
     },
     "flywheel": {
       "suite": "Curation",

--- a/gear/csv_center_splitter/src/python/csv_center_splitter_app/main.py
+++ b/gear/csv_center_splitter/src/python/csv_center_splitter_app/main.py
@@ -15,6 +15,7 @@ from outputs.errors import (
 )
 from outputs.outputs import write_csv_to_stream
 from projects.project_mapper import generate_project_map
+from utils.files import check_duplicate_project_file
 
 log = logging.getLogger(__name__)
 
@@ -124,6 +125,7 @@ def run(
     include: Optional[Set[str]] = None,
     downstream_gears: Optional[List[str]] = None,
     delimiter: str = ",",
+    replace_duplicates: bool = False,
 ) -> List[Dict[str, Any]]:
     """Runs the CSV Center Splitter. Splits an input CSV by ADCID and uploads
     to each center's target project.
@@ -145,6 +147,8 @@ def run(
         downstream_gears: Gears to wait on before processing the
             next batch when scheduling
         delimiter: The CSV's delimiter; defaults to ','
+        replace_duplicates: Replace a center-split file even if it's an
+            exact duplicate of an existing file
 
     Returns:
         The list of dropped rows, if any
@@ -212,14 +216,21 @@ def run(
             project = project_map[f"adcid-{adcid}"]
             filename = f"{adcid}_{input_filename}"
 
-            log.info(
-                f"Uploading {filename} for project {project.label} "  # type: ignore
-                + f"ADCID {adcid} with project ID {project.id}"
-            )  # type: ignore
-
             contents = write_csv_to_stream(
                 headers=visitor.headers, data=data
             ).getvalue()
+
+            if not replace_duplicates and check_duplicate_project_file(
+                project, contents, filename
+            ):
+                log.info(f"Duplicate data, skipping upload of {filename}")
+                continue
+
+            log.info(
+                f"Uploading {filename} for {project.group}/{project.label} "  # type: ignore
+                + f"ADCID {adcid} with project ID {project.id}"
+            )  # type: ignore
+
             if proxy.dry_run:
                 log.info(f"DRY RUN: Would have uploaded {filename}")
                 continue

--- a/gear/csv_center_splitter/src/python/csv_center_splitter_app/run.py
+++ b/gear/csv_center_splitter/src/python/csv_center_splitter_app/run.py
@@ -47,7 +47,7 @@ class CSVCenterSplitterVisitor(GearExecutionEnvironment):
         include: Optional[str] = None,
         exclude: Optional[str] = None,
         delimiter: str = ",",
-        local_run: bool = False,
+        replace_duplicates: bool = False,
         email_client: Optional[EmailListClient] = None,
     ):
         super().__init__(client=client)
@@ -59,7 +59,7 @@ class CSVCenterSplitterVisitor(GearExecutionEnvironment):
         self.__batch_size = batch_size
         self.__downstream_gears = downstream_gears
         self.__delimiter = delimiter
-        self.__local_run = local_run
+        self.__replace_duplicates = replace_duplicates
         self.__email_client = email_client
 
         self.__centers = filter_include_exclude(
@@ -137,26 +137,20 @@ class CSVCenterSplitterVisitor(GearExecutionEnvironment):
             include=options.get("include", None),
             exclude=options.get("exclude", None),
             delimiter=options.get("delimiter", ","),
-            local_run=options.get("local_run", False),
+            replace_duplicates=options.get("replace_duplicates", False),
             email_client=email_client,
         )
 
     def run(self, context: GearContext) -> None:
         """Runs the CSV Center Splitter app."""
-        # if local run, give dummy container for local file, otherwise
-        # grab from project
-        if self.__local_run:
-            file_id = "local-container"
-            fw_path = "local-run"
-        else:
-            file_id = self.__file_input.file_id
-            try:
-                file = self.proxy.get_file(file_id)
-                fw_path = self.proxy.get_lookup_path(file)
-            except ApiException as error:
-                raise GearExecutionError(
-                    f"Failed to find the input file: {error}"
-                ) from error
+        file_id = self.__file_input.file_id
+        try:
+            file = self.proxy.get_file(file_id)
+            fw_path = self.proxy.get_lookup_path(file)
+        except ApiException as error:
+            raise GearExecutionError(
+                f"Failed to find the input file: {error}"
+            ) from error
 
         dropped_rows = None
         with open(self.__file_input.filepath, mode="r", encoding="utf-8-sig") as fh:
@@ -174,6 +168,7 @@ class CSVCenterSplitterVisitor(GearExecutionEnvironment):
                 downstream_gears=self.__downstream_gears,
                 include=set(self.__centers),
                 delimiter=self.__delimiter,
+                replace_duplicates=self.__replace_duplicates,
             )
 
         # report out any dropped rows

--- a/gear/file_distribution/src/docker/BUILD
+++ b/gear/file_distribution/src/docker/BUILD
@@ -7,5 +7,5 @@ docker_image(
         ":manifest",
         "gear/file_distribution/src/python/file_distribution_app:bin",
     ],
-    image_tags=["1.1.0", "latest"],
+    image_tags=["1.1.1a", "latest"],
 )

--- a/gear/file_distribution/src/docker/BUILD
+++ b/gear/file_distribution/src/docker/BUILD
@@ -7,5 +7,5 @@ docker_image(
         ":manifest",
         "gear/file_distribution/src/python/file_distribution_app:bin",
     ],
-    image_tags=["1.1.1a", "latest"],
+    image_tags=["1.1.1", "latest"],
 )

--- a/gear/file_distribution/src/docker/manifest.json
+++ b/gear/file_distribution/src/docker/manifest.json
@@ -2,7 +2,7 @@
   "name": "file-distribution",
   "label": "File Distribution",
   "description": "Gear that distributes files to target projects",
-  "version": "1.1.0",
+  "version": "1.1.1a",
   "author": "NACC",
   "maintainer": "NACC <nacchelp@uw.edu>",
   "cite": "",
@@ -15,7 +15,7 @@
   "custom": {
     "gear-builder": {
       "category": "utility",
-      "image": "naccdata/file-distribution:1.1.0"
+      "image": "naccdata/file-distribution:1.1.1a"
     },
     "flywheel": {
       "suite": "Utility",
@@ -86,6 +86,11 @@
       "description": "If scheduling, comma-delimited string of downstream gears to wait for",
       "type": "string",
       "default": ""
+    },
+    "replace_duplicates": {
+      "description": "Replace a file even if it's an exact duplicate of an existing file",
+      "type": "boolean",
+      "default": false
     }
   },
   "command": "/bin/run"

--- a/gear/file_distribution/src/docker/manifest.json
+++ b/gear/file_distribution/src/docker/manifest.json
@@ -2,7 +2,7 @@
   "name": "file-distribution",
   "label": "File Distribution",
   "description": "Gear that distributes files to target projects",
-  "version": "1.1.1a",
+  "version": "1.1.1",
   "author": "NACC",
   "maintainer": "NACC <nacchelp@uw.edu>",
   "cite": "",
@@ -15,7 +15,7 @@
   "custom": {
     "gear-builder": {
       "category": "utility",
-      "image": "naccdata/file-distribution:1.1.1a"
+      "image": "naccdata/file-distribution:1.1.1"
     },
     "flywheel": {
       "suite": "Utility",

--- a/gear/file_distribution/src/python/file_distribution_app/main.py
+++ b/gear/file_distribution/src/python/file_distribution_app/main.py
@@ -24,6 +24,7 @@ def run(
     target_project: Optional[str] = None,
     staging_project_id: Optional[str] = None,
     downstream_gears: Optional[List[str]] = None,
+    replace_duplicates: bool = False,
 ):
     """Runs the File Distribution process.
 
@@ -38,6 +39,8 @@ def run(
         staging_project_id: Target staging project to write file to instead
         downstream_gears: Gears to wait on before processing the
             next batch when scheduling
+        replace_duplicates: Replace a file even if it's an exact duplicate
+            of an existing file
     """
     # if staging_project_id, really just have to do it once since
     # we're not splitting files
@@ -51,7 +54,7 @@ def run(
             )
 
         staging_project = ProjectAdaptor(project=fw_project, proxy=proxy)
-        copy_file(file, staging_project, proxy.dry_run)
+        copy_file(file, staging_project, proxy.dry_run, replace_duplicates)
         return
 
     assert target_project, "target_project required if no staging_project_id provided"
@@ -79,7 +82,7 @@ def run(
 
         for adcid in batch:
             project = project_map[adcid]
-            copy_file(file, project, proxy.dry_run)
+            copy_file(file, project, proxy.dry_run, replace_duplicates)
             project_ids_list.append(project.id)
 
         if project_ids_list and downstream_gears:

--- a/gear/file_distribution/src/python/file_distribution_app/run.py
+++ b/gear/file_distribution/src/python/file_distribution_app/run.py
@@ -45,6 +45,7 @@ class FileDistributionVisitor(GearExecutionEnvironment):
         downstream_gears: Optional[List[str]] = None,
         include: Optional[str] = None,
         exclude: Optional[str] = None,
+        replace_duplicates: bool = False,
     ):
         super().__init__(client=client)
 
@@ -57,6 +58,7 @@ class FileDistributionVisitor(GearExecutionEnvironment):
         self.__exclude = exclude
         self.__batch_size = batch_size
         self.__downstream_gears = downstream_gears
+        self.__replace_duplicates = replace_duplicates
 
         self.__centers = filter_include_exclude(
             [str(x) for x in self.admin_group("nacc").get_adcids()], include, exclude
@@ -120,6 +122,7 @@ class FileDistributionVisitor(GearExecutionEnvironment):
             downstream_gears=downstream_gears,
             include=options.get("include", None),
             exclude=options.get("exclude", None),
+            replace_duplicates=options.get("replace_duplicates", False),
         )
 
     def __find_associated_adcids(self, file: FileEntry) -> List[str]:
@@ -196,6 +199,7 @@ class FileDistributionVisitor(GearExecutionEnvironment):
             target_project=self.__target_project,
             staging_project_id=self.__staging_project_id,
             downstream_gears=self.__downstream_gears,
+            replace_duplicates=self.__replace_duplicates,
         )
 
 


### PR DESCRIPTION
Updates `csv-center-splitter` and `file-distribution` to check if the uploaded file is a duplicate, and avoid re-uploading if so. Can be turned off with the `replace_duplicates` config.

Also removes the `local_run` configuration from `csv-center-splitter` as it is not needed.