### PR TITLE
Add formver_split option to gather_form_data gear

### DIFF
--- a/common/src/python/data_requests/data_request.py
+++ b/common/src/python/data_requests/data_request.py
@@ -39,28 +39,108 @@ class DataRequestMatch(BaseModel):
     project_label: str
 
 
+def formver_label(formver: Any) -> str:
+    """Normalize a form version value into a filename-safe label.
+
+    Examples:
+        "1"   -> "v1"
+        "1.0" -> "v1"
+        "1.5" -> "v1.5"
+        "3.0" -> "v3"
+        ""    -> "unknown"
+        None  -> "unknown"
+
+    Args:
+      formver: the raw form version value (any type; coerced via str)
+    Returns:
+      a label suitable for use in a filename, e.g. "v3" or "unknown"
+    """
+    s = str(formver if formver is not None else "").strip()
+    if not s:
+        return "unknown"
+    if s.endswith(".0"):
+        s = s[:-2]
+    return f"v{s}"
+
+
 class ModuleDataGatherer:
-    """Defines process to gather file.info.form custom info for data
-    requests."""
+    """Defines process to gather file.info.form custom info for data requests.
+
+    When ``split_by_formver`` is True, rows are bucketed by form version
+    (using the ``formver`` field in the merged form data) and surfaced via
+    ``content_by_formver`` instead of ``content``. Each formver bucket has
+    its own ``StringCSVWriter``, which means the column set for each bucket
+    is naturally restricted to the columns that bucket's rows actually use —
+    no cross-version sparse columns.
+
+    When ``split_by_formver`` is False (default), behavior is identical to
+    the original single-CSV-per-module flow: ``content`` returns the union-
+    schema CSV string, ``content_by_formver`` is unavailable.
+    """
 
     def __init__(
         self,
         proxy: FlywheelProxy,
         module_name: str,
         info_paths: Optional[list[str]] = None,
+        split_by_formver: bool = False,
     ) -> None:
         self.__proxy = proxy
         self.__module_name = module_name
-        self.__writer = StringCSVWriter()
         self.__info_paths = info_paths if info_paths is not None else ["forms.json"]
+        self.__split_by_formver = split_by_formver
+        # One writer for the default flow; a dict of writers (keyed by
+        # formver label) when splitting by formver.
+        self.__writer: Optional[StringCSVWriter] = (
+            None if split_by_formver else StringCSVWriter()
+        )
+        self.__writers_by_formver: dict[str, StringCSVWriter] = {}
 
     @property
     def module_name(self):
         return self.__module_name
 
     @property
+    def split_by_formver(self) -> bool:
+        return self.__split_by_formver
+
+    @property
     def content(self):
+        """Returns the CSV content for this module (single-bucket mode).
+
+        Raises:
+          AttributeError if this gatherer was constructed with
+          split_by_formver=True; use ``content_by_formver`` instead.
+        """
+        if self.__split_by_formver:
+            raise AttributeError(
+                "content is unavailable when split_by_formver=True; "
+                "use content_by_formver instead"
+            )
+        assert self.__writer is not None
         return self.__writer.get_content()
+
+    @property
+    def content_by_formver(self) -> dict[str, str]:
+        """Returns CSV content keyed by form-version label.
+
+        Each value is a complete CSV string whose header is restricted to
+        the columns present in that formver bucket — rows are not padded
+        across buckets.
+
+        Raises:
+          AttributeError if this gatherer was constructed with
+          split_by_formver=False; use ``content`` instead.
+        """
+        if not self.__split_by_formver:
+            raise AttributeError(
+                "content_by_formver is unavailable when "
+                "split_by_formver=False; use content instead"
+            )
+        return {
+            label: writer.get_content()
+            for label, writer in self.__writers_by_formver.items()
+        }
 
     def gather_file_info(self, file: FileEntry) -> None:
         """Writes file info to the writer. Uses the info paths of this object
@@ -89,7 +169,16 @@ class ModuleDataGatherer:
 
             merged_data.update(form_data)
 
-        self.__writer.write(merged_data)
+        if self.__split_by_formver:
+            label = formver_label(merged_data.get("formver"))
+            writer = self.__writers_by_formver.get(label)
+            if writer is None:
+                writer = StringCSVWriter()
+                self.__writers_by_formver[label] = writer
+            writer.write(merged_data)
+        else:
+            assert self.__writer is not None
+            self.__writer.write(merged_data)
 
     def gather_request_data(self, request: DataRequestMatch) -> None:
         """Writes the file custom info to the writer of this object for each

