### PR TITLE
Add user profile sync to Authorization API

### DIFF
--- a/.kiro/specs/authorization-user-profiles/.config.kiro
+++ b/.kiro/specs/authorization-user-profiles/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "f9e3f5f6-4a1f-45b5-9b1e-a650cb51c5a1", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/authorization-user-profiles/design.md
+++ b/.kiro/specs/authorization-user-profiles/design.md
@@ -1,0 +1,454 @@
+# Design Document: Authorization User Profiles
+
+## Overview
+
+This feature extends the existing authorization client library and user processing pipeline to support user profile CRUD operations against the NACC Authorization API's `/users` endpoints. The design adds:
+
+1. New Pydantic models (`UserProfileRequest`, `UserProfile`, `UserProfileList`) in the authorization models module
+2. A new `NotFoundError` exception for 404 responses
+3. Four new client methods (`put_user_profile`, `get_user_profile`, `delete_user_profile`, `get_user_profiles`) with Profile_User_ID validation and retry-on-503
+4. A `sync_profile` method on `AuthorizationSyncService` for pushing user profiles during processing
+5. Integration points in `InactiveUserProcess` and `UpdateUserProcess`/`UpdateCenterUserProcess` for both active and inactive users
+
+The design follows existing patterns in the codebase: Pydantic models with camelCase aliases, `retry_on_503` wrapping, error classification into `ValidationError`/`UnexpectedError`/`ParseError`, and fault-isolated error reporting via `UserEventCollector`.
+
+## Architecture
+
+```mermaid
+graph TD
+    subgraph "User Processing Layer"
+        UP[UpdateUserProcess]
+        IUP[InactiveUserProcess]
+    end
+
+    subgraph "Sync Layer"
+        SS[AuthorizationSyncService]
+    end
+
+    subgraph "Client Layer"
+        AC[AuthorizationClient]
+    end
+
+    subgraph "Transport Layer"
+        HT[HttpTransport]
+    end
+
+    subgraph "Authorization API"
+        API["/users/{profileUserId}"]
+        APIB["/users?ids=..."]
+    end
+
+    UP -->|sync_profile| SS
+    IUP -->|sync_profile| SS
+    SS -->|put_user_profile| AC
+    AC -->|retry_on_503| HT
+    HT --> API
+    HT --> APIB
+```
+
+The profile sync is invoked alongside (but independently of) the existing grant sync. Both operations are fault-isolated: failure of one does not prevent the other from executing.
+
+## Components and Interfaces
+
+### 1. New Exception: `NotFoundError`
+
+Added to `authorization/exceptions.py`:
+
+```python
+class NotFoundError(AuthorizationClientError):
+    """Raised when the API returns 404 (resource not found)."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.message = message
+```
+
+### 2. New Models in `authorization/models.py`
+
+#### UserProfileRequest
+
+```python
+class UserProfileRequest(BaseModel):
+    """Request model for creating or updating a user profile."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    first_name: str = Field(alias="firstName", min_length=1, max_length=256)
+    last_name: str = Field(alias="lastName", min_length=1, max_length=256)
+    email: str | None = Field(default=None, alias="email")
+    auth_email: str = Field(alias="authEmail", min_length=1, max_length=256)
+    active: bool | None = Field(default=None, alias="active")
+
+    @field_validator("first_name", "last_name")
+    @classmethod
+    def must_contain_non_whitespace(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("must contain at least one non-whitespace character")
+        return v
+```
+
+#### UserProfile
+
+```python
+class UserProfile(BaseModel):
+    """Response model for a user profile."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    user_id: str = Field(alias="userId")
+    first_name: str = Field(alias="firstName")
+    last_name: str = Field(alias="lastName")
+    email: str | None = Field(default=None)
+    auth_email: str = Field(alias="authEmail")
+    active: bool
+```
+
+#### UserProfileList
+
+```python
+class UserProfileList(BaseModel):
+    """Response model for batch user profile retrieval."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    users: list[UserProfile]
+```
+
+### 3. Profile_User_ID Validation
+
+A private validation method on `AuthorizationClient`:
+
+```python
+import re
+
+_PROFILE_USER_ID_PATTERN = re.compile(r"^Registry\d{6}@naccdata\.org$")
+
+def _validate_profile_user_id(self, profile_user_id: str | None) -> None:
+    """Validate a Profile User ID format.
+
+    Args:
+        profile_user_id: The ID to validate.
+
+    Raises:
+        ValidationError: If the ID is None, empty, or doesn't match the pattern.
+    """
+    if not profile_user_id:
+        raise ValidationError(
+            message="A non-empty Profile_User_ID is required",
+        )
+    if not _PROFILE_USER_ID_PATTERN.match(profile_user_id):
+        raise ValidationError(
+            message=(
+                f"Invalid Profile_User_ID '{profile_user_id}'. "
+                f"Expected format: RegistryNNNNNN@naccdata.org"
+            ),
+        )
+```
+
+### 4. New Client Methods on `AuthorizationClient`
+
+All four methods follow the same pattern as existing methods:
+- Validate input
+- Build request
+- Wrap transport call in `retry_on_503`
+- Dispatch on status code
+- Parse response or raise appropriate exception
+
+#### put_user_profile
+
+```python
+def put_user_profile(
+    self,
+    profile_user_id: str,
+    request: UserProfileRequest,
+) -> UserProfile:
+    """Create or update a user profile.
+
+    Args:
+        profile_user_id: The profile user ID (RegistryNNNNNN@naccdata.org).
+        request: The profile data to set.
+
+    Returns:
+        The created/updated UserProfile.
+
+    Raises:
+        ValidationError: If profile_user_id is invalid or API returns 400.
+        ServiceUnavailableError: If retries exhausted on 503.
+        UnexpectedError: On other unexpected HTTP errors.
+        ParseError: If the response body cannot be parsed.
+    """
+```
+
+#### get_user_profile
+
+```python
+def get_user_profile(self, profile_user_id: str) -> UserProfile:
+    """Get a user profile.
+
+    Raises:
+        ValidationError: If profile_user_id is invalid.
+        NotFoundError: If the profile does not exist (404).
+        ServiceUnavailableError: If retries exhausted on 503.
+        UnexpectedError: On other unexpected HTTP errors.
+        ParseError: If the response body cannot be parsed.
+    """
+```
+
+#### delete_user_profile
+
+```python
+def delete_user_profile(self, profile_user_id: str) -> None:
+    """Delete a user profile. Returns None on 204 or 404 (idempotent).
+
+    Raises:
+        ValidationError: If profile_user_id is invalid.
+        ServiceUnavailableError: If retries exhausted on 503.
+        UnexpectedError: On other unexpected HTTP errors.
+    """
+```
+
+#### get_user_profiles
+
+```python
+def get_user_profiles(self, profile_user_ids: list[str]) -> list[UserProfile]:
+    """Get multiple user profiles by ID.
+
+    Args:
+        profile_user_ids: List of profile user IDs to retrieve.
+
+    Returns:
+        List of UserProfile models.
+
+    Raises:
+        ValidationError: If any ID is invalid or API returns 400.
+        ServiceUnavailableError: If retries exhausted on 503.
+        UnexpectedError: On other unexpected HTTP errors.
+        ParseError: If the response body cannot be parsed.
+    """
+```
+
+### 5. AuthorizationSyncService.sync_profile
+
+New method on `AuthorizationSyncService`:
+
+```python
+def sync_profile(
+    self,
+    registry_id: str,
+    user_entry: UserEntry,
+) -> None:
+    """Push a user profile to the Authorization API.
+
+    Constructs a UserProfileRequest from the user entry fields and
+    calls put_user_profile. Catches AuthorizationClientError and
+    reports via the event collector without raising.
+
+    Skips sync if user_entry.auth_email is None (logs warning).
+
+    Args:
+        registry_id: The user's registry ID (used as Profile_User_ID).
+        user_entry: The user entry containing profile data.
+    """
+```
+
+The `AuthorizationClientProtocol` will be extended to include `put_user_profile`:
+
+```python
+class AuthorizationClientProtocol(Protocol):
+    # ... existing methods ...
+
+    def put_user_profile(
+        self,
+        profile_user_id: str,
+        request: "UserProfileRequest",
+    ) -> "UserProfile": ...
+```
+
+### 6. Integration in User Processes
+
+#### Active Users (UpdateUserProcess / UpdateCenterUserProcess)
+
+Profile sync is called after the existing authorization sync in `UpdateUserProcess.__authorize_user`:
+
+```python
+# After existing sync_user call
+if sync_service is not None:
+    try:
+        sync_service.sync_profile(
+            registry_id=registry_id,
+            user_entry=entry,
+        )
+    except Exception as error:
+        log.error("Profile sync failed for user %s: %s", registry_id, error)
+```
+
+Similarly in `UpdateCenterUserProcess.__authorize_user`.
+
+#### Inactive Users (InactiveUserProcess)
+
+A new step is added to `InactiveUserProcess.visit` before the existing steps:
+
+```python
+# Step 0: Profile sync (mark inactive)
+if entry.registry_id:  # from registry_person if available
+    try:
+        sync_service = self.__env.authorization_sync
+        if sync_service is not None:
+            sync_service.sync_profile(
+                registry_id=registry_id,
+                user_entry=entry,  # entry.active is False
+            )
+    except Exception as error:
+        log.error("Profile sync failed for inactive user %s: %s", entry.email, error)
+```
+
+Note: For inactive users, the `UserEntry` does not have a `registry_id` property directly. The registry_id must be resolved from the COmanage lookup (Step 2) or from the entry if it's a `CenterUserEntry` with a known registry person. The design handles this by checking if registry_id is available before attempting sync.
+
+## Data Models
+
+### Field Mapping: UserEntry → UserProfileRequest
+
+| UserEntry field | UserProfileRequest field | Notes |
+|---|---|---|
+| `name.first_name` | `firstName` | Required, 1-256 chars |
+| `name.last_name` | `lastName` | Required, 1-256 chars |
+| `email` | `email` | Optional, email format |
+| `auth_email` | `authEmail` | Required — skip sync if None |
+| `active` | `active` | Boolean |
+
+### Profile_User_ID
+
+The Profile_User_ID is the `registry_id` from the user's COmanage registry person record. It follows the format `RegistryNNNNNN@naccdata.org` (e.g., `Registry000001@naccdata.org`).
+
+### API Response Mapping
+
+| API field (camelCase) | Python field (snake_case) | Type |
+|---|---|---|
+| `userId` | `user_id` | str |
+| `firstName` | `first_name` | str |
+| `lastName` | `last_name` | str |
+| `email` | `email` | str \| None |
+| `authEmail` | `auth_email` | str |
+| `active` | `active` | bool |
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: Request routing correctness
+
+*For any* valid Profile_User_ID, calling `put_user_profile` SHALL send a PUT request to `/users/{profileUserId}`, calling `get_user_profile` SHALL send a GET request to `/users/{profileUserId}`, calling `delete_user_profile` SHALL send a DELETE request to `/users/{profileUserId}`, and calling `get_user_profiles` with a list of IDs SHALL send a GET request to `/users` with the IDs joined as a comma-separated `ids` query parameter.
+
+**Validates: Requirements 1.1, 1.2, 1.3, 1.4**
+
+### Property 2: UserProfile response parsing round-trip
+
+*For any* valid UserProfile data (userId, firstName, lastName, email, authEmail, active), serializing to JSON with camelCase keys and then parsing via `UserProfile.model_validate_json` SHALL produce a model whose fields match the original data.
+
+**Validates: Requirements 1.5, 1.11, 1.13, 2.2, 2.4**
+
+### Property 3: UserProfileRequest serialization round-trip
+
+*For any* valid UserProfileRequest constructed with snake_case field names, serializing with `model_dump_json(by_alias=True)` SHALL produce JSON with camelCase keys, and deserializing that JSON back SHALL produce an equivalent model.
+
+**Validates: Requirements 2.1, 2.3**
+
+### Property 4: Profile_User_ID validation
+
+*For any* string, the validation method SHALL accept it if and only if it matches the pattern `^Registry\d{6}@naccdata\.org$`. Strings that do not match (including None and empty string) SHALL cause a ValidationError to be raised before any HTTP request is sent.
+
+**Validates: Requirements 5.1, 5.2, 5.3, 5.4**
+
+### Property 5: Name field validation rejects invalid inputs
+
+*For any* string that is empty or composed entirely of whitespace, or exceeds 256 characters, constructing a `UserProfileRequest` with that string as `first_name` or `last_name` SHALL raise a Pydantic validation error.
+
+**Validates: Requirements 2.5**
+
+### Property 6: Field mapping correctness
+
+*For any* user entry with non-null auth_email, calling `sync_profile` SHALL construct a `UserProfileRequest` where `firstName` equals `entry.name.first_name`, `lastName` equals `entry.name.last_name`, `email` equals `entry.email`, `authEmail` equals `entry.auth_email`, and `active` equals `entry.active`.
+
+**Validates: Requirements 3.3, 6.2**
+
+### Property 7: Unexpected status codes raise UnexpectedError
+
+*For any* HTTP status code not in the set of explicitly handled codes for a given profile method, the method SHALL raise an `UnexpectedError` containing that status code and the error message from the response body.
+
+**Validates: Requirements 1.12**
+
+### Property 8: Idempotent profile sync
+
+*For any* user entry processed N times (N ≥ 1) with the same data, the `sync_profile` method SHALL send the same `UserProfileRequest` body to the same Profile_User_ID endpoint each time, and SHALL not raise exceptions or report errors when the API returns 200.
+
+**Validates: Requirements 6.1, 6.2, 6.3**
+
+## Error Handling
+
+### Client Layer
+
+| HTTP Status | Method | Behavior |
+|---|---|---|
+| 200 | put, get, get_profiles | Parse and return model |
+| 204 | delete | Return None |
+| 400 | all | Raise `ValidationError` with error message |
+| 404 | get | Raise `NotFoundError` |
+| 404 | delete | Return None (idempotent) |
+| 503 | all | Retry with exponential backoff; raise `ServiceUnavailableError` if exhausted |
+| Other | all | Raise `UnexpectedError` with status code and message |
+
+### Sync Layer
+
+`AuthorizationSyncService.sync_profile` catches all `AuthorizationClientError` exceptions and reports them via the event collector with category `AUTHORIZATION_SYNC`. It does not propagate exceptions.
+
+### Process Layer
+
+Both `UpdateUserProcess` and `InactiveUserProcess` wrap `sync_profile` calls in try/except blocks catching `Exception` as a safety net (matching the existing pattern for `sync_user`). This ensures profile sync failures never block other processing steps.
+
+### Fault Isolation
+
+Profile sync and grant sync are independent operations:
+- In `UpdateUserProcess.__authorize_user`: grant sync runs first, then profile sync. Each has its own try/except.
+- In `InactiveUserProcess.visit`: profile sync runs as a new independent step alongside existing steps (Flywheel disable, COmanage lookup, REDCap removal, COmanage suspend).
+
+## Testing Strategy
+
+### Property-Based Tests (Hypothesis)
+
+Property-based testing is appropriate for this feature because:
+- The models have clear input/output behavior with validation constraints
+- Profile_User_ID validation has a well-defined acceptance pattern
+- Field mapping is a pure transformation testable across many inputs
+- Serialization/deserialization are classic round-trip properties
+
+**Library**: [Hypothesis](https://hypothesis.readthedocs.io/) (already available in the project)
+
+**Configuration**: Minimum 100 iterations per property test.
+
+**Tag format**: `Feature: authorization-user-profiles, Property {number}: {property_text}`
+
+Each correctness property above maps to a single property-based test:
+
+1. **Property 1** — Generate random valid Profile_User_IDs, call each method with a mock transport, assert correct HTTP method and path.
+2. **Property 2** — Generate random UserProfile field values, serialize to JSON, parse, assert field equality.
+3. **Property 3** — Generate random valid UserProfileRequest inputs, serialize, deserialize, assert equivalence.
+4. **Property 4** — Generate random strings (both matching and non-matching the pattern), assert validation accepts/rejects correctly.
+5. **Property 5** — Generate empty strings, whitespace-only strings, and strings >256 chars, assert validation rejects.
+6. **Property 6** — Generate random user entries with non-null auth_email, call sync_profile with mock client, assert UserProfileRequest fields match mapping.
+7. **Property 7** — Generate random unexpected status codes, assert UnexpectedError raised with correct fields.
+8. **Property 8** — Generate random user entries, call sync_profile multiple times, assert same request sent each time.
+
+### Unit Tests (Example-Based)
+
+- `delete_user_profile` returns None on 204
+- `delete_user_profile` returns None on 404 (idempotent)
+- `sync_profile` skips when auth_email is None and logs warning
+- `sync_profile` reports error via event collector on AuthorizationClientError
+- Profile sync for inactive user with null registry_id is skipped
+- Retry-on-503 integration (mock 503 then 200)
+
+### Integration Tests
+
+- Fault isolation: profile sync failure does not block grant sync
+- Fault isolation: grant sync failure does not block profile sync
+- InactiveUserProcess continues remaining steps after profile sync failure

--- a/.kiro/specs/authorization-user-profiles/openapi.yaml
+++ b/.kiro/specs/authorization-user-profiles/openapi.yaml
@@ -1,0 +1,1180 @@
+openapi: 3.1.0
+info:
+  title: NACC Authorization API
+  version: 1.0.0
+  description: |
+    Domain-level REST interface to the NACC authorization system.
+    
+    This API provides authorization operations in NACC domain terms — granting access,
+    querying permissions, checking authorization, and managing resource hierarchy.
+    The underlying authorization engine (OpenFGA) is an implementation detail;
+    consumers interact only with this API.
+    
+    See ADR-008 for the architectural decision and rationale.
+  contact:
+    name: NACC Development Team
+
+servers:
+  - url: https://{environment}.api.nacc.example/authorization
+    description: NACC Authorization API
+    variables:
+      environment:
+        default: dev
+        enum: [dev, staging, prod]
+
+tags:
+  - name: Model
+    description: Authorization model metadata — resource types, relations, hierarchy rules, and computed permissions.
+  - name: Permissions
+    description: Query what access exists — user permissions, resource access, and authorization checks.
+  - name: Access Management
+    description: Grant and revoke access to resources and organizations.
+  - name: Resource Hierarchy
+    description: Manage parent relationships that define the resource hierarchy and enable inherited permissions.
+  - name: Batch Operations
+    description: Bulk grant and revoke operations for data loading and synchronization.
+  - name: User Profiles
+    description: CRUD operations for user profile records backed by MySQL.
+  - name: Health
+    description: Operational health checks.
+
+paths:
+  # ---------------------------------------------------------------------------
+  # Model
+  # ---------------------------------------------------------------------------
+  /model:
+    get:
+      operationId: getModel
+      summary: Get authorization model metadata
+      description: |
+        Returns the complete authorization model: all organization types, resource types,
+        their relations, categories, structural relations, computed relations, and valid
+        parent combinations.
+        
+        This is the single source of truth for authorization model semantics. Consumers
+        use this to populate UI dropdowns, validate inputs client-side, and understand
+        the permission structure.
+      tags: [Model]
+      responses:
+        "200":
+          description: Authorization model metadata.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthorizationModel"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+  /model/types/{type}:
+    get:
+      operationId: getTypeMetadata
+      summary: Get metadata for a specific type
+      description: |
+        Returns metadata for a single organization or resource type, including its
+        relations, category, structural relations, computed relations, and valid
+        parent combinations.
+      tags: [Model]
+      parameters:
+        - $ref: "#/components/parameters/TypePath"
+      responses:
+        "200":
+          description: Type metadata.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TypeMetadata"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  # ---------------------------------------------------------------------------
+  # Permissions
+  # ---------------------------------------------------------------------------
+  /users/{userId}/permissions:
+    get:
+      operationId: getUserPermissions
+      summary: Get all permissions for a user
+      description: |
+        Returns every resource and organization a user can access, grouped by type.
+        Each entry includes the relation and whether the access is direct, inherited,
+        or both.
+        
+        For inherited permissions, the response includes the inheritance source —
+        which parent organization and role grants the access (e.g., "inherited from
+        admin role on study:study1").
+        
+        This is the primary endpoint Portal uses to render what a user can see.
+      tags: [Permissions]
+      parameters:
+        - $ref: "#/components/parameters/UserIdPath"
+        - name: type
+          in: query
+          description: Filter results to a specific resource or organization type.
+          schema:
+            type: string
+            example: data_pipeline
+        - name: relation
+          in: query
+          description: Filter results to a specific relation.
+          schema:
+            type: string
+            example: viewer
+      responses:
+        "200":
+          description: User permissions grouped by type.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserPermissions"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+
+  /resources/{type}/{resourceId}/access:
+    get:
+      operationId: getResourceAccess
+      summary: Get all users with access to a resource
+      description: |
+        Returns all users who have access to the specified resource, with their
+        relation and whether access is direct, inherited, or both.
+        
+        For inherited access, includes the source (parent organization and role).
+        This is the endpoint the Authorization Interface uses for the resource
+        access view.
+      tags: [Permissions]
+      parameters:
+        - $ref: "#/components/parameters/TypePath"
+        - $ref: "#/components/parameters/ResourceIdPath"
+        - name: relation
+          in: query
+          description: Filter to a specific relation.
+          schema:
+            type: string
+            example: viewer
+      responses:
+        "200":
+          description: Users with access to the resource.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResourceAccessList"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /check:
+    post:
+      operationId: checkPermission
+      summary: Check whether a user has a specific permission
+      description: |
+        Returns whether the specified user has the specified relation on the
+        specified resource. Validates that the resource type and relation are
+        valid per the authorization model before evaluating.
+        
+        Use this for real-time authorization decisions (e.g., "can this user
+        view this dashboard?").
+      tags: [Permissions]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PermissionCheckRequest"
+      responses:
+        "200":
+          description: Permission check result.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PermissionCheckResponse"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+
+  /users/{userId}/effective-permissions/{type}/{resourceId}:
+    get:
+      operationId: getEffectivePermissions
+      summary: Get all effective relations a user has on a resource
+      description: |
+        Returns all relations the user effectively holds on the specified resource,
+        including both direct and inherited. This answers "what can this user do
+        on this resource?" without requiring the caller to check each relation
+        individually.
+      tags: [Permissions]
+      parameters:
+        - $ref: "#/components/parameters/UserIdPath"
+        - $ref: "#/components/parameters/TypePath"
+        - $ref: "#/components/parameters/ResourceIdPath"
+      responses:
+        "200":
+          description: Effective permissions on the resource.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EffectivePermissions"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+
+  # ---------------------------------------------------------------------------
+  # Access Management
+  # ---------------------------------------------------------------------------
+  /grants:
+    post:
+      operationId: grantAccess
+      summary: Grant a user access to a resource or organization
+      description: |
+        Grants the specified user the specified relation on the specified resource
+        or organization. Validates that:
+        - The type exists in the authorization model
+        - The relation is user-assignable for that type (not a computed or structural relation)
+        - The user and resource IDs are well-formed
+        
+        Returns 409 if the grant already exists (idempotent consumers should treat
+        409 as success).
+      tags: [Access Management]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/GrantRequest"
+      responses:
+        "201":
+          description: Access granted.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GrantResponse"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "409":
+          description: Grant already exists.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+    delete:
+      operationId: revokeAccess
+      summary: Revoke a user's access to a resource or organization
+      description: |
+        Revokes the specified user's relation on the specified resource or
+        organization. Same validation as grant.
+        
+        Returns 404 if the grant does not exist.
+      tags: [Access Management]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RevokeRequest"
+      responses:
+        "200":
+          description: Access revoked.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RevokeResponse"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  # ---------------------------------------------------------------------------
+  # Resource Hierarchy
+  # ---------------------------------------------------------------------------
+  /resources/{type}/{resourceId}/parents:
+    get:
+      operationId: getResourceParents
+      summary: Get the parent organizations of a resource
+      description: |
+        Returns the current parent relationships for a resource — which study,
+        research center, or community it is linked to. This defines the resource's
+        position in the hierarchy and determines inherited permissions.
+      tags: [Resource Hierarchy]
+      parameters:
+        - $ref: "#/components/parameters/TypePath"
+        - $ref: "#/components/parameters/ResourceIdPath"
+      responses:
+        "200":
+          description: Parent relationships for the resource.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResourceParents"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+
+    put:
+      operationId: setResourceParents
+      summary: Set the parent organizations of a resource
+      description: |
+        Sets the parent relationships for a resource, replacing any existing parents.
+        Validates that:
+        - The structural relation is valid for the resource type
+        - The parent type matches the expected type for that structural relation
+        - The combination of parents is valid per the authorization model
+        
+        This is the primary way to place a resource in the hierarchy. For example,
+        linking a data pipeline to its parent study and center, or linking a
+        dashboard to its parent community.
+      tags: [Resource Hierarchy]
+      parameters:
+        - $ref: "#/components/parameters/TypePath"
+        - $ref: "#/components/parameters/ResourceIdPath"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SetParentsRequest"
+      responses:
+        "200":
+          description: Parents set successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResourceParents"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+
+    delete:
+      operationId: removeResourceParents
+      summary: Remove all parent relationships from a resource
+      description: |
+        Removes all parent relationships from a resource, effectively unlinking it
+        from the hierarchy. This removes any inherited permissions that flowed
+        through those parent relationships.
+        
+        Use with caution — this will immediately revoke inherited access for all
+        users who had it through the hierarchy.
+      tags: [Resource Hierarchy]
+      parameters:
+        - $ref: "#/components/parameters/TypePath"
+        - $ref: "#/components/parameters/ResourceIdPath"
+      responses:
+        "200":
+          description: Parents removed.
+        "400":
+          $ref: "#/components/responses/ValidationError"
+
+  # ---------------------------------------------------------------------------
+  # Batch Operations
+  # ---------------------------------------------------------------------------
+  /grants/batch:
+    post:
+      operationId: batchModifyAccess
+      summary: Grant and/or revoke access in bulk
+      description: |
+        Accepts a list of grant and/or revoke operations (up to 100 per request).
+        Each operation is validated individually. The entire batch is rejected if
+        any operation fails validation (all-or-nothing semantics).
+        
+        Returns a summary of results. Designed for data loading scripts and
+        synchronization workflows.
+      tags: [Batch Operations]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BatchRequest"
+      responses:
+        "200":
+          description: Batch completed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BatchResponse"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+
+  # ---------------------------------------------------------------------------
+  # User Profiles
+  # ---------------------------------------------------------------------------
+  /users/{profileUserId}:
+    get:
+      operationId: getUserProfile
+      summary: Get a user profile
+      description: |
+        Returns the user profile for the specified profile user ID.
+      tags: [User Profiles]
+      parameters:
+        - $ref: "#/components/parameters/ProfileUserIdPath"
+      responses:
+        "200":
+          description: User profile found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserProfile"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+    put:
+      operationId: putUserProfile
+      summary: Create or update a user profile
+      description: |
+        Creates or updates the user profile for the specified profile user ID.
+        If the profile does not exist, it is created. If it exists, it is updated
+        with the provided fields.
+      tags: [User Profiles]
+      parameters:
+        - $ref: "#/components/parameters/ProfileUserIdPath"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UserProfileRequest"
+      responses:
+        "200":
+          description: User profile created or updated.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserProfile"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+    delete:
+      operationId: deleteUserProfile
+      summary: Delete a user profile
+      description: |
+        Deletes the user profile for the specified profile user ID.
+      tags: [User Profiles]
+      parameters:
+        - $ref: "#/components/parameters/ProfileUserIdPath"
+      responses:
+        "204":
+          description: User profile deleted.
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /users:
+    get:
+      operationId: getUserProfiles
+      summary: Get user profiles in batch
+      description: |
+        Returns user profiles for the specified profile user IDs. Accepts a
+        comma-separated list of IDs via the `ids` query parameter (maximum 50).
+      tags: [User Profiles]
+      parameters:
+        - name: ids
+          in: query
+          required: true
+          description: |
+            Comma-separated list of profile user IDs to retrieve (maximum 50).
+          schema:
+            type: string
+            maxLength: 3200
+          example: "Registry000001@naccdata.org,Registry000002@naccdata.org"
+      responses:
+        "200":
+          description: User profiles found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserProfileList"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+
+  # ---------------------------------------------------------------------------
+  # Health
+  # ---------------------------------------------------------------------------
+  /health:
+    get:
+      operationId: healthCheck
+      summary: Health check
+      description: |
+        Returns the health status of the API, including connectivity to the
+        authorization engine.
+      tags: [Health]
+      responses:
+        "200":
+          description: Service is healthy.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HealthResponse"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
+# =============================================================================
+# Components
+# =============================================================================
+components:
+
+  # ---------------------------------------------------------------------------
+  # Parameters
+  # ---------------------------------------------------------------------------
+  parameters:
+    UserIdPath:
+      name: userId
+      in: path
+      required: true
+      description: |
+        User identifier. This is the user's ID within the authorization system
+        (not prefixed with "user:" — the API handles that internally).
+      schema:
+        type: string
+        example: alice
+
+    TypePath:
+      name: type
+      in: path
+      required: true
+      description: |
+        Organization or resource type as defined in the authorization model
+        (e.g., study, research_center, data_pipeline, dashboard, page).
+      schema:
+        type: string
+        example: data_pipeline
+
+    ResourceIdPath:
+      name: resourceId
+      in: path
+      required: true
+      description: |
+        Resource or organization identifier (e.g., "study1",
+        "study1-center1-clinical-ingest").
+      schema:
+        type: string
+        example: study1-center1-clinical-ingest
+
+    ProfileUserIdPath:
+      name: profileUserId
+      in: path
+      required: true
+      description: |
+        User profile identifier in the format `RegistryNNNNNN@naccdata.org`.
+        This is distinct from the authorization user ID (e.g., "alice") used
+        by the permissions and access management endpoints.
+      schema:
+        type: string
+        pattern: "^Registry\\d{6}@naccdata\\.org$"
+        example: "Registry000001@naccdata.org"
+
+  # ---------------------------------------------------------------------------
+  # Responses
+  # ---------------------------------------------------------------------------
+  responses:
+    ValidationError:
+      description: Request validation failed.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+          example:
+            error: validation_error
+            message: "Relation 'submitter' is not valid for type 'dashboard'. Valid relations: viewer, editor."
+
+    NotFound:
+      description: Resource not found.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+          example:
+            error: not_found
+            message: "Type 'invalid_type' does not exist in the authorization model."
+
+    ServiceUnavailable:
+      description: Authorization engine is unreachable.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+          example:
+            error: service_unavailable
+            message: "Unable to connect to the authorization engine."
+
+  # ---------------------------------------------------------------------------
+  # Schemas
+  # ---------------------------------------------------------------------------
+  schemas:
+
+    # --- Model schemas ---
+
+    AuthorizationModel:
+      type: object
+      required: [version, types]
+      properties:
+        version:
+          type: string
+          description: Authorization model version (semantic versioning).
+          example: "2.0.0"
+        types:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/TypeMetadata"
+          description: Map of type name to type metadata.
+
+    TypeMetadata:
+      type: object
+      required: [name, category, relations]
+      properties:
+        name:
+          type: string
+          description: Type name.
+          example: data_pipeline
+        category:
+          type: string
+          enum: [organization, resource]
+          description: Whether this is an organization type or a resource type.
+        description:
+          type: string
+          description: Human-readable description of the type.
+          example: "Datatype-specific data collections for ingest or distribution."
+        relations:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/RelationMetadata"
+          description: Map of relation name to relation metadata.
+        structuralRelations:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/StructuralRelationMetadata"
+          description: |
+            Structural relations that link this type to parent organizations.
+            Only present for resource types that participate in the hierarchy.
+        computedRelations:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/ComputedRelationMetadata"
+          description: |
+            Computed relations that derive permissions from the hierarchy.
+            These are never directly assigned — they are resolved by the
+            authorization engine based on structural relations.
+        validParentCombinations:
+          type: array
+          items:
+            $ref: "#/components/schemas/ParentCombination"
+          description: |
+            Valid combinations of parent relationships for this type.
+            Only present for resource types with structural relations.
+
+    RelationMetadata:
+      type: object
+      required: [name, assignable]
+      properties:
+        name:
+          type: string
+          example: viewer
+        description:
+          type: string
+          example: "Can view pipeline data."
+        assignable:
+          type: boolean
+          description: |
+            Whether this relation can be directly assigned to a user via the
+            grant endpoint. False for computed and structural relations.
+
+    StructuralRelationMetadata:
+      type: object
+      required: [name, parentType]
+      properties:
+        name:
+          type: string
+          example: parent_study
+        parentType:
+          type: string
+          description: The type of the parent organization.
+          example: study
+        description:
+          type: string
+          example: "Links this resource to its parent study."
+
+    ComputedRelationMetadata:
+      type: object
+      required: [name, sourceRelation, parentRelation, grantsRelation]
+      properties:
+        name:
+          type: string
+          example: study_admin_access
+        description:
+          type: string
+          example: "Grants viewer access to admins of the parent study."
+        sourceRelation:
+          type: string
+          description: The role on the parent organization that grants this computed access.
+          example: admin
+        parentRelation:
+          type: string
+          description: The structural relation traversed to reach the parent.
+          example: parent_study
+        grantsRelation:
+          type: string
+          description: The user-facing relation that this computed relation effectively grants on the resource.
+          example: viewer
+
+    ParentCombination:
+      type: object
+      required: [parents]
+      properties:
+        parents:
+          type: array
+          items:
+            type: string
+          description: |
+            List of structural relation names that form a valid combination.
+            For types where valid combinations depend on additional context
+            (e.g., pipeline_type), the condition field describes when this
+            combination applies.
+          example: ["parent_study", "parent_center"]
+        description:
+          type: string
+          example: "Center ingest pipeline — ingests data from a center for a study."
+        condition:
+          type: string
+          description: |
+            Optional condition describing when this parent combination applies.
+            Used when a single resource type has multiple valid parent
+            combinations that depend on the resource's characteristics.
+          example: "pipeline_type is center-ingest"
+
+    # --- Permission schemas ---
+
+    UserPermissions:
+      type: object
+      required: [userId, permissions]
+      properties:
+        userId:
+          type: string
+          example: alice
+        permissions:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              $ref: "#/components/schemas/PermissionEntry"
+          description: |
+            Map of type name to list of permission entries. Each entry represents
+            one resource the user can access with a specific relation.
+          example:
+            study:
+              - resourceId: study1
+                relation: admin
+                access: direct
+            data_pipeline:
+              - resourceId: study1-center1-clinical-ingest
+                relation: viewer
+                access: inherited
+                inheritedFrom:
+                  parentType: study
+                  parentId: study1
+                  parentRole: admin
+
+    PermissionEntry:
+      type: object
+      required: [resourceId, relation, access]
+      properties:
+        resourceId:
+          type: string
+          example: study1-center1-clinical-ingest
+        relation:
+          type: string
+          example: viewer
+        access:
+          type: string
+          enum: [direct, inherited, both]
+          description: |
+            How the user has this access:
+            - direct: explicitly granted
+            - inherited: derived from a parent organization role
+            - both: both directly granted and inherited
+        inheritedFrom:
+          $ref: "#/components/schemas/InheritanceSource"
+
+    InheritanceSource:
+      type: object
+      required: [parentType, parentId, parentRole]
+      description: |
+        Describes why inherited access exists, in domain terms.
+        For example: "user is admin of study:study1, which is the parent study
+        of this data pipeline."
+      properties:
+        parentType:
+          type: string
+          description: The type of the parent organization granting inherited access.
+          example: study
+        parentId:
+          type: string
+          description: The ID of the parent organization.
+          example: study1
+        parentRole:
+          type: string
+          description: The user's role on the parent organization that grants this access.
+          example: admin
+
+    ResourceAccessList:
+      type: object
+      required: [type, resourceId, users]
+      properties:
+        type:
+          type: string
+          example: data_pipeline
+        resourceId:
+          type: string
+          example: study1-center1-clinical-ingest
+        users:
+          type: array
+          items:
+            $ref: "#/components/schemas/ResourceAccessEntry"
+
+    ResourceAccessEntry:
+      type: object
+      required: [userId, relation, access]
+      properties:
+        userId:
+          type: string
+          example: alice
+        relation:
+          type: string
+          example: viewer
+        access:
+          type: string
+          enum: [direct, inherited, both]
+        inheritedFrom:
+          $ref: "#/components/schemas/InheritanceSource"
+
+    PermissionCheckRequest:
+      type: object
+      required: [userId, relation, type, resourceId]
+      properties:
+        userId:
+          type: string
+          example: alice
+        relation:
+          type: string
+          example: viewer
+        type:
+          type: string
+          example: data_pipeline
+        resourceId:
+          type: string
+          example: study1-center1-clinical-ingest
+
+    PermissionCheckResponse:
+      type: object
+      required: [allowed]
+      properties:
+        allowed:
+          type: boolean
+          description: Whether the user has the specified permission.
+          example: true
+
+    EffectivePermissions:
+      type: object
+      required: [userId, type, resourceId, relations]
+      properties:
+        userId:
+          type: string
+          example: alice
+        type:
+          type: string
+          example: data_pipeline
+        resourceId:
+          type: string
+          example: study1-center1-clinical-ingest
+        relations:
+          type: array
+          items:
+            $ref: "#/components/schemas/EffectiveRelation"
+          description: All relations the user effectively holds on this resource.
+
+    EffectiveRelation:
+      type: object
+      required: [relation, access]
+      properties:
+        relation:
+          type: string
+          example: viewer
+        access:
+          type: string
+          enum: [direct, inherited, both]
+        inheritedFrom:
+          $ref: "#/components/schemas/InheritanceSource"
+
+    # --- Access management schemas ---
+
+    GrantRequest:
+      type: object
+      required: [userId, relation, type, resourceId]
+      properties:
+        userId:
+          type: string
+          description: The user to grant access to.
+          example: charlie
+        relation:
+          type: string
+          description: |
+            The relation to grant. Must be a user-assignable relation for the
+            specified type (not a computed or structural relation).
+          example: viewer
+        type:
+          type: string
+          description: The resource or organization type.
+          example: data_pipeline
+        resourceId:
+          type: string
+          description: The resource or organization ID.
+          example: study1-center1-clinical-ingest
+
+    GrantResponse:
+      type: object
+      required: [userId, relation, type, resourceId]
+      properties:
+        userId:
+          type: string
+        relation:
+          type: string
+        type:
+          type: string
+        resourceId:
+          type: string
+
+    RevokeRequest:
+      type: object
+      required: [userId, relation, type, resourceId]
+      properties:
+        userId:
+          type: string
+          example: charlie
+        relation:
+          type: string
+          example: viewer
+        type:
+          type: string
+          example: data_pipeline
+        resourceId:
+          type: string
+          example: study1-center1-clinical-ingest
+
+    RevokeResponse:
+      type: object
+      required: [userId, relation, type, resourceId]
+      properties:
+        userId:
+          type: string
+        relation:
+          type: string
+        type:
+          type: string
+        resourceId:
+          type: string
+
+    # --- Resource hierarchy schemas ---
+
+    ResourceParents:
+      type: object
+      required: [type, resourceId, parents]
+      properties:
+        type:
+          type: string
+          example: data_pipeline
+        resourceId:
+          type: string
+          example: study1-center1-clinical-ingest
+        parents:
+          type: array
+          items:
+            $ref: "#/components/schemas/ParentRelationship"
+
+    ParentRelationship:
+      type: object
+      required: [structuralRelation, parentType, parentId]
+      properties:
+        structuralRelation:
+          type: string
+          description: The structural relation name (e.g., parent_study, parent_center).
+          example: parent_study
+        parentType:
+          type: string
+          description: The type of the parent organization.
+          example: study
+        parentId:
+          type: string
+          description: The ID of the parent organization.
+          example: study1
+
+    SetParentsRequest:
+      type: object
+      required: [parents]
+      properties:
+        parents:
+          type: array
+          items:
+            $ref: "#/components/schemas/ParentRelationship"
+          description: |
+            The parent relationships to set. Must be a valid combination per the
+            authorization model's validParentCombinations for this resource type.
+          example:
+            - structuralRelation: parent_study
+              parentType: study
+              parentId: study1
+            - structuralRelation: parent_center
+              parentType: research_center
+              parentId: center1
+
+    # --- Batch schemas ---
+
+    BatchRequest:
+      type: object
+      required: [operations]
+      properties:
+        operations:
+          type: array
+          maxItems: 100
+          items:
+            $ref: "#/components/schemas/BatchOperation"
+
+    BatchOperation:
+      type: object
+      required: [action, userId, relation, type, resourceId]
+      properties:
+        action:
+          type: string
+          enum: [grant, revoke]
+          description: Whether to grant or revoke this access.
+        userId:
+          type: string
+          example: charlie
+        relation:
+          type: string
+          example: viewer
+        type:
+          type: string
+          example: data_pipeline
+        resourceId:
+          type: string
+          example: study1-center1-clinical-ingest
+
+    BatchResponse:
+      type: object
+      required: [total, succeeded, failed]
+      properties:
+        total:
+          type: integer
+          description: Total number of operations in the batch.
+          example: 10
+        succeeded:
+          type: integer
+          description: Number of operations that succeeded.
+          example: 9
+        failed:
+          type: integer
+          description: Number of operations that failed.
+          example: 1
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/BatchError"
+
+    BatchError:
+      type: object
+      required: [index, error, message]
+      properties:
+        index:
+          type: integer
+          description: Zero-based index of the failed operation in the batch.
+          example: 3
+        error:
+          type: string
+          example: conflict
+        message:
+          type: string
+          example: "Grant already exists."
+
+    # --- Health schemas ---
+
+    HealthResponse:
+      type: object
+      required: [status]
+      properties:
+        status:
+          type: string
+          enum: [healthy, degraded, unhealthy]
+          example: healthy
+        authorizationEngine:
+          type: string
+          enum: [connected, unreachable]
+          example: connected
+
+    # --- Error schemas ---
+
+    ErrorResponse:
+      type: object
+      required: [error, message]
+      properties:
+        error:
+          type: string
+          description: Machine-readable error code.
+          example: validation_error
+        message:
+          type: string
+          description: Human-readable error description.
+          example: "Relation 'parent_study' is a structural relation and cannot be directly assigned. Use the resource hierarchy endpoints instead."
+        details:
+          type: object
+          additionalProperties: true
+          description: Additional error context (optional).
+
+    # --- User Profile schemas ---
+
+    UserProfile:
+      type: object
+      required: [userId, firstName, lastName, authEmail, active]
+      properties:
+        userId:
+          type: string
+          example: "Registry000001@naccdata.org"
+        firstName:
+          type: string
+          example: "Jane"
+        lastName:
+          type: string
+          example: "Doe"
+        email:
+          type: ["string", "null"]
+          format: email
+        authEmail:
+          type: string
+          format: email
+        active:
+          type: boolean
+
+    UserProfileRequest:
+      type: object
+      required: [firstName, lastName, authEmail]
+      properties:
+        firstName:
+          type: string
+          minLength: 1
+          maxLength: 256
+        lastName:
+          type: string
+          minLength: 1
+          maxLength: 256
+        email:
+          type: ["string", "null"]
+          format: email
+        authEmail:
+          type: string
+          format: email
+          minLength: 1
+          maxLength: 256
+        active:
+          type: ["boolean", "null"]
+
+    UserProfileList:
+      type: object
+      required: [users]
+      properties:
+        users:
+          type: array
+          items:
+            $ref: "#/components/schemas/UserProfile"

--- a/.kiro/specs/authorization-user-profiles/requirements.md
+++ b/.kiro/specs/authorization-user-profiles/requirements.md
@@ -1,0 +1,95 @@
+# Requirements Document
+
+## Introduction
+
+The NACC Authorization API now provides user profile CRUD endpoints for managing user profile records. The existing user management processes (user management gear and authorization sync service) need to push user entry information as user profiles to these new endpoints whenever user entries are processed. This enables the authorization system to maintain a complete view of user identity alongside their permissions.
+
+## Glossary
+
+- **Authorization_Client**: The `AuthorizationClient` class that wraps HTTP calls to the NACC Authorization API.
+- **Authorization_Sync_Service**: The service that orchestrates synchronization of user data with the Authorization API during user processing.
+- **User_Entry**: A model representing a user in the NACC directory, containing name, email, auth_email, active status, and registry person information.
+- **User_Profile**: A record in the Authorization API containing userId, firstName, lastName, email, authEmail, and active status.
+- **Profile_User_ID**: The user identifier for profile endpoints, in the format `RegistryNNNNNN@naccdata.org` (the registry_id from COmanage).
+- **User_Process**: The processing logic that manages user entries, including creating Flywheel users, syncing authorizations, and sending notifications.
+- **Event_Collector**: The mechanism for reporting processing outcomes (successes and errors) without propagating exceptions.
+- **UserProfileRequest**: The request body for creating or updating a user profile, containing firstName, lastName, email, authEmail, and active fields.
+
+## Requirements
+
+### Requirement 1: Authorization Client User Profile Methods
+
+**User Story:** As a developer, I want the Authorization Client to support user profile CRUD operations, so that other services can push and retrieve user profile data through a consistent client interface.
+
+#### Acceptance Criteria
+
+1. THE Authorization_Client SHALL provide a `put_user_profile` method that accepts a Profile_User_ID and a UserProfileRequest and sends a PUT request to `/users/{profileUserId}`
+2. THE Authorization_Client SHALL provide a `get_user_profile` method that accepts a Profile_User_ID and sends a GET request to `/users/{profileUserId}`
+3. THE Authorization_Client SHALL provide a `delete_user_profile` method that accepts a Profile_User_ID and sends a DELETE request to `/users/{profileUserId}`
+4. THE Authorization_Client SHALL provide a `get_user_profiles` method that accepts a list of Profile_User_IDs and sends a GET request to `/users?ids=...` with the IDs joined as a comma-separated query parameter
+5. WHEN the `put_user_profile` method receives a 200 response, THE Authorization_Client SHALL return a parsed UserProfile model
+6. WHEN the `put_user_profile` method receives a 400 response, THE Authorization_Client SHALL raise a ValidationError with the error message from the response
+7. WHEN the `get_user_profile` method receives a 404 response, THE Authorization_Client SHALL raise a NotFoundError indicating the requested Profile_User_ID was not found
+8. WHEN the `delete_user_profile` method receives a 204 response, THE Authorization_Client SHALL return None
+9. WHEN the `delete_user_profile` method receives a 404 response, THE Authorization_Client SHALL return None without raising an exception
+10. THE Authorization_Client SHALL apply the same retry-on-503 strategy to user profile methods as used by existing methods, using the configured max_retries and base_backoff parameters with exponential backoff
+11. WHEN the `get_user_profile` method receives a 200 response, THE Authorization_Client SHALL return a parsed UserProfile model
+12. IF any user profile method receives an unexpected HTTP status code not explicitly handled, THEN THE Authorization_Client SHALL raise an UnexpectedError containing the status code and error message from the response
+13. WHEN the `get_user_profiles` method receives a 200 response, THE Authorization_Client SHALL return a list of parsed UserProfile models
+
+### Requirement 2: User Profile Data Models
+
+**User Story:** As a developer, I want Pydantic models for user profile requests and responses, so that profile data is validated and serialized consistently.
+
+#### Acceptance Criteria
+
+1. THE Authorization_Client module SHALL define a `UserProfileRequest` model with fields: firstName (str, 1-256 chars, must contain at least one non-whitespace character), lastName (str, 1-256 chars, must contain at least one non-whitespace character), email (str or None, email format, 1-256 chars, default None), authEmail (str, email format, 1-256 chars), and active (bool or None, default None)
+2. THE Authorization_Client module SHALL define a `UserProfile` response model with fields: userId (str), firstName (str), lastName (str), email (str or None), authEmail (str), and active (bool)
+3. THE UserProfileRequest model SHALL serialize field names using camelCase aliases matching the API schema (firstName, lastName, authEmail) and support field access by both Python snake_case names and camelCase aliases (populate_by_name)
+4. THE UserProfile model SHALL deserialize field names from camelCase aliases matching the API schema and support field access by both Python snake_case names and camelCase aliases (populate_by_name)
+5. IF a UserProfileRequest is constructed with a firstName or lastName that is empty or exceeds 256 characters, THEN THE Authorization_Client module SHALL raise a validation error indicating the field length constraint
+
+### Requirement 3: Profile Sync During User Processing
+
+**User Story:** As a system operator, I want user profiles to be pushed to the Authorization API whenever user entries are processed, so that the authorization system has up-to-date user identity information.
+
+#### Acceptance Criteria
+
+1. WHEN a registered active user entry is processed by the User_Process, THE Authorization_Sync_Service SHALL push a user profile to the Authorization API using the PUT endpoint
+2. THE Authorization_Sync_Service SHALL construct the Profile_User_ID from the user entry's registry_id
+3. THE Authorization_Sync_Service SHALL map user entry fields to UserProfileRequest fields as follows: name.first_name to firstName, name.last_name to lastName, email to email, auth_email to authEmail, active to active
+4. IF a user entry has a null auth_email, THEN THE Authorization_Sync_Service SHALL skip the profile sync for that entry and log a warning message indicating the user's email and the reason the sync was skipped
+5. IF profile sync fails with an AuthorizationClientError, THEN THE Authorization_Sync_Service SHALL report the failure via the Event_Collector as an error event with the AUTHORIZATION_SYNC category and continue processing without raising the exception
+6. THE Authorization_Sync_Service SHALL execute profile sync independently of grant sync such that an exception in either operation does not prevent the other from executing
+
+### Requirement 4: Profile Sync for Inactive Users
+
+**User Story:** As a system operator, I want inactive user profiles to be updated in the Authorization API when users are deactivated, so that the authorization system reflects the current active status.
+
+#### Acceptance Criteria
+
+1. WHEN an inactive user entry is processed and the user has a non-null registry_id, THE User_Process SHALL push a profile update to the Authorization API using the PUT endpoint with active set to false and identity fields mapped per Requirement 3 criterion 3
+2. IF an inactive user entry has a null registry_id, THEN THE User_Process SHALL skip the profile sync for that entry
+3. IF the profile update for an inactive user raises an AuthorizationClientError, THEN THE User_Process SHALL report the failure via the Event_Collector and continue with the remaining deactivation steps (Flywheel disable, COmanage lookup, REDCap role removal, COmanage suspend)
+4. THE User_Process SHALL execute profile sync for inactive users independently of other deactivation steps so that failure of one does not block the other
+
+### Requirement 5: Profile User ID Validation
+
+**User Story:** As a developer, I want the Profile User ID to be validated before sending requests, so that invalid IDs are caught early rather than rejected by the API.
+
+#### Acceptance Criteria
+
+1. THE Authorization_Client SHALL validate that the Profile_User_ID matches the pattern `^Registry\d{6}@naccdata\.org$` before sending any profile request
+2. IF the Profile_User_ID does not match the expected pattern, THEN THE Authorization_Client SHALL raise a ValidationError with a message indicating the invalid value provided and the expected format
+3. IF the Profile_User_ID is None or an empty string, THEN THE Authorization_Client SHALL raise a ValidationError with a message indicating that a non-empty Profile_User_ID is required
+4. WHEN the `get_user_profiles` method is called with a list of Profile_User_IDs, THE Authorization_Client SHALL validate each ID in the list against the expected pattern before sending the request
+
+### Requirement 6: Idempotent Profile Sync
+
+**User Story:** As a system operator, I want profile sync to be idempotent, so that reprocessing user entries does not cause errors or inconsistent state.
+
+#### Acceptance Criteria
+
+1. THE Authorization_Sync_Service SHALL use the PUT endpoint for profile sync, which creates the profile if it does not exist or updates it if it already exists
+2. WHEN the same user entry is processed multiple times with the same data, THE Authorization_Sync_Service SHALL send the same UserProfileRequest to the PUT endpoint each time, and the resulting UserProfile state in the Authorization API SHALL match the field mapping defined in Requirement 3 criterion 3
+3. WHEN a user entry is reprocessed and the profile already exists in the Authorization API, THE Authorization_Sync_Service SHALL complete without raising exceptions or reporting errors via the Event_Collector

--- a/.kiro/specs/authorization-user-profiles/tasks.md
+++ b/.kiro/specs/authorization-user-profiles/tasks.md
@@ -1,0 +1,185 @@
+# Implementation Plan: Authorization User Profiles
+
+## Overview
+
+Implement user profile CRUD operations in the authorization client library and integrate profile sync into the user processing pipeline. The implementation follows the existing patterns: Pydantic models with camelCase aliases, `retry_on_503` wrapping, error classification, and fault-isolated error reporting via `UserEventCollector`.
+
+## Tasks
+
+- [x] 1. Add NotFoundError exception and UserProfile models
+  - [x] 1.1 Add `NotFoundError` to `common/src/python/authorization/exceptions.py`
+    - Add `NotFoundError(AuthorizationClientError)` with a `message` attribute
+    - Follows the same pattern as `ValidationError` and `UnexpectedError`
+    - _Requirements: 1.7_
+
+  - [x] 1.2 Add `UserProfileRequest`, `UserProfile`, and `UserProfileList` models to `common/src/python/authorization/models.py`
+    - `UserProfileRequest` with fields: first_name (alias firstName, 1-256 chars, non-whitespace validator), last_name (alias lastName, 1-256 chars, non-whitespace validator), email (alias email, optional), auth_email (alias authEmail, 1-256 chars), active (optional bool)
+    - `UserProfile` with fields: user_id (alias userId), first_name (alias firstName), last_name (alias lastName), email (optional), auth_email (alias authEmail), active (bool)
+    - `UserProfileList` with field: users (list[UserProfile])
+    - All models use `ConfigDict(populate_by_name=True)`
+    - _Requirements: 2.1, 2.2, 2.3, 2.4, 2.5_
+
+  - [x]* 1.3 Write property test for UserProfileRequest serialization round-trip
+    - **Property 3: UserProfileRequest serialization round-trip**
+    - Generate valid UserProfileRequest inputs with Hypothesis, serialize with `model_dump_json(by_alias=True)`, deserialize back, assert equivalence
+    - **Validates: Requirements 2.1, 2.3**
+
+  - [x]* 1.4 Write property test for UserProfile response parsing round-trip
+    - **Property 2: UserProfile response parsing round-trip**
+    - Generate valid UserProfile JSON data with camelCase keys, parse via `model_validate_json`, assert fields match original data
+    - **Validates: Requirements 1.5, 1.11, 1.13, 2.2, 2.4**
+
+  - [x]* 1.5 Write property test for name field validation
+    - **Property 5: Name field validation rejects invalid inputs**
+    - Generate empty strings, whitespace-only strings, and strings >256 chars; assert Pydantic validation error on UserProfileRequest construction
+    - **Validates: Requirements 2.5**
+
+- [x] 2. Implement Profile_User_ID validation and client profile methods
+  - [x] 2.1 Add `_validate_profile_user_id` method and `_PROFILE_USER_ID_PATTERN` to `common/src/python/authorization/client.py`
+    - Compile regex `^Registry\d{6}@naccdata\.org$`
+    - Raise `ValidationError` if ID is None, empty, or doesn't match pattern
+    - Import `re` module at top of file
+    - _Requirements: 5.1, 5.2, 5.3_
+
+  - [x]* 2.2 Write property test for Profile_User_ID validation
+    - **Property 4: Profile_User_ID validation**
+    - Generate random strings (both matching and non-matching the pattern), assert validation accepts/rejects correctly
+    - **Validates: Requirements 5.1, 5.2, 5.3, 5.4**
+
+  - [x] 2.3 Implement `put_user_profile` method on `AuthorizationClient`
+    - Validate profile_user_id, serialize UserProfileRequest body, PUT to `/users/{profileUserId}`
+    - Handle 200 (parse and return UserProfile), 400 (raise ValidationError), other (raise UnexpectedError)
+    - Wrap transport call in `retry_on_503`
+    - Import `UserProfileRequest`, `UserProfile` from models; import `NotFoundError` from exceptions
+    - _Requirements: 1.1, 1.5, 1.6, 1.10, 1.12_
+
+  - [x] 2.4 Implement `get_user_profile` method on `AuthorizationClient`
+    - Validate profile_user_id, GET `/users/{profileUserId}`
+    - Handle 200 (parse and return UserProfile), 404 (raise NotFoundError), 400 (raise ValidationError), other (raise UnexpectedError)
+    - Wrap transport call in `retry_on_503`
+    - _Requirements: 1.2, 1.7, 1.11, 1.10, 1.12_
+
+  - [x] 2.5 Implement `delete_user_profile` method on `AuthorizationClient`
+    - Validate profile_user_id, DELETE `/users/{profileUserId}`
+    - Handle 204 (return None), 404 (return None, idempotent), 400 (raise ValidationError), other (raise UnexpectedError)
+    - Wrap transport call in `retry_on_503`
+    - _Requirements: 1.3, 1.8, 1.9, 1.10, 1.12_
+
+  - [x] 2.6 Implement `get_user_profiles` method on `AuthorizationClient`
+    - Validate each profile_user_id in the list, GET `/users?ids=id1,id2,...`
+    - Handle 200 (parse UserProfileList, return list of UserProfile), 400 (raise ValidationError), other (raise UnexpectedError)
+    - Wrap transport call in `retry_on_503`
+    - _Requirements: 1.4, 1.13, 5.4, 1.10, 1.12_
+
+  - [x]* 2.7 Write property test for request routing correctness
+    - **Property 1: Request routing correctness**
+    - Generate valid Profile_User_IDs, call each method with a mock transport, assert correct HTTP method and path
+    - **Validates: Requirements 1.1, 1.2, 1.3, 1.4**
+
+  - [x]* 2.8 Write property test for unexpected status codes
+    - **Property 7: Unexpected status codes raise UnexpectedError**
+    - Generate random unexpected status codes (not in handled set), assert UnexpectedError raised with correct status code and message
+    - **Validates: Requirements 1.12**
+
+  - [x] 2.9 Write unit tests for client profile methods
+    - Test `put_user_profile` returns parsed UserProfile on 200
+    - Test `get_user_profile` raises NotFoundError on 404
+    - Test `delete_user_profile` returns None on 204
+    - Test `delete_user_profile` returns None on 404 (idempotent)
+    - Test retry-on-503 integration (mock 503 then 200)
+    - _Requirements: 1.5, 1.7, 1.8, 1.9, 1.10_
+
+- [x] 3. Implement sync_profile on AuthorizationSyncService
+  - [x] 3.1 Extend `AuthorizationClientProtocol` with `put_user_profile` method in `common/src/python/authorization_sync/sync_service.py`
+    - Add `put_user_profile(self, profile_user_id: str, request: "UserProfileRequest") -> "UserProfile": ...` to the Protocol class
+    - Add necessary imports for `UserProfileRequest` and `UserProfile` (use string annotations in Protocol)
+    - _Requirements: 3.1_
+
+  - [x] 3.2 Implement `sync_profile` method on `AuthorizationSyncService`
+    - Accept `registry_id: str` and `user_entry: UserEntry` parameters
+    - Skip sync if `user_entry.auth_email` is None (log warning with user email)
+    - Construct `UserProfileRequest` mapping: name.first_name → firstName, name.last_name → lastName, email → email, auth_email → authEmail, active → active
+    - Call `self._client.put_user_profile(registry_id, request)`
+    - Catch `AuthorizationClientError` and report via event collector with `AUTHORIZATION_SYNC` category
+    - Import `UserEntry` from `users.user_entry` and `UserProfileRequest`, `UserProfile` from `authorization.models`
+    - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5_
+
+  - [x]* 3.3 Write property test for field mapping correctness
+    - **Property 6: Field mapping correctness**
+    - Generate random user entries with non-null auth_email, call sync_profile with mock client, assert UserProfileRequest fields match the mapping
+    - **Validates: Requirements 3.3, 6.2**
+
+  - [x]* 3.4 Write property test for idempotent profile sync
+    - **Property 8: Idempotent profile sync**
+    - Generate random user entries, call sync_profile multiple times, assert same request sent each time
+    - **Validates: Requirements 6.1, 6.2, 6.3**
+
+  - [x] 3.5 Write unit tests for sync_profile
+    - Test sync_profile skips when auth_email is None and logs warning
+    - Test sync_profile reports error via event collector on AuthorizationClientError
+    - Test sync_profile completes without error when API returns 200
+    - _Requirements: 3.4, 3.5, 6.3_
+
+- [x] 4. Integrate profile sync into user processes
+  - [x] 4.1 Add profile sync to `UpdateUserProcess.__authorize_user` in `common/src/python/users/user_processes.py`
+    - After existing `sync_service.sync_user` call, add independent `sync_service.sync_profile(registry_id=registry_id, user_entry=entry)` call
+    - Wrap in try/except catching `Exception` for fault isolation (matching existing pattern)
+    - Log error on failure; do not propagate
+    - Pass the `ActiveUserEntry` as the user_entry parameter (requires passing entry into `__authorize_user` or accessing it from context)
+    - _Requirements: 3.1, 3.6, 6.1_
+
+  - [x] 4.2 Add profile sync to `UpdateCenterUserProcess.__authorize_user` in `common/src/python/users/user_processes.py`
+    - After existing `sync_service.sync_user` loop, add independent `sync_service.sync_profile(registry_id=registry_id, user_entry=entry)` call
+    - Wrap in try/except catching `Exception` for fault isolation
+    - Log error on failure; do not propagate
+    - Pass the `CenterUserEntry` as the user_entry parameter (requires passing entry into `__authorize_user` or accessing it from context)
+    - _Requirements: 3.1, 3.6, 6.1_
+
+  - [x] 4.3 Add profile sync to `InactiveUserProcess.visit` in `common/src/python/users/user_processes.py`
+    - Add a new independent step (Step 0 or after Step 2 when registry_id is resolved) for profile sync
+    - Only attempt sync if registry_id is available (from person_list lookup)
+    - Call `sync_service.sync_profile(registry_id=registry_id, user_entry=entry)` where entry.active is False
+    - Wrap in try/except catching `Exception` for fault isolation
+    - Log error on failure; continue with remaining deactivation steps
+    - _Requirements: 4.1, 4.2, 4.3, 4.4_
+
+  - [x] 4.4 Write unit tests for profile sync integration in user processes
+    - Test fault isolation: profile sync failure does not block grant sync
+    - Test fault isolation: grant sync failure does not block profile sync
+    - Test InactiveUserProcess continues remaining steps after profile sync failure
+    - Test profile sync is skipped for inactive user with null registry_id
+    - _Requirements: 3.6, 4.3, 4.4_
+
+- [x] 5. Final checkpoint - Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for faster MVP
+- Each task references specific requirements for traceability
+- Checkpoints ensure incremental validation
+- Property tests validate universal correctness properties from the design document
+- Unit tests validate specific examples and edge cases
+- All property tests use Hypothesis with minimum 100 iterations
+- Test files go in `common/test/python/authorization_test/` and `common/test/python/authorization_sync_test/` (existing directories with BUILD files)
+- User process integration tests go in `common/test/python/user_test/`
+- The `UserEntry` type used in `sync_profile` is the base class; both `ActiveUserEntry` and `CenterUserEntry` inherit from it and provide the needed fields
+
+## Task Dependency Graph
+
+```json
+{
+  "waves": [
+    { "id": 0, "tasks": ["1.1", "1.2"] },
+    { "id": 1, "tasks": ["1.3", "1.4", "1.5", "2.1"] },
+    { "id": 2, "tasks": ["2.2", "2.3"] },
+    { "id": 3, "tasks": ["2.4", "2.5", "2.6"] },
+    { "id": 4, "tasks": ["2.7", "2.8", "2.9"] },
+    { "id": 5, "tasks": ["3.1"] },
+    { "id": 6, "tasks": ["3.2"] },
+    { "id": 7, "tasks": ["3.3", "3.4", "3.5"] },
+    { "id": 8, "tasks": ["4.1", "4.2", "4.3"] },
+    { "id": 9, "tasks": ["4.4"] }
+  ]
+}
+```

--- a/common/src/python/authorization/client.py
+++ b/common/src/python/authorization/client.py
@@ -3,10 +3,12 @@
 import json
 import logging
 import math
+import re
 from collections.abc import Callable
 from typing import Any
 
 from authorization.exceptions import (
+    NotFoundError,
     ParseError,
     UnexpectedError,
     ValidationError,
@@ -27,6 +29,9 @@ from authorization.models import (
     RevokeResult,
     SetParentsRequestModel,
     UserPermissions,
+    UserProfile,
+    UserProfileList,
+    UserProfileRequest,
 )
 from authorization.retry import retry_on_503
 from authorization.transport import HttpResponse, HttpTransport
@@ -41,6 +46,9 @@ _IDEMPOTENT_ERROR_CODES = frozenset({"conflict", "not_found"})
 
 # Per-operation error codes treated as retriable failures
 _RETRIABLE_ERROR_CODES = frozenset({"service_unavailable"})
+
+# Pattern for validating Profile_User_ID format
+_PROFILE_USER_ID_PATTERN = re.compile(r"^Registry\d{6}@naccdata\.org$")
 
 
 class AuthorizationClient:
@@ -81,6 +89,28 @@ class AuthorizationClient:
         if self._sleep is not None:
             kwargs["sleep"] = self._sleep
         return kwargs
+
+    def _validate_profile_user_id(self, profile_user_id: str | None) -> None:
+        """Validate a Profile User ID format.
+
+        Args:
+            profile_user_id: The ID to validate.
+
+        Raises:
+            ValidationError: If the ID is None, empty, or doesn't match
+                the expected pattern.
+        """
+        if not profile_user_id:
+            raise ValidationError(
+                message="A non-empty Profile_User_ID is required",
+            )
+        if not _PROFILE_USER_ID_PATTERN.match(profile_user_id):
+            raise ValidationError(
+                message=(
+                    f"Invalid Profile_User_ID '{profile_user_id}'. "
+                    f"Expected format: RegistryNNNNNN@naccdata.org"
+                ),
+            )
 
     def grant(
         self,
@@ -590,6 +620,305 @@ class AuthorizationClient:
         error_msg = self._extract_error_message(response)
         log.error(
             "Set resource parents unexpected error %d: %s",
+            response.status_code,
+            error_msg,
+        )
+        raise UnexpectedError(
+            status_code=response.status_code,
+            message=error_msg,
+        )
+
+    def put_user_profile(
+        self,
+        profile_user_id: str,
+        request: UserProfileRequest,
+    ) -> UserProfile:
+        """Create or update a user profile.
+
+        Sends a PUT request to /users/{profileUserId} with the profile
+        data serialized as JSON.
+
+        Args:
+            profile_user_id: The profile user ID
+                (RegistryNNNNNN@naccdata.org).
+            request: The profile data to set.
+
+        Returns:
+            The created/updated UserProfile.
+
+        Raises:
+            ValidationError: If profile_user_id is invalid or API
+                returns 400.
+            ServiceUnavailableError: If retries exhausted on 503.
+            UnexpectedError: On other unexpected HTTP errors.
+            ParseError: If the response body cannot be parsed.
+        """
+        self._validate_profile_user_id(profile_user_id)
+
+        body = request.model_dump_json(by_alias=True).encode()
+        path = f"/users/{profile_user_id}"
+
+        def do_request() -> HttpResponse:
+            return self._transport.request(
+                method="PUT",
+                path=path,
+                body=body,
+            )
+
+        response = retry_on_503(do_request, **self._retry_kwargs())
+
+        if response.status_code == 200:
+            log.debug(
+                "Put user profile succeeded: profile_user_id=%s",
+                profile_user_id,
+            )
+            try:
+                return UserProfile.model_validate_json(response.body)
+            except Exception as exc:
+                raise ParseError(
+                    message=(f"Failed to parse put user profile response: {exc}"),
+                    raw_content=response.body,
+                ) from exc
+
+        if response.status_code == 400:
+            error_resp = self._parse_error_response(response)
+            log.error(
+                "Put user profile validation error: %s",
+                error_resp.message,
+            )
+            raise ValidationError(
+                message=error_resp.message,
+                details=error_resp.details,
+            )
+
+        # Any other error status
+        error_msg = self._extract_error_message(response)
+        log.error(
+            "Put user profile unexpected error %d: %s",
+            response.status_code,
+            error_msg,
+        )
+        raise UnexpectedError(
+            status_code=response.status_code,
+            message=error_msg,
+        )
+
+    def delete_user_profile(self, profile_user_id: str) -> None:
+        """Delete a user profile. Returns None on 204 or 404 (idempotent).
+
+        Sends a DELETE request to /users/{profileUserId}.
+
+        Args:
+            profile_user_id: The profile user ID
+                (RegistryNNNNNN@naccdata.org).
+
+        Returns:
+            None on successful deletion or if already deleted.
+
+        Raises:
+            ValidationError: If profile_user_id is invalid or API
+                returns 400.
+            ServiceUnavailableError: If retries exhausted on 503.
+            UnexpectedError: On other unexpected HTTP errors.
+        """
+        self._validate_profile_user_id(profile_user_id)
+
+        path = f"/users/{profile_user_id}"
+
+        def do_request() -> HttpResponse:
+            return self._transport.request(
+                method="DELETE",
+                path=path,
+                body=None,
+            )
+
+        response = retry_on_503(do_request, **self._retry_kwargs())
+
+        if response.status_code == 204:
+            log.debug(
+                "Delete user profile succeeded: profile_user_id=%s",
+                profile_user_id,
+            )
+            return None
+
+        if response.status_code == 404:
+            log.debug(
+                "Delete user profile not found (idempotent): profile_user_id=%s",
+                profile_user_id,
+            )
+            return None
+
+        if response.status_code == 400:
+            error_resp = self._parse_error_response(response)
+            log.error(
+                "Delete user profile validation error: %s",
+                error_resp.message,
+            )
+            raise ValidationError(
+                message=error_resp.message,
+                details=error_resp.details,
+            )
+
+        # Any other error status
+        error_msg = self._extract_error_message(response)
+        log.error(
+            "Delete user profile unexpected error %d: %s",
+            response.status_code,
+            error_msg,
+        )
+        raise UnexpectedError(
+            status_code=response.status_code,
+            message=error_msg,
+        )
+
+    def get_user_profile(self, profile_user_id: str) -> UserProfile:
+        """Get a user profile.
+
+        Sends a GET request to /users/{profileUserId} and returns the
+        parsed profile.
+
+        Args:
+            profile_user_id: The profile user ID
+                (RegistryNNNNNN@naccdata.org).
+
+        Returns:
+            The UserProfile for the given ID.
+
+        Raises:
+            ValidationError: If profile_user_id is invalid or API
+                returns 400.
+            NotFoundError: If the profile does not exist (404).
+            ServiceUnavailableError: If retries exhausted on 503.
+            UnexpectedError: On other unexpected HTTP errors.
+            ParseError: If the response body cannot be parsed.
+        """
+        self._validate_profile_user_id(profile_user_id)
+
+        path = f"/users/{profile_user_id}"
+
+        def do_request() -> HttpResponse:
+            return self._transport.request(
+                method="GET",
+                path=path,
+                body=None,
+            )
+
+        response = retry_on_503(do_request, **self._retry_kwargs())
+
+        if response.status_code == 200:
+            log.debug(
+                "Get user profile succeeded: profile_user_id=%s",
+                profile_user_id,
+            )
+            try:
+                return UserProfile.model_validate_json(response.body)
+            except Exception as exc:
+                raise ParseError(
+                    message=(f"Failed to parse get user profile response: {exc}"),
+                    raw_content=response.body,
+                ) from exc
+
+        if response.status_code == 404:
+            log.debug(
+                "User profile not found: profile_user_id=%s",
+                profile_user_id,
+            )
+            raise NotFoundError(
+                message=f"User profile not found: {profile_user_id}",
+            )
+
+        if response.status_code == 400:
+            error_resp = self._parse_error_response(response)
+            log.error(
+                "Get user profile validation error: %s",
+                error_resp.message,
+            )
+            raise ValidationError(
+                message=error_resp.message,
+                details=error_resp.details,
+            )
+
+        # Any other error status
+        error_msg = self._extract_error_message(response)
+        log.error(
+            "Get user profile unexpected error %d: %s",
+            response.status_code,
+            error_msg,
+        )
+        raise UnexpectedError(
+            status_code=response.status_code,
+            message=error_msg,
+        )
+
+    def get_user_profiles(
+        self,
+        profile_user_ids: list[str],
+    ) -> list[UserProfile]:
+        """Get multiple user profiles by ID.
+
+        Sends a GET request to /users?ids=id1,id2,... with the IDs
+        joined as a comma-separated query parameter.
+
+        Args:
+            profile_user_ids: List of profile user IDs to retrieve.
+
+        Returns:
+            List of UserProfile models.
+
+        Raises:
+            ValidationError: If any ID is invalid or API returns 400.
+            ServiceUnavailableError: If retries exhausted on 503.
+            UnexpectedError: On other unexpected HTTP errors.
+            ParseError: If the response body cannot be parsed.
+        """
+        for profile_user_id in profile_user_ids:
+            self._validate_profile_user_id(profile_user_id)
+
+        if not profile_user_ids:
+            return []
+
+        path = "/users"
+        ids_param = ",".join(profile_user_ids)
+
+        def do_request() -> HttpResponse:
+            return self._transport.request(
+                method="GET",
+                path=path,
+                body=None,
+                query_params={"ids": ids_param},
+            )
+
+        response = retry_on_503(do_request, **self._retry_kwargs())
+
+        if response.status_code == 200:
+            log.debug(
+                "Get user profiles succeeded: count=%d",
+                len(profile_user_ids),
+            )
+            try:
+                result = UserProfileList.model_validate_json(response.body)
+                return result.users
+            except Exception as exc:
+                raise ParseError(
+                    message=(f"Failed to parse get user profiles response: {exc}"),
+                    raw_content=response.body,
+                ) from exc
+
+        if response.status_code == 400:
+            error_resp = self._parse_error_response(response)
+            log.error(
+                "Get user profiles validation error: %s",
+                error_resp.message,
+            )
+            raise ValidationError(
+                message=error_resp.message,
+                details=error_resp.details,
+            )
+
+        # Any other error status
+        error_msg = self._extract_error_message(response)
+        log.error(
+            "Get user profiles unexpected error %d: %s",
             response.status_code,
             error_msg,
         )

--- a/common/src/python/authorization/exceptions.py
+++ b/common/src/python/authorization/exceptions.py
@@ -22,6 +22,14 @@ class ServiceUnavailableError(AuthorizationClientError):
     """Raised when retries are exhausted on 503."""
 
 
+class NotFoundError(AuthorizationClientError):
+    """Raised when the API returns 404 (resource not found)."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.message = message
+
+
 class UnexpectedError(AuthorizationClientError):
     """Raised on unexpected HTTP errors (non-retriable 4xx/5xx)."""
 

--- a/common/src/python/authorization/models.py
+++ b/common/src/python/authorization/models.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Callable, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 # --- Request Models ---
 
@@ -210,6 +210,51 @@ class ErrorResponse(BaseModel):
     error: str
     message: str
     details: dict | None = None
+
+
+# --- User Profile Models ---
+
+
+class UserProfileRequest(BaseModel):
+    """Request model for creating or updating a user profile."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    first_name: str = Field(alias="firstName", min_length=1, max_length=256)
+    last_name: str = Field(alias="lastName", min_length=1, max_length=256)
+    email: str | None = Field(default=None, alias="email")
+    auth_email: str = Field(alias="authEmail", min_length=1, max_length=256)
+    active: bool | None = Field(default=None, alias="active")
+
+    @field_validator("first_name", "last_name")
+    @classmethod
+    def must_contain_non_whitespace(cls, v: str) -> str:
+        """Validate that name fields contain at least one non-whitespace
+        character."""
+        if not v.strip():
+            raise ValueError("must contain at least one non-whitespace character")
+        return v
+
+
+class UserProfile(BaseModel):
+    """Response model for a user profile."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    user_id: str = Field(alias="userId")
+    first_name: str = Field(alias="firstName")
+    last_name: str = Field(alias="lastName")
+    email: str | None = Field(default=None)
+    auth_email: str = Field(alias="authEmail")
+    active: bool
+
+
+class UserProfileList(BaseModel):
+    """Response model for batch user profile retrieval."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    users: list[UserProfile]
 
 
 # --- Domain Types ---

--- a/common/src/python/authorization_sync/sync_service.py
+++ b/common/src/python/authorization_sync/sync_service.py
@@ -5,7 +5,13 @@ import logging
 from typing import Protocol
 
 from authorization.exceptions import AuthorizationClientError
-from authorization.models import BatchOperation, BatchResult, UserPermissions
+from authorization.models import (
+    BatchOperation,
+    BatchResult,
+    UserPermissions,
+    UserProfile,
+    UserProfileRequest,
+)
 from users.authorizations import Authorizations
 from users.event_models import (
     EventCategory,
@@ -14,6 +20,7 @@ from users.event_models import (
     UserEventCollector,
     UserProcessEvent,
 )
+from users.user_entry import UserEntry
 
 from authorization_sync.models import DesiredGrant
 from authorization_sync.translator import translate
@@ -35,6 +42,12 @@ class AuthorizationClientProtocol(Protocol):
         self,
         operations: list[BatchOperation],
     ) -> BatchResult: ...
+
+    def put_user_profile(
+        self,
+        profile_user_id: str,
+        request: UserProfileRequest,
+    ) -> UserProfile: ...
 
 
 class AuthorizationSyncService:
@@ -121,6 +134,47 @@ class AuthorizationSyncService:
                 error,
             )
             self._report_failure(registry_id, "sync", error)
+
+    def sync_profile(
+        self,
+        registry_id: str,
+        user_entry: UserEntry,
+    ) -> None:
+        """Push a user profile to the Authorization API.
+
+        Constructs a UserProfileRequest from the user entry fields and
+        calls put_user_profile. Catches AuthorizationClientError and
+        reports via the event collector without raising.
+
+        Skips sync if user_entry.auth_email is None (logs warning).
+
+        Args:
+            registry_id: The user's registry ID (used as Profile_User_ID).
+            user_entry: The user entry containing profile data.
+        """
+        if user_entry.auth_email is None:
+            log.warning(
+                "Skipping profile sync for user %s: auth_email is None",
+                user_entry.email,
+            )
+            return
+
+        try:
+            request = UserProfileRequest(
+                first_name=user_entry.first_name,
+                last_name=user_entry.last_name,
+                email=user_entry.email,
+                auth_email=user_entry.auth_email,
+                active=user_entry.active,
+            )
+            self._client.put_user_profile(registry_id, request)
+        except AuthorizationClientError as error:
+            log.error(
+                "Profile sync failed for user %s: %s",
+                registry_id,
+                error,
+            )
+            self._report_failure(registry_id, "profile_sync", error)
 
     def _report_failure(
         self,

--- a/common/src/python/users/user_processes.py
+++ b/common/src/python/users/user_processes.py
@@ -1,8 +1,13 @@
+from __future__ import annotations
+
 import logging
 from abc import ABC, abstractmethod
 from collections import defaultdict, deque
 from datetime import datetime
-from typing import Dict, Generic, List, Optional, TypeVar
+from typing import TYPE_CHECKING, Dict, Generic, List, Optional, TypeVar
+
+if TYPE_CHECKING:
+    from authorization_sync.sync_service import AuthorizationSyncService
 
 from centers.center_group import CenterError, CenterGroup
 from coreapi_client.models.identifier import Identifier
@@ -32,6 +37,36 @@ from users.user_registry import DomainCandidate, RegistryError, RegistryPerson
 log = logging.getLogger(__name__)
 
 T = TypeVar("T")
+
+
+def _try_sync_profile(
+    sync_service: "AuthorizationSyncService",
+    registry_id: str,
+    user_entry: UserEntry,
+) -> None:
+    """Attempt to sync a user profile, logging errors without propagating.
+
+    This is a fault-isolation wrapper around sync_service.sync_profile.
+    Expected API failures are handled inside sync_profile via the event
+    collector. This wrapper catches unexpected programming errors
+    (TypeError, KeyError, etc.) so they don't disrupt the calling workflow.
+
+    Args:
+        sync_service: The authorization sync service.
+        registry_id: The user's registry ID (ePPN).
+        user_entry: The user entry containing profile data.
+    """
+    try:
+        sync_service.sync_profile(
+            registry_id=registry_id,
+            user_entry=user_entry,
+        )
+    except Exception as error:
+        log.error(
+            "Profile sync failed for user %s: %s",
+            registry_id,
+            error,
+        )
 
 
 class BaseUserProcess(ABC, Generic[T]):
@@ -433,6 +468,31 @@ class InactiveUserProcess(BaseUserProcess[UserEntry]):
                 )
                 self.collector.collect(error_event)
 
+    def __sync_inactive_profile(
+        self,
+        entry: UserEntry,
+        person_list: Optional[list[RegistryPerson]],
+    ) -> None:
+        """Sync the inactive user's profile to the Authorization API.
+
+        Resolves the registry_id from the person_list and calls
+        sync_profile. Wrapped in try/except for fault isolation.
+
+        Args:
+            entry: The inactive user entry
+            person_list: The list of registry persons from COmanage lookup
+        """
+        registry_id: Optional[str] = None
+        if person_list:
+            first_person = person_list[0]
+            registry_id = first_person.registry_id()
+        if not registry_id:
+            return
+
+        sync_service = self.__env.authorization_sync
+        if sync_service is not None:
+            _try_sync_profile(sync_service, registry_id, entry)
+
     def visit(self, entry: UserEntry) -> None:
         """Visit method for an inactive user entry.
 
@@ -485,6 +545,9 @@ class InactiveUserProcess(BaseUserProcess[UserEntry]):
                 error,
                 exc_info=True,
             )
+
+        # Profile sync (mark inactive)
+        self.__sync_inactive_profile(entry, person_list)
 
         # Step 3: REDCap role removal
         try:
@@ -623,6 +686,7 @@ class UpdateCenterUserProcess(BaseUserProcess[CenterUserEntry]):
             center_id=entry.adcid,
             authorizations=authorizations,
             registry_id=registry_id,
+            entry=entry,
         )
 
     def __authorize_user(
@@ -633,6 +697,7 @@ class UpdateCenterUserProcess(BaseUserProcess[CenterUserEntry]):
         center_id: int,
         authorizations: dict[str, StudyAuthorizations],
         registry_id: str,
+        entry: CenterUserEntry,
     ) -> None:
         """Adds authorizations to the user.
 
@@ -644,6 +709,7 @@ class UpdateCenterUserProcess(BaseUserProcess[CenterUserEntry]):
         center_id: the center of the user
         authorizations: list of authorizations
         registry_id: the user's registry ID (ePPN)
+        entry: the center user entry for profile sync
         """
         center_group = self.__env.admin_group.get_center(center_id)
         if not center_group:
@@ -690,6 +756,8 @@ class UpdateCenterUserProcess(BaseUserProcess[CenterUserEntry]):
                     )
                     # Fault isolation: sync failure must not affect
                     # Flywheel role assignment
+
+            _try_sync_profile(sync_service, registry_id, entry)
 
     def execute(self, queue: UserQueue[CenterUserEntry]) -> None:
         log.info("**Processing center users")
@@ -756,6 +824,7 @@ class UpdateUserProcess(BaseUserProcess[ActiveUserEntry]):
             email=entry.email,
             authorizations=entry.authorizations,
             registry_id=registry_id,
+            entry=entry,
         )
         self.__update_email(user=fw_user, email=entry.email)
 
@@ -769,6 +838,7 @@ class UpdateUserProcess(BaseUserProcess[ActiveUserEntry]):
         email: str,
         authorizations: Authorizations,
         registry_id: str,
+        entry: ActiveUserEntry,
     ) -> None:
         """Applies authorizations to give access to general resources.
 
@@ -782,6 +852,7 @@ class UpdateUserProcess(BaseUserProcess[ActiveUserEntry]):
             email: The user's email address
             authorizations: The general authorizations containing activities
             registry_id: The user's registry ID (ePPN) for authorization sync
+            entry: The active user entry for profile sync
         """
         # Apply Flywheel role assignment via GeneralAuthorizationVisitor
         if authorizations.activities:
@@ -833,6 +904,8 @@ class UpdateUserProcess(BaseUserProcess[ActiveUserEntry]):
                 )
                 # Fault isolation: sync failure must not affect
                 # Flywheel role assignment or downstream processing
+
+            _try_sync_profile(sync_service, registry_id, entry)
 
     def __update_email(self, *, user: User, email: str) -> None:
         """Updates user email on FW instance if email is different.

--- a/common/test/python/authorization_sync_test/conftest.py
+++ b/common/test/python/authorization_sync_test/conftest.py
@@ -16,6 +16,8 @@ from authorization.models import (
     BatchResult,
     PermissionEntry,
     UserPermissions,
+    UserProfile,
+    UserProfileRequest,
 )
 from authorization_sync.models import DesiredGrant
 from hypothesis import strategies as st
@@ -287,6 +289,7 @@ class MockAuthorizationClient:
     # Call tracking
     get_user_permissions_calls: list[dict] = field(default_factory=list)
     batch_calls: list[list[BatchOperation]] = field(default_factory=list)
+    put_user_profile_calls: list[dict] = field(default_factory=list)
 
     def get_user_permissions(
         self,
@@ -318,6 +321,26 @@ class MockAuthorizationClient:
             succeeded=len(operations),
             failed=0,
             errors=[],
+        )
+
+    def put_user_profile(
+        self,
+        profile_user_id: str,
+        request: UserProfileRequest,
+    ) -> UserProfile:
+        """Mock put_user_profile that returns a default profile."""
+        self.put_user_profile_calls.append(
+            {"profile_user_id": profile_user_id, "request": request}
+        )
+        if self.error_to_raise is not None:
+            raise self.error_to_raise
+        return UserProfile(
+            user_id=profile_user_id,
+            first_name=request.first_name,
+            last_name=request.last_name,
+            email=request.email,
+            auth_email=request.auth_email,
+            active=request.active if request.active is not None else True,
         )
 
 

--- a/common/test/python/authorization_sync_test/test_fault_isolation.py
+++ b/common/test/python/authorization_sync_test/test_fault_isolation.py
@@ -11,6 +11,8 @@ from authorization.models import (
     BatchOperation,
     BatchResult,
     UserPermissions,
+    UserProfile,
+    UserProfileRequest,
 )
 from authorization_sync.sync_service import AuthorizationSyncService
 from authorization_sync_test.conftest import (
@@ -55,6 +57,21 @@ class PartialFailureClient:
         """Return the configured partial failure result."""
         self.batch_calls.append(operations)
         return self.batch_result
+
+    def put_user_profile(
+        self,
+        profile_user_id: str,
+        request: UserProfileRequest,
+    ) -> UserProfile:
+        """Mock put_user_profile that returns a default profile."""
+        return UserProfile(
+            user_id=profile_user_id,
+            first_name="Test",
+            last_name="User",
+            email=None,
+            auth_email="test@example.com",
+            active=True,
+        )
 
 
 @st.composite

--- a/common/test/python/authorization_sync_test/test_sync_profile.py
+++ b/common/test/python/authorization_sync_test/test_sync_profile.py
@@ -1,0 +1,206 @@
+"""Unit tests for AuthorizationSyncService.sync_profile.
+
+Tests cover:
+- Skipping sync when auth_email is None (with warning log)
+- Reporting errors via event collector on AuthorizationClientError
+- Completing successfully when API returns 200
+
+Requirements: 3.4, 3.5, 6.3
+"""
+
+import logging
+
+import pytest
+from authorization.exceptions import ServiceUnavailableError
+from authorization_sync.sync_service import AuthorizationSyncService
+from authorization_sync_test.conftest import MockAuthorizationClient
+from users.event_models import (
+    EventCategory,
+    EventType,
+    UserEventCollector,
+)
+from users.user_entry import PersonName, UserEntry
+
+
+class TestSyncProfileSkipsWhenAuthEmailIsNone:
+    """Test that sync_profile skips when auth_email is None.
+
+    Validates: Requirement 3.4
+    """
+
+    def test_no_put_user_profile_call_when_auth_email_is_none(self) -> None:
+        """sync_profile does not call put_user_profile when auth_email is
+        None."""
+        client = MockAuthorizationClient()
+        collector = UserEventCollector()
+        service = AuthorizationSyncService(client=client, collector=collector)
+
+        entry = UserEntry(
+            name=PersonName(first_name="Jane", last_name="Doe"),
+            email="jane@example.com",
+            auth_email=None,
+            active=True,
+            approved=True,
+        )
+
+        service.sync_profile(
+            registry_id="Registry000001@naccdata.org",
+            user_entry=entry,
+        )
+
+        # put_user_profile should not have been called
+        assert len(client.put_user_profile_calls) == 0
+        # No error events should be reported
+        assert not collector.has_errors()
+
+    def test_logs_warning_when_auth_email_is_none(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """sync_profile logs a warning when auth_email is None."""
+        client = MockAuthorizationClient()
+        collector = UserEventCollector()
+        service = AuthorizationSyncService(client=client, collector=collector)
+
+        entry = UserEntry(
+            name=PersonName(first_name="Jane", last_name="Doe"),
+            email="jane@example.com",
+            auth_email=None,
+            active=True,
+            approved=True,
+        )
+
+        with caplog.at_level(logging.WARNING):
+            service.sync_profile(
+                registry_id="Registry000001@naccdata.org",
+                user_entry=entry,
+            )
+
+        # Should log a warning mentioning the user email and skipping
+        assert any(
+            "jane@example.com" in record.message and "auth_email" in record.message
+            for record in caplog.records
+            if record.levelno == logging.WARNING
+        )
+
+
+class TestSyncProfileReportsErrorOnClientError:
+    """Test that sync_profile reports errors via event collector.
+
+    Validates: Requirement 3.5
+    """
+
+    def test_reports_error_via_event_collector(self) -> None:
+        """sync_profile catches AuthorizationClientError and reports via event
+        collector."""
+        error = ServiceUnavailableError("Service unavailable after retries")
+        client = MockAuthorizationClient(error_to_raise=error)
+        collector = UserEventCollector()
+        service = AuthorizationSyncService(client=client, collector=collector)
+
+        entry = UserEntry(
+            name=PersonName(first_name="John", last_name="Smith"),
+            email="john@example.com",
+            auth_email="john@university.edu",
+            active=True,
+            approved=True,
+        )
+
+        # Should not raise
+        service.sync_profile(
+            registry_id="Registry000002@naccdata.org",
+            user_entry=entry,
+        )
+
+        # Should have reported an error event
+        assert collector.has_errors()
+        errors = collector.get_errors()
+        assert len(errors) == 1
+
+        event = errors[0]
+        assert event.event_type == EventType.ERROR.value
+        assert event.category == EventCategory.AUTHORIZATION_SYNC.value
+        assert event.user_context.registry_id == "Registry000002@naccdata.org"
+        assert "profile_sync" in event.message
+
+    def test_does_not_propagate_exception(self) -> None:
+        """sync_profile does not raise AuthorizationClientError."""
+        error = ServiceUnavailableError("Service unavailable after retries")
+        client = MockAuthorizationClient(error_to_raise=error)
+        collector = UserEventCollector()
+        service = AuthorizationSyncService(client=client, collector=collector)
+
+        entry = UserEntry(
+            name=PersonName(first_name="John", last_name="Smith"),
+            email="john@example.com",
+            auth_email="john@university.edu",
+            active=True,
+            approved=True,
+        )
+
+        # Should complete without raising
+        service.sync_profile(
+            registry_id="Registry000002@naccdata.org",
+            user_entry=entry,
+        )
+
+
+class TestSyncProfileCompletesSuccessfully:
+    """Test that sync_profile completes without error on success.
+
+    Validates: Requirement 6.3
+    """
+
+    def test_completes_without_error_when_api_returns_200(self) -> None:
+        """sync_profile completes successfully when client returns normally."""
+        client = MockAuthorizationClient()
+        collector = UserEventCollector()
+        service = AuthorizationSyncService(client=client, collector=collector)
+
+        entry = UserEntry(
+            name=PersonName(first_name="Alice", last_name="Johnson"),
+            email="alice@example.com",
+            auth_email="alice@university.edu",
+            active=True,
+            approved=True,
+        )
+
+        # Should complete without raising
+        service.sync_profile(
+            registry_id="Registry000003@naccdata.org",
+            user_entry=entry,
+        )
+
+        # No errors should be reported
+        assert not collector.has_errors()
+        assert not collector.has_events()
+
+    def test_constructs_request_from_user_entry_fields(self) -> None:
+        """sync_profile builds UserProfileRequest with correct field
+        mapping."""
+        client = MockAuthorizationClient()
+        collector = UserEventCollector()
+        service = AuthorizationSyncService(client=client, collector=collector)
+
+        entry = UserEntry(
+            name=PersonName(first_name="Alice", last_name="Johnson"),
+            email="alice@example.com",
+            auth_email="alice@university.edu",
+            active=False,
+            approved=True,
+        )
+
+        service.sync_profile(
+            registry_id="Registry000003@naccdata.org",
+            user_entry=entry,
+        )
+
+        assert len(client.put_user_profile_calls) == 1
+        call = client.put_user_profile_calls[0]
+        assert call["profile_user_id"] == "Registry000003@naccdata.org"
+
+        request = call["request"]
+        assert request.first_name == "Alice"
+        assert request.last_name == "Johnson"
+        assert request.email == "alice@example.com"
+        assert request.auth_email == "alice@university.edu"
+        assert request.active is False

--- a/common/test/python/authorization_test/test_client_profile.py
+++ b/common/test/python/authorization_test/test_client_profile.py
@@ -1,0 +1,144 @@
+"""Unit tests for AuthorizationClient user profile methods."""
+
+import json
+
+import pytest
+from authorization.client import AuthorizationClient
+from authorization.exceptions import NotFoundError
+from authorization.models import UserProfile, UserProfileRequest
+
+from .conftest import MockResponse, MockTransport, no_sleep
+
+
+class TestPutUserProfile:
+    """Tests for the put_user_profile method."""
+
+    def test_put_user_profile_returns_parsed_user_profile_on_200(self) -> None:
+        """Verify put_user_profile returns a parsed UserProfile on 200.
+
+        Validates: Requirements 1.5
+        """
+        response_body = json.dumps(
+            {
+                "userId": "Registry000001@naccdata.org",
+                "firstName": "Alice",
+                "lastName": "Smith",
+                "email": "alice@example.com",
+                "authEmail": "alice@institution.edu",
+                "active": True,
+            }
+        ).encode()
+        transport = MockTransport(MockResponse(status_code=200, body=response_body))
+        client = AuthorizationClient(transport=transport, sleep=no_sleep)
+
+        request = UserProfileRequest(
+            first_name="Alice",
+            last_name="Smith",
+            email="alice@example.com",
+            auth_email="alice@institution.edu",
+            active=True,
+        )
+        result = client.put_user_profile(
+            profile_user_id="Registry000001@naccdata.org",
+            request=request,
+        )
+
+        assert isinstance(result, UserProfile)
+        assert result.user_id == "Registry000001@naccdata.org"
+        assert result.first_name == "Alice"
+        assert result.last_name == "Smith"
+        assert result.email == "alice@example.com"
+        assert result.auth_email == "alice@institution.edu"
+        assert result.active is True
+
+
+class TestGetUserProfile:
+    """Tests for the get_user_profile method."""
+
+    def test_get_user_profile_raises_not_found_error_on_404(self) -> None:
+        """Verify get_user_profile raises NotFoundError on 404.
+
+        Validates: Requirements 1.7
+        """
+        transport = MockTransport(MockResponse(status_code=404, body=b""))
+        client = AuthorizationClient(transport=transport, sleep=no_sleep)
+
+        with pytest.raises(NotFoundError) as exc_info:
+            client.get_user_profile(
+                profile_user_id="Registry000001@naccdata.org",
+            )
+
+        assert "Registry000001@naccdata.org" in exc_info.value.message
+
+
+class TestDeleteUserProfile:
+    """Tests for the delete_user_profile method."""
+
+    def test_delete_user_profile_returns_none_on_204(self) -> None:
+        """Verify delete_user_profile returns None on 204.
+
+        Validates: Requirements 1.8
+        """
+        transport = MockTransport(MockResponse(status_code=204, body=b""))
+        client = AuthorizationClient(transport=transport, sleep=no_sleep)
+
+        # delete_user_profile returns None; just verify no exception
+        client.delete_user_profile(
+            profile_user_id="Registry000001@naccdata.org",
+        )
+
+    def test_delete_user_profile_returns_none_on_404(self) -> None:
+        """Verify delete_user_profile returns None on 404 (idempotent).
+
+        Validates: Requirements 1.9
+        """
+        transport = MockTransport(MockResponse(status_code=404, body=b""))
+        client = AuthorizationClient(transport=transport, sleep=no_sleep)
+
+        # delete_user_profile returns None; just verify no exception
+        client.delete_user_profile(
+            profile_user_id="Registry000001@naccdata.org",
+        )
+
+
+class TestRetryOn503:
+    """Tests for retry-on-503 integration with profile methods."""
+
+    def test_put_user_profile_retries_on_503_then_succeeds(self) -> None:
+        """Verify put_user_profile retries on 503 and succeeds on 200.
+
+        Validates: Requirements 1.10
+        """
+        success_body = json.dumps(
+            {
+                "userId": "Registry000001@naccdata.org",
+                "firstName": "Bob",
+                "lastName": "Jones",
+                "email": None,
+                "authEmail": "bob@institution.edu",
+                "active": True,
+            }
+        ).encode()
+        responses = [
+            MockResponse(status_code=503, body=b""),
+            MockResponse(status_code=200, body=success_body),
+        ]
+        transport = MockTransport(responses)
+        client = AuthorizationClient(transport=transport, max_retries=3, sleep=no_sleep)
+
+        request = UserProfileRequest(
+            first_name="Bob",
+            last_name="Jones",
+            auth_email="bob@institution.edu",
+            active=True,
+        )
+        result = client.put_user_profile(
+            profile_user_id="Registry000001@naccdata.org",
+            request=request,
+        )
+
+        assert isinstance(result, UserProfile)
+        assert result.user_id == "Registry000001@naccdata.org"
+        assert result.first_name == "Bob"
+        # Initial request + 1 retry = 2 total
+        assert len(transport.requests) == 2

--- a/common/test/python/user_test/test_profile_sync_integration.py
+++ b/common/test/python/user_test/test_profile_sync_integration.py
@@ -1,0 +1,237 @@
+"""Integration tests for profile sync in user processes.
+
+Tests fault isolation between profile sync and grant sync, and verifies
+that InactiveUserProcess continues remaining steps after profile sync failure.
+
+Validates: Requirements 3.6, 4.3, 4.4
+"""
+
+import logging
+from unittest.mock import Mock
+
+from centers.center_info import CenterMapInfo
+from flywheel.models.user import User
+from flywheel_adaptor.flywheel_proxy import FlywheelProxy
+from users.authorizations import Authorizations
+from users.event_models import UserEventCollector
+from users.user_entry import ActiveUserEntry, PersonName, UserEntry
+from users.user_process_environment import UserProcessEnvironment
+from users.user_processes import InactiveUserProcess, UpdateUserProcess
+from users.user_registry import RegistryPerson, UserRegistry
+
+
+def _build_mock_env(
+    *,
+    authorization_sync: Mock | None = None,
+) -> Mock:
+    """Build a mock UserProcessEnvironment with sensible defaults."""
+    mock_env = Mock(spec=UserProcessEnvironment)
+    mock_env.proxy = Mock(spec=FlywheelProxy)
+    mock_env.proxy.dry_run = False
+    mock_env.proxy.find_user_by_email.return_value = []
+    mock_env.user_registry = Mock(spec=UserRegistry)
+    mock_env.user_registry.get.return_value = []
+    mock_env.admin_group = Mock()
+    mock_env.admin_group.get_center_map.return_value = CenterMapInfo(centers={})
+    mock_env.authorization_map = Mock()
+    mock_env.authorization_sync = authorization_sync
+    mock_env.notification_client = Mock()
+    mock_env.find_user = Mock(return_value=None)
+    return mock_env
+
+
+def _build_registry_person(
+    registry_id: str = "Registry000001@naccdata.org",
+    suspended: bool = False,
+) -> Mock:
+    """Build a mock RegistryPerson."""
+    person = Mock(spec=RegistryPerson)
+    person.registry_id.return_value = registry_id
+    person.is_suspended.return_value = suspended
+    person.is_claimed.return_value = True
+    person.creation_date = "2024-01-01"
+    person.email_address = Mock()
+    person.email_address.mail = "user@example.com"
+    return person
+
+
+def _build_active_entry() -> ActiveUserEntry:
+    """Build an ActiveUserEntry for testing."""
+    entry = ActiveUserEntry(
+        name=PersonName(first_name="John", last_name="Doe"),
+        email="john.doe@example.com",
+        auth_email="john.auth@example.com",
+        active=True,
+        approved=True,
+        authorizations=Authorizations(),
+    )
+    person = _build_registry_person()
+    entry.register(person)
+    return entry
+
+
+def _build_inactive_entry() -> UserEntry:
+    """Build an inactive UserEntry for testing."""
+    return UserEntry(
+        name=PersonName(first_name="Jane", last_name="Smith"),
+        email="jane.smith@example.com",
+        auth_email="jane.auth@example.com",
+        active=False,
+        approved=True,
+    )
+
+
+class TestUpdateUserProcessFaultIsolation:
+    """Tests that profile sync and grant sync are independent in
+    UpdateUserProcess."""
+
+    def test_profile_sync_failure_does_not_block_grant_sync(self, caplog) -> None:
+        """Profile sync failure does not prevent grant sync from completing.
+
+        Validates: Requirements 3.6
+        """
+        mock_sync = Mock()
+        # grant sync succeeds
+        mock_sync.sync_user.return_value = None
+        # profile sync fails
+        mock_sync.sync_profile.side_effect = Exception("Profile API down")
+
+        mock_env = _build_mock_env(authorization_sync=mock_sync)
+
+        entry = _build_active_entry()
+        fw_user = Mock(spec=User)
+        fw_user.id = "Registry000001@naccdata.org"
+        fw_user.email = "john.doe@example.com"
+        mock_env.find_user.return_value = fw_user
+
+        collector = UserEventCollector()
+        process = UpdateUserProcess(mock_env, collector)
+
+        with caplog.at_level(logging.ERROR):
+            process.visit(entry)
+
+        # Grant sync was called and completed successfully
+        mock_sync.sync_user.assert_called_once()
+        # Profile sync was attempted (and failed)
+        mock_sync.sync_profile.assert_called_once()
+        # Error was logged but did not propagate
+        assert "Profile sync failed" in caplog.text
+
+    def test_grant_sync_failure_does_not_block_profile_sync(self, caplog) -> None:
+        """Grant sync failure does not prevent profile sync from completing.
+
+        Validates: Requirements 3.6
+        """
+        mock_sync = Mock()
+        # grant sync fails
+        mock_sync.sync_user.side_effect = Exception("Grant API down")
+        # profile sync succeeds
+        mock_sync.sync_profile.return_value = None
+
+        mock_env = _build_mock_env(authorization_sync=mock_sync)
+
+        entry = _build_active_entry()
+        fw_user = Mock(spec=User)
+        fw_user.id = "Registry000001@naccdata.org"
+        fw_user.email = "john.doe@example.com"
+        mock_env.find_user.return_value = fw_user
+
+        collector = UserEventCollector()
+        process = UpdateUserProcess(mock_env, collector)
+
+        with caplog.at_level(logging.ERROR):
+            process.visit(entry)
+
+        # Grant sync was attempted (and failed)
+        mock_sync.sync_user.assert_called_once()
+        # Profile sync was still called and completed
+        mock_sync.sync_profile.assert_called_once()
+        # Error was logged but did not propagate
+        assert "Authorization sync failed" in caplog.text
+
+
+class TestInactiveUserProcessProfileSync:
+    """Tests for profile sync integration in InactiveUserProcess."""
+
+    def test_continues_remaining_steps_after_profile_sync_failure(self, caplog) -> None:
+        """InactiveUserProcess continues with REDCap disable and COmanage
+        suspend after profile sync failure.
+
+        Validates: Requirements 4.3, 4.4
+        """
+        mock_sync = Mock()
+        mock_sync.sync_profile.side_effect = Exception("Profile API down")
+
+        mock_env = _build_mock_env(authorization_sync=mock_sync)
+
+        # Setup COmanage lookup to return a person (so profile sync is attempted)
+        person = _build_registry_person(
+            registry_id="Registry000001@naccdata.org",
+            suspended=False,
+        )
+        mock_env.user_registry.get.return_value = [person]
+
+        collector = UserEventCollector()
+        process = InactiveUserProcess(mock_env, collector)
+        entry = _build_inactive_entry()
+
+        with caplog.at_level(logging.ERROR):
+            process.visit(entry)
+
+        # Profile sync was attempted and failed
+        mock_sync.sync_profile.assert_called_once()
+        assert "Profile sync failed" in caplog.text
+
+        # Step 4 (COmanage suspend) was still executed
+        mock_env.user_registry.suspend.assert_called_once_with(
+            "Registry000001@naccdata.org"
+        )
+
+    def test_profile_sync_skipped_when_registry_id_is_none(self, caplog) -> None:
+        """Profile sync is skipped when no person_list is found (registry_id is
+        None).
+
+        Validates: Requirements 4.3
+        """
+        mock_sync = Mock()
+        mock_env = _build_mock_env(authorization_sync=mock_sync)
+
+        # No COmanage records found — person_list is empty
+        mock_env.user_registry.get.return_value = []
+
+        collector = UserEventCollector()
+        process = InactiveUserProcess(mock_env, collector)
+        entry = _build_inactive_entry()
+
+        with caplog.at_level(logging.INFO):
+            process.visit(entry)
+
+        # Profile sync was NOT called because registry_id is None
+        mock_sync.sync_profile.assert_not_called()
+
+    def test_profile_sync_skipped_when_person_has_no_registry_id(self, caplog) -> None:
+        """Profile sync is skipped when person_list exists but registry_id
+        returns None.
+
+        Validates: Requirements 4.3
+        """
+        mock_sync = Mock()
+        mock_env = _build_mock_env(authorization_sync=mock_sync)
+
+        # Person exists but has no registry_id
+        person = Mock(spec=RegistryPerson)
+        person.registry_id.return_value = None
+        person.is_suspended.return_value = False
+        person.email_address = Mock()
+        person.email_address.mail = "jane@example.com"
+        mock_env.user_registry.get.return_value = [person]
+
+        collector = UserEventCollector()
+        process = InactiveUserProcess(mock_env, collector)
+        entry = _build_inactive_entry()
+
+        with caplog.at_level(logging.INFO):
+            process.visit(entry)
+
+        # Profile sync was NOT called because registry_id is None
+        mock_sync.sync_profile.assert_not_called()


### PR DESCRIPTION
## Summary

Adds user profile CRUD operations to the authorization client and integrates profile sync into user management workflows. When users are processed (active, inactive, or center), their profile data is pushed to the Authorization API.

## Changes

### Models & Exceptions
- `UserProfileRequest` with field validation (non-whitespace names, length constraints)
- `UserProfile` and `UserProfileList` response models
- `NotFoundError` exception for 404 responses

### Authorization Client
- `put_user_profile`: create/update (PUT)
- `get_user_profile`: retrieve single profile (GET)
- `get_user_profiles`: batch retrieve using `query_params` (GET)
- `delete_user_profile`: idempotent delete (DELETE, treats 404 as success)
- `_validate_profile_user_id`: format validation (RegistryNNNNNN@naccdata.org)
- Empty list guard on `get_user_profiles`

### Sync Service
- `sync_profile` method on `AuthorizationSyncService`
- Skips when `auth_email` is None (logs warning)
- Catches `AuthorizationClientError` and reports via event collector
- Extended `AuthorizationClientProtocol` with `put_user_profile`

### User Processes
- Extracted `_try_sync_profile()` helper for fault-isolated calls (replaces 3x duplicated try/except)
- Profile sync called in `InactiveUserProcess`, `UpdateCenterUserProcess`, and `UpdateUserProcess`
- Uses `UserEntry` properties (`first_name`, `last_name`) instead of reaching into `.name`

### Tests
- `test_sync_profile.py`: skip on None, error reporting, request field construction
- `test_client_profile.py`: client CRUD method unit tests
- `test_profile_sync_integration.py`: fault isolation in user processes
- Enhanced `MockAuthorizationClient` with call tracking for `put_user_profile`

## Testing

All pants checks pass (fix, lint, check, test) on affected directories.