--- a/common/src/python/data_requests/data_request.py
+++ b/common/src/python/data_requests/data_request.py
@@ -89,12 +89,9 @@ class ModuleDataGatherer:
         self.__module_name = module_name
         self.__info_paths = info_paths if info_paths is not None else ["forms.json"]
         self.__split_by_formver = split_by_formver
-        # One writer for the default flow; a dict of writers (keyed by
-        # formver label) when splitting by formver.
-        self.__writer: Optional[StringCSVWriter] = (
-            None if split_by_formver else StringCSVWriter()
-        )
-        self.__writers_by_formver: dict[str, StringCSVWriter] = {}
+        # Writers keyed by formver label when splitting; a single writer under
+        # the "default" label otherwise.
+        self.__writers: dict[str, StringCSVWriter] = {}
 
     @property
     def module_name(self):
@@ -117,8 +114,8 @@ class ModuleDataGatherer:
                 "content is unavailable when split_by_formver=True; "
                 "use content_by_formver instead"
             )
-        assert self.__writer is not None
-        return self.__writer.get_content()
+        writer = self.__writers.setdefault("default", StringCSVWriter())
+        return writer.get_content()
 
     @property
     def content_by_formver(self) -> dict[str, str]:
@@ -137,10 +134,7 @@ class ModuleDataGatherer:
                 "content_by_formver is unavailable when "
                 "split_by_formver=False; use content instead"
             )
-        return {
-            label: writer.get_content()
-            for label, writer in self.__writers_by_formver.items()
-        }
+        return {label: writer.get_content() for label, writer in self.__writers.items()}
 
     def gather_file_info(self, file: FileEntry) -> None:
         """Writes file info to the writer. Uses the info paths of this object
@@ -169,16 +163,13 @@ class ModuleDataGatherer:
 
             merged_data.update(form_data)
 
-        if self.__split_by_formver:
-            label = formver_label(merged_data.get("formver"))
-            writer = self.__writers_by_formver.get(label)
-            if writer is None:
-                writer = StringCSVWriter()
-                self.__writers_by_formver[label] = writer
-            writer.write(merged_data)
-        else:
-            assert self.__writer is not None
-            self.__writer.write(merged_data)
+        label = (
+            formver_label(merged_data.get("formver"))
+            if self.__split_by_formver
+            else "default"
+        )
+        writer = self.__writers.setdefault(label, StringCSVWriter())
+        writer.write(merged_data)
 
     def gather_request_data(self, request: DataRequestMatch) -> None:
         """Writes the file custom info to the writer of this object for each

--- a/common/test/python/data_requests/test_data_request.py
+++ b/common/test/python/data_requests/test_data_request.py
@@ -1,7 +1,184 @@
-from data_requests.data_request import DataRequest
+from unittest.mock import MagicMock
+
+import pytest
+from data_requests.data_request import (
+    DataRequest,
+    ModuleDataGatherer,
+    formver_label,
+)
 
 
 class TestDataRequest:
     def test_case(self):
         request = DataRequest.model_validate({"NACCID": "NACC000000"})
         assert request == DataRequest(naccid="NACC000000")
+
+
+class TestFormverLabel:
+    """Normalization of form version values into filename-safe labels."""
+
+    @pytest.mark.parametrize(
+        "raw, expected",
+        [
+            ("1", "v1"),
+            ("1.0", "v1"),
+            ("1.5", "v1.5"),
+            ("2", "v2"),
+            ("3.0", "v3"),
+            ("4.0", "v4"),
+            ("4", "v4"),
+            ("", "unknown"),
+            ("   ", "unknown"),
+            (None, "unknown"),
+            (1.0, "v1"),  # numeric input — coerced via str()
+            (3, "v3"),
+        ],
+    )
+    def test_label(self, raw, expected):
+        assert formver_label(raw) == expected
+
+
+def _make_file_mock(merged_data: dict, file_id: str = "fake-file-id"):
+    """Build a mock FileEntry whose reload().info contains a 'forms.json' key
+    matching ``merged_data``."""
+    file_mock = MagicMock()
+    file_mock.file_id = file_id
+    reloaded = MagicMock()
+    reloaded.info = {"forms.json": merged_data}
+    reloaded.file_id = file_id
+    file_mock.reload.return_value = reloaded
+    return file_mock
+
+
+class TestModuleDataGathererSingleWriter:
+    """Default mode (split_by_formver=False) — backward-compatible."""
+
+    def test_content_returns_csv_string(self):
+        gatherer = ModuleDataGatherer(
+            proxy=MagicMock(),
+            module_name="UDS",
+            info_paths=["forms.json"],
+        )
+        gatherer.gather_file_info(
+            _make_file_mock({"naccid": "NACC0001", "formver": "4.0", "field_a": "x"})
+        )
+        content = gatherer.content
+        assert "naccid" in content
+        assert "NACC0001" in content
+        assert "field_a" in content
+
+    def test_content_by_formver_raises_in_default_mode(self):
+        gatherer = ModuleDataGatherer(
+            proxy=MagicMock(),
+            module_name="UDS",
+            info_paths=["forms.json"],
+        )
+        with pytest.raises(AttributeError, match="split_by_formver=False"):
+            _ = gatherer.content_by_formver
+
+    def test_split_by_formver_property_reports_false(self):
+        gatherer = ModuleDataGatherer(
+            proxy=MagicMock(),
+            module_name="UDS",
+            info_paths=["forms.json"],
+        )
+        assert gatherer.split_by_formver is False
+
+
+class TestModuleDataGathererFormverSplit:
+    """split_by_formver=True groups rows by formver into separate writers, each
+    with its own column set."""
+
+    def _build_with_rows(self, rows: list[dict], module_name: str = "UDS"):
+        gatherer = ModuleDataGatherer(
+            proxy=MagicMock(),
+            module_name=module_name,
+            info_paths=["forms.json"],
+            split_by_formver=True,
+        )
+        for row in rows:
+            gatherer.gather_file_info(_make_file_mock(row))
+        return gatherer
+
+    def test_split_by_formver_property_reports_true(self):
+        gatherer = ModuleDataGatherer(
+            proxy=MagicMock(),
+            module_name="UDS",
+            info_paths=["forms.json"],
+            split_by_formver=True,
+        )
+        assert gatherer.split_by_formver is True
+
+    def test_content_raises_in_split_mode(self):
+        gatherer = self._build_with_rows([{"formver": "4.0"}])
+        with pytest.raises(AttributeError, match="split_by_formver=True"):
+            _ = gatherer.content
+
+    def test_separates_rows_by_formver(self):
+        gatherer = self._build_with_rows(
+            [
+                {"naccid": "NACC0001", "formver": "3.0", "v3_field": "a"},
+                {"naccid": "NACC0002", "formver": "3.0", "v3_field": "b"},
+                {"naccid": "NACC0003", "formver": "4.0", "v4_field": "c"},
+            ]
+        )
+        buckets = gatherer.content_by_formver
+        assert set(buckets.keys()) == {"v3", "v4"}
+        assert "NACC0001" in buckets["v3"]
+        assert "NACC0002" in buckets["v3"]
+        assert "NACC0003" in buckets["v4"]
+        assert "NACC0003" not in buckets["v3"]
+        assert "NACC0001" not in buckets["v4"]
+
+    def test_each_bucket_has_its_own_column_set(self):
+        """A row's columns only appear in its own formver bucket — no cross-
+        version sparse columns."""
+        gatherer = self._build_with_rows(
+            [
+                {"naccid": "NACC0001", "formver": "3.0", "v3_only_field": "a"},
+                {"naccid": "NACC0002", "formver": "4.0", "v4_only_field": "b"},
+            ]
+        )
+        buckets = gatherer.content_by_formver
+        # Each bucket's header should include only that bucket's columns
+        v3_header = buckets["v3"].splitlines()[0]
+        v4_header = buckets["v4"].splitlines()[0]
+        assert "v3_only_field" in v3_header
+        assert "v3_only_field" not in v4_header
+        assert "v4_only_field" in v4_header
+        assert "v4_only_field" not in v3_header
+
+    def test_missing_formver_routes_to_unknown_bucket(self):
+        gatherer = self._build_with_rows(
+            [
+                {"naccid": "NACC0001", "field_a": "value"},  # no formver
+                {"naccid": "NACC0002", "formver": "", "field_a": "value2"},
+                {"naccid": "NACC0003", "formver": "4.0", "v4_field": "c"},
+            ]
+        )
+        buckets = gatherer.content_by_formver
+        assert "unknown" in buckets
+        assert "v4" in buckets
+        assert "NACC0001" in buckets["unknown"]
+        assert "NACC0002" in buckets["unknown"]
+        assert "NACC0003" not in buckets["unknown"]
+
+    def test_normalizes_formver_to_label(self):
+        gatherer = self._build_with_rows(
+            [
+                {"naccid": "NACC0001", "formver": "1.0", "f1": "a"},
+                {"naccid": "NACC0002", "formver": "1.5", "f15": "b"},
+                {"naccid": "NACC0003", "formver": "2", "f2": "c"},
+            ]
+        )
+        buckets = gatherer.content_by_formver
+        assert set(buckets.keys()) == {"v1", "v1.5", "v2"}
+
+    def test_no_rows_yields_empty_dict(self):
+        gatherer = ModuleDataGatherer(
+            proxy=MagicMock(),
+            module_name="UDS",
+            info_paths=["forms.json"],
+            split_by_formver=True,
+        )
+        assert gatherer.content_by_formver == {}

--- a/gear/gather_form_data/src/docker/manifest.json
+++ b/gear/gather_form_data/src/docker/manifest.json
@@ -31,9 +31,7 @@
       "base": "file",
       "optional": true,
       "type": {
-        "enum": [
-          "tabular data"
-        ]
+        "enum": ["tabular data"]
       }
     }
   },
@@ -42,10 +40,7 @@
       "description": "Execution mode: participant_list or project",
       "type": "string",
       "default": "participant_list",
-      "enum": [
-        "participant_list",
-        "project"
-      ]
+      "enum": ["participant_list", "project"]
     },
     "group_id": {
       "description": "Flywheel group ID for the center (required in project mode)",
@@ -86,6 +81,11 @@
       "description": "The study ID",
       "type": "string",
       "default": "adrc"
+    },
+    "formver_split": {
+      "description": "Split output CSVs by form version (one file per module/formver, e.g. uds-v3.csv, uds-v4.csv). Each file has a column set restricted to that exact form version; rows are not column-unioned across versions.",
+      "type": "boolean",
+      "default": false
     }
   },
   "command": "/bin/run"

--- a/gear/gather_form_data/src/python/gather_form_data_app/main.py
+++ b/gear/gather_form_data/src/python/gather_form_data_app/main.py
@@ -36,11 +36,10 @@ class ProjectModeConfig(BaseModel):
     @field_validator("modules")
     @classmethod
     def must_have_valid_modules(cls, v: set[str]) -> set[str]:
-        """Filter to valid module set and raise if none remain."""
-        valid = {"UDS", "FTLD", "LBD"}
-        filtered = v & valid
+        """Reject empty or whitespace-only module sets."""
+        filtered = {module.strip() for module in v if module.strip()}
         if not filtered:
-            raise ValueError(f"no valid modules specified; allowed values are {valid}")
+            raise ValueError("at least one module must be specified")
         return filtered
 
 

--- a/gear/gather_form_data/src/python/gather_form_data_app/run.py
+++ b/gear/gather_form_data/src/python/gather_form_data_app/run.py
@@ -285,20 +285,19 @@ class ProjectModeVisitor(GearExecutionEnvironment):
 
         Resolves group/project, iterates subjects, gathers data, and
         writes output files.
+
+        Raises:
+          GearExecutionError if the group or project cannot be found.
         """
         group = self.proxy.find_group(self.__group_id)
         if not group:
-            log.error("Group not found: %s", self.__group_id)
-            return
+            raise GearExecutionError(f"Group not found: {self.__group_id}")
 
         project = group.find_project(self.__project_name)
         if not project:
-            log.error(
-                "Project not found: %s in group %s",
-                self.__project_name,
-                self.__group_id,
+            raise GearExecutionError(
+                f"Project not found: {self.__project_name} in group {self.__group_id}"
             )
-            return
 
         subjects = list(project.project.subjects.iter())
         if not subjects:

--- a/gear/gather_form_data/src/python/gather_form_data_app/run.py
+++ b/gear/gather_form_data/src/python/gather_form_data_app/run.py
@@ -36,8 +36,16 @@ def _write_module_output(
     gatherers: list[ModuleDataGatherer],
     study_id: str,
 ) -> None:
-    """Writes the data content in each gatherer to a file named with the study-
-    id and the module of the gatherer.
+    """Writes the data content in each gatherer to one or more output files.
+
+    For gatherers with ``split_by_formver=False`` (default), produces a single
+    CSV per module named ``{study_id}-{module}-{date}.csv``.
+
+    For gatherers with ``split_by_formver=True``, produces one CSV per
+    (module, formver) pair, named
+    ``{study_id}-{module}-{formver_label}-{date}.csv`` (e.g.
+    ``adrc-UDS-v4-2026-05-29.csv``). The formver label is normalized via
+    ``formver_label`` (e.g. "1.0" -> "v1", missing -> "unknown").
 
     Args:
       context: the gear context
@@ -46,6 +54,27 @@ def _write_module_output(
     """
     today = date.today().isoformat()
     for gatherer in gatherers:
+        if gatherer.split_by_formver:
+            buckets = gatherer.content_by_formver
+            if not buckets:
+                log.warning(
+                    "skipping output for module %s: no data found",
+                    gatherer.module_name,
+                )
+                continue
+            for formver_label_value, content in buckets.items():
+                if not content:
+                    continue
+                output_filename = (
+                    f"{study_id}-{gatherer.module_name}-"
+                    f"{formver_label_value}-{today}.csv"
+                )
+                with context.open_output(
+                    output_filename, mode="w", encoding="utf-8"
+                ) as output_file:
+                    output_file.write(content)
+            continue
+
         if not gatherer.content:
             log.warning(
                 "skipping output for module %s: no data found",
@@ -71,6 +100,7 @@ class GatherFormDataVisitor(GearExecutionEnvironment):
         info_paths: list[str],
         modules: set[ModuleName],
         study_id: str,
+        formver_split: bool = False,
     ):
         super().__init__(client=client)
         self.__file_input = file_input
@@ -78,6 +108,7 @@ class GatherFormDataVisitor(GearExecutionEnvironment):
         self.__info_paths = info_paths
         self.__modules = modules
         self.__study_id = study_id
+        self.__formver_split = formver_split
 
     @classmethod
     def create(
@@ -112,6 +143,7 @@ class GatherFormDataVisitor(GearExecutionEnvironment):
             log.warning("ignoring unexpected modules: %s", ",".join(unexpected_modules))
 
         study_id = options.get("study_id", "adrc")
+        formver_split = options.get("formver_split", False)
 
         return GatherFormDataVisitor(
             client=client,
@@ -120,6 +152,7 @@ class GatherFormDataVisitor(GearExecutionEnvironment):
             info_paths=info_paths,
             modules={module for module in get_args(ModuleName) if module in modules},
             study_id=study_id,
+            formver_split=formver_split,
         )
 
     def run(self, context: GearContext) -> None:
@@ -130,6 +163,7 @@ class GatherFormDataVisitor(GearExecutionEnvironment):
                     proxy=self.proxy,
                     module_name=module_name,
                     info_paths=self.__info_paths,
+                    split_by_formver=self.__formver_split,
                 )
             )
 
@@ -182,6 +216,7 @@ class ProjectModeVisitor(GearExecutionEnvironment):
         info_paths: list[str],
         modules: set[str],
         study_id: str,
+        formver_split: bool = False,
     ):
         super().__init__(client=client)
         self.__group_id = group_id
@@ -189,6 +224,7 @@ class ProjectModeVisitor(GearExecutionEnvironment):
         self.__info_paths = info_paths
         self.__modules = modules
         self.__study_id = study_id
+        self.__formver_split = formver_split
 
     @classmethod
     def create(
@@ -219,6 +255,7 @@ class ProjectModeVisitor(GearExecutionEnvironment):
         include_derived = options.get("include_derived", False)
         info_paths = ["forms.json", "derived"] if include_derived else ["forms.json"]
         study_id = options.get("study_id", "adrc")
+        formver_split = options.get("formver_split", False)
 
         try:
             config = ProjectModeConfig(
@@ -240,6 +277,7 @@ class ProjectModeVisitor(GearExecutionEnvironment):
             info_paths=config.info_paths,
             modules=config.modules,
             study_id=config.study_id,
+            formver_split=formver_split,
         )
 
     def run(self, context: GearContext) -> None:
@@ -285,6 +323,7 @@ class ProjectModeVisitor(GearExecutionEnvironment):
                 proxy=self.proxy,
                 module_name=module_name,
                 info_paths=self.__info_paths,
+                split_by_formver=self.__formver_split,
             )
             for module_name in self.__modules
         ]

--- a/gear/gather_form_data/test/python/test_project_mode_integration.py
+++ b/gear/gather_form_data/test/python/test_project_mode_integration.py
@@ -13,7 +13,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from gather_form_data_app.run import ProjectModeVisitor
-from gear_execution.gear_execution import ClientWrapper
+from gear_execution.gear_execution import ClientWrapper, GearExecutionError
 
 
 @pytest.fixture
@@ -89,17 +89,17 @@ class TestProjectModeErrorHandling:
         mock_client: MagicMock,
         mock_proxy: MagicMock,
         mock_context: MagicMock,
-        caplog: pytest.LogCaptureFixture,
     ):
-        """When proxy.find_group returns None, log error and return."""
+        """When proxy.find_group returns None, raise GearExecutionError."""
         mock_proxy.find_group.return_value = None
 
         visitor = create_visitor(mock_client, group_id="nonexistent-group")
 
-        with caplog.at_level(logging.ERROR):
+        with pytest.raises(
+            GearExecutionError, match="Group not found: nonexistent-group"
+        ):
             visitor.run(mock_context)
 
-        assert "Group not found: nonexistent-group" in caplog.text
         mock_context.open_output.assert_not_called()
 
     def test_project_not_found(
@@ -107,9 +107,8 @@ class TestProjectModeErrorHandling:
         mock_client: MagicMock,
         mock_proxy: MagicMock,
         mock_context: MagicMock,
-        caplog: pytest.LogCaptureFixture,
     ):
-        """When group is found but project is not, log error and return."""
+        """When group is found but project is not, raise GearExecutionError."""
         mock_group = MagicMock()
         mock_proxy.find_group.return_value = mock_group
         mock_group.find_project.return_value = None
@@ -120,10 +119,11 @@ class TestProjectModeErrorHandling:
             project_name="nonexistent-project",
         )
 
-        with caplog.at_level(logging.ERROR):
+        with pytest.raises(
+            GearExecutionError, match="Project not found: nonexistent-project"
+        ):
             visitor.run(mock_context)
 
-        assert "Project not found: nonexistent-project" in caplog.text
         mock_context.open_output.assert_not_called()
 
     def test_empty_project(

--- a/gear/gather_form_data/test/python/test_project_mode_integration.py
+++ b/gear/gather_form_data/test/python/test_project_mode_integration.py
@@ -182,6 +182,7 @@ class TestProjectModeOutput:
             mock_gatherer = MagicMock()
             mock_gatherer.module_name = "UDS"
             mock_gatherer.content = "header1,header2\nval1,val2\n"
+            mock_gatherer.split_by_formver = False
             mock_gatherer_cls.return_value = mock_gatherer
 
             visitor.run(mock_context)
@@ -214,6 +215,7 @@ class TestProjectModeOutput:
             mock_gatherer = MagicMock()
             mock_gatherer.module_name = "FTLD"
             mock_gatherer.content = "col1\ndata1\n"
+            mock_gatherer.split_by_formver = False
             mock_gatherer_cls.return_value = mock_gatherer
 
             with patch("gather_form_data_app.run.date") as mock_date:
@@ -246,14 +248,16 @@ class TestProjectModeOutput:
         mock_uds_gatherer = MagicMock()
         mock_uds_gatherer.module_name = "UDS"
         mock_uds_gatherer.content = "header\ndata\n"
+        mock_uds_gatherer.split_by_formver = False
 
         mock_ftld_gatherer = MagicMock()
         mock_ftld_gatherer.module_name = "FTLD"
         mock_ftld_gatherer.content = ""  # Empty - no data
+        mock_ftld_gatherer.split_by_formver = False
 
         with patch("gather_form_data_app.run.ModuleDataGatherer") as mock_gatherer_cls:
 
-            def create_gatherer(proxy, module_name, info_paths):
+            def create_gatherer(proxy, module_name, info_paths, **kwargs):
                 if module_name == "UDS":
                     return mock_uds_gatherer
                 return mock_ftld_gatherer
@@ -271,3 +275,134 @@ class TestProjectModeOutput:
 
         # Warning should be logged for the empty module
         assert "skipping output for module FTLD" in caplog.text
+
+
+class TestProjectModeFormverSplit:
+    """Tests for formver_split=True output behavior in project mode.
+
+    When formver_split is enabled, the gear produces one CSV per
+    (module, formver) pair instead of one CSV per module.
+    """
+
+    def _build_visitor_with_formver_split(self, mock_client: MagicMock):
+        return ProjectModeVisitor(
+            client=mock_client,
+            group_id="test-group",
+            project_name="test-project",
+            info_paths=["forms.json"],
+            modules={"UDS"},
+            study_id="adrc",
+            formver_split=True,
+        )
+
+    def test_produces_one_file_per_formver_bucket(
+        self,
+        mock_client: MagicMock,
+        mock_proxy: MagicMock,
+        mock_context: MagicMock,
+    ):
+        """A gatherer with two formver buckets produces two output files."""
+        mock_group = MagicMock()
+        mock_project = MagicMock()
+        mock_project.project.subjects.iter.return_value = iter(
+            [create_mock_subject("NACC000001", "sub-001")]
+        )
+        mock_project.label = "test-project"
+        mock_proxy.find_group.return_value = mock_group
+        mock_group.find_project.return_value = mock_project
+
+        visitor = self._build_visitor_with_formver_split(mock_client)
+
+        with patch("gather_form_data_app.run.ModuleDataGatherer") as mock_gatherer_cls:
+            mock_gatherer = MagicMock()
+            mock_gatherer.module_name = "UDS"
+            mock_gatherer.split_by_formver = True
+            mock_gatherer.content_by_formver = {
+                "v3": "naccid\nNACC000001\n",
+                "v4": "naccid,extra\nNACC000002,x\n",
+            }
+            mock_gatherer_cls.return_value = mock_gatherer
+
+            with patch("gather_form_data_app.run.date") as mock_date:
+                mock_date.today.return_value.isoformat.return_value = "2024-01-15"
+                visitor.run(mock_context)
+
+        assert mock_context.open_output.call_count == 2
+        filenames = sorted(mock_context.output_files.keys())
+        assert filenames == [
+            "adrc-UDS-v3-2024-01-15.csv",
+            "adrc-UDS-v4-2024-01-15.csv",
+        ]
+        # Each output file contains its bucket's content
+        assert mock_context.output_files["adrc-UDS-v3-2024-01-15.csv"] == (
+            "naccid\nNACC000001\n"
+        )
+        assert mock_context.output_files["adrc-UDS-v4-2024-01-15.csv"] == (
+            "naccid,extra\nNACC000002,x\n"
+        )
+
+    def test_empty_buckets_are_skipped(
+        self,
+        mock_client: MagicMock,
+        mock_proxy: MagicMock,
+        mock_context: MagicMock,
+    ):
+        """Buckets with empty content do not produce files."""
+        mock_group = MagicMock()
+        mock_project = MagicMock()
+        mock_project.project.subjects.iter.return_value = iter(
+            [create_mock_subject("NACC000001", "sub-001")]
+        )
+        mock_project.label = "test-project"
+        mock_proxy.find_group.return_value = mock_group
+        mock_group.find_project.return_value = mock_project
+
+        visitor = self._build_visitor_with_formver_split(mock_client)
+
+        with patch("gather_form_data_app.run.ModuleDataGatherer") as mock_gatherer_cls:
+            mock_gatherer = MagicMock()
+            mock_gatherer.module_name = "UDS"
+            mock_gatherer.split_by_formver = True
+            mock_gatherer.content_by_formver = {
+                "v3": "naccid\nNACC000001\n",
+                "v4": "",  # empty
+            }
+            mock_gatherer_cls.return_value = mock_gatherer
+
+            visitor.run(mock_context)
+
+        assert mock_context.open_output.call_count == 1
+        filename = next(iter(mock_context.output_files.keys()))
+        assert "v3" in filename and "v4" not in filename
+
+    def test_gatherer_with_no_buckets_logs_warning(
+        self,
+        mock_client: MagicMock,
+        mock_proxy: MagicMock,
+        mock_context: MagicMock,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        """A gatherer that gathered no rows produces no files and logs."""
+        mock_group = MagicMock()
+        mock_project = MagicMock()
+        mock_project.project.subjects.iter.return_value = iter(
+            [create_mock_subject("NACC000001", "sub-001")]
+        )
+        mock_project.label = "test-project"
+        mock_proxy.find_group.return_value = mock_group
+        mock_group.find_project.return_value = mock_project
+
+        visitor = self._build_visitor_with_formver_split(mock_client)
+
+        with patch("gather_form_data_app.run.ModuleDataGatherer") as mock_gatherer_cls:
+            mock_gatherer = MagicMock()
+            mock_gatherer.module_name = "UDS"
+            mock_gatherer.split_by_formver = True
+            mock_gatherer.content_by_formver = {}
+            mock_gatherer_cls.return_value = mock_gatherer
+
+            with caplog.at_level(logging.WARNING):
+                visitor.run(mock_context)
+
+        mock_context.open_output.assert_not_called()
+        assert "skipping output for module UDS" in caplog.text


### PR DESCRIPTION
When formver_split=true, ModuleDataGatherer buckets rows by form version (using the formver field in the merged form data) and emits one CSV per (module, formver) pair instead of a single CSV per module.

Each bucket maintains its own StringCSVWriter, so column sets are naturally restricted to that formver's columns.

Default is false (backward compatible). Existing participant_list consumers and project-mode invocations without the flag are unaffected.

- Add formver_label() helper for filename-safe version labels
- Add split_by_formver kwarg + content_by_formver property to ModuleDataGatherer; raises AttributeError on mode mismatch
- Plumb through GatherFormDataVisitor and ProjectModeVisitor
- _write_module_output branches on gatherer.split_by_formver:
    False: {study_id}-{module}-{date}.csv (existing)
    True:  {study_id}-{module}-{formver_label}-{date}.csv
- Tests for new behavior; defensive updates to existing mocks to tolerate the new constructor kwarg
