### PR TITLE
Restrict BDS and NP to single submission

### DIFF
--- a/common/src/python/configs/ingest_configs.py
+++ b/common/src/python/configs/ingest_configs.py
@@ -15,7 +15,6 @@ from pydantic import (
     Field,
     RootModel,
     ValidationError,
-    model_validator,
 )
 
 PipelineType = Literal["submission", "finalization", "deletion"]
@@ -140,8 +139,12 @@ class ModuleConfigs(BaseModel):
     errorlog_template: Optional[ErrorLogTemplate] = None
     longitudinal: Optional[bool] = True
 
-    @model_validator(mode="after")
-    def validate_preprocess_checks(self) -> "ModuleConfigs":
+    def validate_preprocess_checks(self) -> None:
+        """Validate the list of preprocessing checks specified for the module.
+
+        Raises:
+            ValueError: If undefined pre-processing checks found
+        """
         not_defined = []
         if self.preprocess_checks:
             for check in self.preprocess_checks:
@@ -152,8 +155,6 @@ class ModuleConfigs(BaseModel):
                 raise ValueError(
                     f"Following pre-processing checks are not defined: {not_defined}"
                 )
-
-        return self
 
 
 class FormProjectConfigs(BaseModel):

--- a/common/src/python/datastore/forms_store.py
+++ b/common/src/python/datastore/forms_store.py
@@ -77,7 +77,7 @@ class FormsStore:
         search_col: str,
         search_val: Optional[str] | Optional[List[str]] = None,
         search_op: Optional[SearchOperator] | Optional[str] = None,
-        qc_gear: Optional[str] = None,
+        qc_gear: Optional[str | List[str]] = None,
         extra_columns: Optional[List[str]] = None,
         find_all: bool = False,
     ) -> Optional[List[Dict[str, Any]]]:
@@ -90,7 +90,7 @@ class FormsStore:
             search_col: field to search
             search_val: value(s) to search
             search_op: search operator
-            qc_gear (optional): specify qc_gear name to retrieve records that passed QC
+            qc_gear (optional): specify qc_gear names to retrieve records that passed QC
             extra_columns (optional): list of extra columns to return if any
             find_all (optional): bypass search and return all visits for the module
 
@@ -163,7 +163,14 @@ class FormsStore:
             filters += f",{search_col}{search_op}{search_val}"
 
         if qc_gear:
-            filters += f",file.info.qc.{qc_gear}.validation.state=PASS"
+            # filters += f",file.info.qc.{qc_gear}.validation.state=PASS"
+            if isinstance(qc_gear, str):
+                qc_gear = [qc_gear]
+
+            tags = []
+            for gear in qc_gear:
+                tags.append(f"{gear}-PASS")
+            filters += f",file.tags=|[{','.join(tags)}]"
 
         log.info("Searching for visits matching with filters: %s", filters)
 

--- a/common/src/python/keys/keys.py
+++ b/common/src/python/keys/keys.py
@@ -121,6 +121,7 @@ class SysErrorCodes:
     NP_UDS_SEX_MISMATCH = "preprocess-029"
     NP_UDS_DAGE_MISMATCH = "preprocess-030"
     UDS_NOT_EXIST = "preprocess-031"
+    MULTIPLE_SUBMISSIONS = "preprocess-032"
 
     # other errors for preprocessing issues that don't fall
     # in above categories
@@ -140,6 +141,7 @@ class PreprocessingChecks:
     CLINICAL_FORMS = "clinical-forms"
     NP_MLST_RESTRICTIONS = "np-mlst-restrictions"
     NP_UDS_RESTRICTIONS = "np-uds-restrictions"
+    SINGLETON = "singleton"
 
     @classmethod
     def is_check_defined(cls, check: str) -> bool:

--- a/common/src/python/outputs/errors.py
+++ b/common/src/python/outputs/errors.py
@@ -131,10 +131,10 @@ preprocess_errors = {
         "Participant must have an approved UDS, BDS, or MDS packet before "
         "this module/form can be submitted"
     ),
-    SysErrorCodes.MULTIPLE_SUBMISSIONS: {
+    SysErrorCodes.MULTIPLE_SUBMISSIONS: (
         "Multiple submissions not allowed for {0} module, "
         "delete the existing submissions for this participant with dates {1} and retry"
-    },
+    ),
 }
 
 

--- a/common/src/python/outputs/errors.py
+++ b/common/src/python/outputs/errors.py
@@ -131,6 +131,10 @@ preprocess_errors = {
         "Participant must have an approved UDS, BDS, or MDS packet before "
         "this module/form can be submitted"
     ),
+    SysErrorCodes.MULTIPLE_SUBMISSIONS: {
+        "Multiple submissions not allowed for {0} module, "
+        "delete the existing submissions for this participant with dates {1} and retry"
+    },
 }
 
 

--- a/common/src/python/preprocess/preprocessor.py
+++ b/common/src/python/preprocess/preprocessor.py
@@ -741,6 +741,7 @@ class FormPreprocessor:
         )
 
         if not supplement_visits and not supplement_module.exact_match:
+            # include both QC gears for legacy lookup as BDS is processed using new gear
             supplement_visits = self.__forms_store.query_form_data(
                 subject_lbl=pp_context.subject_lbl,
                 module=supplement_module.label,
@@ -748,7 +749,7 @@ class FormPreprocessor:
                 search_col=supplement_module.date_field,
                 search_val=input_record[module_configs.date_field],
                 search_op="<=",
-                qc_gear=self.__legacy_qc_gear if qc_passed else None,
+                qc_gear=[self.__legacy_qc_gear, self.__qc_gear] if qc_passed else None,  # type: ignore
             )
 
         return supplement_visits

--- a/common/src/python/preprocess/preprocessor.py
+++ b/common/src/python/preprocess/preprocessor.py
@@ -1281,13 +1281,14 @@ class FormPreprocessor:
                 module = self.__module_configs.legacy_module.label
                 date_field = self.__module_configs.legacy_module.date_field
 
+            # Look up submissions for the same module even with the same date
+            # in the legacy project
             other_matches = self.__forms_store.query_form_data(
                 subject_lbl=subject_lbl,
                 module=module,
                 legacy=True,
                 search_col=date_field,
-                search_op="!=",
-                search_val=date,
+                find_all=True,
             )
 
         if other_matches:

--- a/common/src/python/preprocess/preprocessor.py
+++ b/common/src/python/preprocess/preprocessor.py
@@ -185,7 +185,7 @@ class FormPreprocessor:
                 value="",
                 pp_context=pp_context,
                 error_code=SysErrorCodes.MISSING_SUBMISSION_STATUS,
-                extra_args=missing_vars,
+                extra_args=[missing_vars],
             )
             return False
 

--- a/common/src/python/preprocess/preprocessor.py
+++ b/common/src/python/preprocess/preprocessor.py
@@ -56,6 +56,8 @@ class FormPreprocessor:
         self.__qc_gear = form_configs.qc_gear
         self.__legacy_qc_gear = form_configs.legacy_qc_gear
 
+        self.__module_configs.validate_preprocess_checks()
+
         # Dispatcher mapping pre-processing checks to their corresponding handlers
         # Checks should be added in the order they need to be evaluated
         # DON'T add `duplicate-record` check here
@@ -68,8 +70,8 @@ class FormPreprocessor:
             PreprocessingChecks.UDSV4_IVP: self._check_udsv4_initial_visit,
             PreprocessingChecks.VISIT_CONFLICT: self._check_visit_conflict,
             PreprocessingChecks.SUPPLEMENT_MODULE: self._check_supplement_module,
-            PreprocessingChecks.CLINICAL_FORMS: self._check_clinical_forms,
             PreprocessingChecks.SINGLETON: self._is_singleton,
+            PreprocessingChecks.CLINICAL_FORMS: self._check_clinical_forms,
             PreprocessingChecks.NP_UDS_RESTRICTIONS: self._check_np_uds_restrictions,
             PreprocessingChecks.NP_MLST_RESTRICTIONS: self._check_np_mlst_restrictions,
         }

--- a/common/src/python/preprocess/preprocessor.py
+++ b/common/src/python/preprocess/preprocessor.py
@@ -69,6 +69,7 @@ class FormPreprocessor:
             PreprocessingChecks.VISIT_CONFLICT: self._check_visit_conflict,
             PreprocessingChecks.SUPPLEMENT_MODULE: self._check_supplement_module,
             PreprocessingChecks.CLINICAL_FORMS: self._check_clinical_forms,
+            PreprocessingChecks.SINGLETON: self._is_singleton,
             PreprocessingChecks.NP_UDS_RESTRICTIONS: self._check_np_uds_restrictions,
             PreprocessingChecks.NP_MLST_RESTRICTIONS: self._check_np_mlst_restrictions,
         }
@@ -1244,6 +1245,65 @@ class FormPreprocessor:
             )
 
         return result_dod
+
+    def _is_singleton(self, pp_context: PreprocessingContext) -> bool:
+        """Check whether there's any other existing submission for the
+        participant for this module in the system.
+
+        Args:
+            pp_context: preprocessing context
+
+        Returns:
+            bool: False, if other submissions found
+        """
+        assert pp_context.subject_lbl, "pp_context.subject_lbl required"
+
+        subject_lbl = pp_context.subject_lbl
+        date_field = self.__module_configs.date_field
+        date = pp_context.input_record.get(date_field)
+
+        # Look up any other submissions with a different visit date/form date
+        other_matches = self.__forms_store.query_form_data(
+            subject_lbl=subject_lbl,
+            module=self.__module,
+            legacy=False,
+            search_col=date_field,
+            search_op="!=",
+            search_val=date,
+        )
+
+        if not other_matches:
+            module = self.__module
+            if self.__module_configs.legacy_module:
+                module = self.__module_configs.legacy_module.label
+                date_field = self.__module_configs.legacy_module.date_field
+
+            other_matches = self.__forms_store.query_form_data(
+                subject_lbl=subject_lbl,
+                module=module,
+                legacy=True,
+                search_col=date_field,
+                search_op="!=",
+                search_val=date,
+            )
+
+        if other_matches:
+            matched_submissions = []
+            for match in other_matches:
+                matched_submissions.append(
+                    match.get(MetadataKeys.get_column_key(date_field))
+                )
+
+            self.__error_handler.write_preprocessing_error(
+                field=FieldNames.MODULE,
+                value=self.__module,
+                pp_context=pp_context,
+                error_code=SysErrorCodes.MULTIPLE_SUBMISSIONS,
+                extra_args=[self.__module, matched_submissions],
+            )
+            return False
+
+        return True
 
     def preprocess(
         self,

--- a/common/src/python/preprocess/preprocessor_helpers.py
+++ b/common/src/python/preprocess/preprocessor_helpers.py
@@ -94,7 +94,7 @@ class FormPreprocessorErrorHandler:
                 error_code=error_code,
                 message=message,
                 visit_keys=visit_keys,
-                extra_args=[extra_args],
+                extra_args=extra_args,
             )
         )
 

--- a/common/test/python/preprocess_test/test_preprocessor_helpers.py
+++ b/common/test/python/preprocess_test/test_preprocessor_helpers.py
@@ -214,7 +214,7 @@ class TestFormPreprocessorErrorHandler:
             value=input_record[field],
             pp_context=uds_pp_context,
             error_code=error_code,
-            extra_args=["mode1", "mode2", "mode3"],
+            extra_args=[["mode1", "mode2", "mode3"]],
         )
 
         self.__check_error(
@@ -226,5 +226,70 @@ class TestFormPreprocessorErrorHandler:
             message=(
                 "Missing submission status (MODE<form name>) variables "
                 "['mode1', 'mode2', 'mode3'] for one or more optional forms"
+            ),
+        )
+
+    def test_write_preprocessing_error_excluded_fields(
+        self, uds_module_configs, uds_pp_context
+    ):
+        """Test EXCLUDED_FIELDS error formats the list of field names into the
+        message."""
+        handler, error_writer = self.__create_error_handler(
+            DefaultValues.UDS_MODULE, uds_module_configs
+        )
+
+        excluded = ["field1", "field2"]
+        error_code = SysErrorCodes.EXCLUDED_FIELDS
+        handler.write_preprocessing_error(
+            field=FieldNames.FORMVER,
+            value=uds_pp_context.input_record[FieldNames.FORMVER],
+            pp_context=uds_pp_context,
+            error_code=error_code,
+            extra_args=[excluded],
+        )
+
+        self.__check_error(
+            error_writer,
+            uds_pp_context,
+            uds_pp_context.input_record[FieldNames.FORMVER],
+            FieldNames.FORMVER,
+            error_code,
+            message=(
+                "Following fields in the input record do not match "
+                "with the submitted version/packet of the form/module: "
+                "['field1', 'field2']"
+            ),
+        )
+
+    def test_write_preprocessing_error_multiple_submissions(
+        self, uds_module_configs, uds_pp_context
+    ):
+        """Test MULTIPLE_SUBMISSIONS error formats module and dates into the
+        message."""
+        handler, error_writer = self.__create_error_handler(
+            DefaultValues.UDS_MODULE, uds_module_configs
+        )
+
+        module = "BDS"
+        dates = ["2024-07-21", "2025-0-25"]
+        error_code = SysErrorCodes.MULTIPLE_SUBMISSIONS
+        handler.write_preprocessing_error(
+            field=FieldNames.MODULE,
+            value=module,
+            pp_context=uds_pp_context,
+            error_code=error_code,
+            extra_args=[module, dates],
+        )
+
+        self.__check_error(
+            error_writer,
+            uds_pp_context,
+            module,
+            FieldNames.MODULE,
+            error_code,
+            message=(
+                "Multiple submissions not allowed for BDS module, "
+                "delete the existing submissions for this participant "
+                "with dates ['2024-07-21', '2025-0-25'] and retry"
             ),
         )

--- a/docs/form_deletion/CHANGELOG.md
+++ b/docs/form_deletion/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this gear are documented in this file.
 
+## 1.0.3
+* Rebuilt for module configs update
+
 ## 1.0.1 - 1.0.2
 * Checks for an existing acquisition matching to the delete request before looking up longitudinal visits
   

--- a/docs/form_qc_checker/CHANGELOG.md
+++ b/docs/form_qc_checker/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this gear are documented in this file.
 
 ## 1.9.1
 * Rebuilt for module configs update
+* Updates the previous visit searches to include both QC gear tags in legacy lookup
 
 ## 1.9.0
 * Rebuilt for log file naming format update

--- a/docs/form_qc_checker/CHANGELOG.md
+++ b/docs/form_qc_checker/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this gear are documented in this file.
 
+## 1.9.1
+* Rebuilt for module configs update
+
 ## 1.9.0
 * Rebuilt for log file naming format update
   

--- a/docs/form_qc_coordinator/CHANGELOG.md
+++ b/docs/form_qc_coordinator/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this gear are documented in this file.
 
+## 1.6.1
+* Rebuilt for module configs update
+
 ## 1.6.0
 * Rebuilt for log file naming format update
   

--- a/docs/form_transformer/CHANGELOG.md
+++ b/docs/form_transformer/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this gear are documented in this file.
 
+## 1.10.0
+* Prevents multiple submissions for the modules that allow only a single submission for a participant
+  
 ## 1.9.0
 * Rebuilt for log file naming format update
   

--- a/docs/form_transformer/CHANGELOG.md
+++ b/docs/form_transformer/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this gear are documented in this file.
 
 ## 1.10.0
 * Prevents multiple submissions for the modules that allow only a single submission for a participant
+* Updates the visit searches to include both QC gear tags in legacy lookup
   
 ## 1.9.0
 * Rebuilt for log file naming format update

--- a/docs/identifier_lookup/CHANGELOG.md
+++ b/docs/identifier_lookup/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this gear are documented in this file.
 
+## 2.4.2
+
+* Rebuilt for module configs update
+
 ## 2.4.1
 
 * Fix multi-center identifier lookup (Scenario 2) when `form_configs_file` is provided with `single_center: false`

--- a/gear/form_deletion/src/docker/BUILD
+++ b/gear/form_deletion/src/docker/BUILD
@@ -4,5 +4,5 @@ docker_image(
     name="form-deletion",
     source="Dockerfile",
     dependencies=[":manifest", "gear/form_deletion/src/python/form_deletion_app:bin"],
-    image_tags=["1.0.2", "latest"],
+    image_tags=["1.0.3", "latest"],
 )

--- a/gear/form_deletion/src/docker/manifest.json
+++ b/gear/form_deletion/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "form-deletion",
     "label": "Form Deletion",
     "description": "A gear to process delete requests for submitted form data",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/form-deletion:1.0.2"
+            "image": "naccdata/form-deletion:1.0.3"
         },
         "flywheel": {
             "suite": "Utility",

--- a/gear/form_qc_checker/src/docker/BUILD
+++ b/gear/form_qc_checker/src/docker/BUILD
@@ -4,5 +4,5 @@ docker_image(
     name="form-qc-checker",
     source="Dockerfile",
     dependencies=[":manifest", "gear/form_qc_checker/src/python/form_qc_app:bin"],
-    image_tags=["1.9.0", "latest"],
+    image_tags=["1.9.1", "latest"],
 )

--- a/gear/form_qc_checker/src/docker/manifest.json
+++ b/gear/form_qc_checker/src/docker/manifest.json
@@ -2,7 +2,7 @@
   "name": "form-qc-checker",
   "label": "Form QC Checker",
   "description": "Gear to check form data as JSON with QC rule set",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "author": "NACC",
   "maintainer": "NACC <nacchelp@uw.edu>",
   "cite": "",
@@ -15,7 +15,7 @@
   "custom": {
     "gear-builder": {
       "category": "utility",
-      "image": "naccdata/form-qc-checker:1.9.0"
+      "image": "naccdata/form-qc-checker:1.9.1"
     },
     "flywheel": {
       "suite": "Curation",

--- a/gear/form_qc_checker/src/python/form_qc_app/datastore.py
+++ b/gear/form_qc_checker/src/python/form_qc_app/datastore.py
@@ -314,9 +314,9 @@ class DatastoreHelper(Datastore):
                 search_val=ivp_codes,
                 search_op=DefaultValues.FW_SEARCH_OR,
                 qc_gear=[
-                    self.__form_configs.legacy_qc_gear,
-                    self.__form_configs.qc_gear,
-                ],  # type: ignore
+                    self.__form_configs.legacy_qc_gear,  # type: ignore
+                    self.__form_configs.qc_gear,  # type: ignore
+                ],
                 extra_columns=[date_field],
             )
 

--- a/gear/form_qc_checker/src/python/form_qc_app/datastore.py
+++ b/gear/form_qc_checker/src/python/form_qc_app/datastore.py
@@ -233,6 +233,8 @@ class DatastoreHelper(Datastore):
             else self.orderby
         )
 
+        # include both QC gears for legacy lookup
+        # as some modules are processed using new submission pipeline
         legacy_visits = self.__forms_store.query_form_data(
             subject_lbl=subject_lbl,
             module=legacy_module,
@@ -240,7 +242,7 @@ class DatastoreHelper(Datastore):
             search_col=legacy_date,
             search_val=orderby_value,
             search_op="<",
-            qc_gear=self.__form_configs.legacy_qc_gear,
+            qc_gear=[self.__form_configs.legacy_qc_gear, self.__form_configs.qc_gear],  # type: ignore
         )
 
         if not legacy_visits:
@@ -302,6 +304,8 @@ class DatastoreHelper(Datastore):
                 if self.__module_configs.legacy_module.initial_packets:
                     ivp_codes = self.__module_configs.legacy_module.initial_packets
 
+            # include both QC gears for legacy lookup
+            # as some modules are processed using new submission pipeline
             initial_visits = self.__forms_store.query_form_data(
                 subject_lbl=subject_lbl,
                 module=module,
@@ -309,7 +313,10 @@ class DatastoreHelper(Datastore):
                 search_col=FieldNames.PACKET,
                 search_val=ivp_codes,
                 search_op=DefaultValues.FW_SEARCH_OR,
-                qc_gear=self.__form_configs.legacy_qc_gear,
+                qc_gear=[
+                    self.__form_configs.legacy_qc_gear,
+                    self.__form_configs.qc_gear,
+                ],  # type: ignore
                 extra_columns=[date_field],
             )
 

--- a/gear/form_qc_coordinator/src/docker/BUILD
+++ b/gear/form_qc_coordinator/src/docker/BUILD
@@ -7,5 +7,5 @@ docker_image(
         ":manifest",
         "gear/form_qc_coordinator/src/python/form_qc_coordinator_app:bin",
     ],
-    image_tags=["1.6.0", "latest"],
+    image_tags=["1.6.1", "latest"],
 )

--- a/gear/form_qc_coordinator/src/docker/manifest.json
+++ b/gear/form_qc_coordinator/src/docker/manifest.json
@@ -2,7 +2,7 @@
   "name": "form-qc-coordinator",
   "label": "Form QC Coordinator",
   "description": "A gear to coordinate data quality checks for a given participant",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "author": "NACC",
   "maintainer": "NACC <nacchelp@uw.edu>",
   "cite": "",
@@ -15,7 +15,7 @@
   "custom": {
     "gear-builder": {
       "category": "utility",
-      "image": "naccdata/form-qc-coordinator:1.6.0"
+      "image": "naccdata/form-qc-coordinator:1.6.1"
     },
     "flywheel": {
       "suite": "Utility",

--- a/gear/form_transformer/data/form-data-module-configs.json
+++ b/gear/form_transformer/data/form-data-module-configs.json
@@ -317,11 +317,20 @@
                 "11.0"
             ],
             "date_field": "npformdate",
+            "legacy_module": {
+                "label": "NP",
+                "date_field": "visitdate",
+                "initial_packets": [
+                    "NP"
+                ],
+                "followup_packets": []
+            },
             "preprocess_checks": [
                 "duplicate-record",
                 "version",
                 "packet",
                 "clinical-forms",
+                "singleton",
                 "np-mlst-restrictions",
                 "np-uds-restrictions"
             ],
@@ -356,7 +365,8 @@
             "date_field": "visitdate",
             "preprocess_checks": [
                 "duplicate-record",
-                "version"
+                "version",
+                "singleton"
             ],
             "longitudinal": false
         },

--- a/gear/form_transformer/data/form-data-module-configs.json
+++ b/gear/form_transformer/data/form-data-module-configs.json
@@ -329,8 +329,8 @@
                 "duplicate-record",
                 "version",
                 "packet",
-                "clinical-forms",
                 "singleton",
+                "clinical-forms",
                 "np-mlst-restrictions",
                 "np-uds-restrictions"
             ],

--- a/gear/form_transformer/src/docker/BUILD
+++ b/gear/form_transformer/src/docker/BUILD
@@ -4,5 +4,5 @@ docker_image(
     name="form-transformer",
     source="Dockerfile",
     dependencies=[":manifest", "gear/form_transformer/src/python/form_csv_app:bin"],
-    image_tags=["1.9.0", "latest"],
+    image_tags=["1.10.0", "latest"],
 )

--- a/gear/form_transformer/src/docker/manifest.json
+++ b/gear/form_transformer/src/docker/manifest.json
@@ -2,7 +2,7 @@
   "name": "form-transformer",
   "label": "Form CSV to JSON Transformer",
   "description": "Form specific transformation from CSV to JSON",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "author": "NACC",
   "maintainer": "NACC <nacchelp@uw.edu>",
   "cite": "",
@@ -15,7 +15,7 @@
   "custom": {
     "gear-builder": {
       "category": "utility",
-      "image": "naccdata/form-transformer:1.9.0"
+      "image": "naccdata/form-transformer:1.10.0"
     },
     "flywheel": {
       "suite": "Curation",

--- a/gear/identifier_lookup/src/docker/BUILD
+++ b/gear/identifier_lookup/src/docker/BUILD
@@ -4,5 +4,5 @@ docker_image(
     name="identifier-lookup",
     source="Dockerfile",
     dependencies=[":manifest", "gear/identifier_lookup/src/python/identifier_app:bin"],
-    image_tags=["2.4.1", "latest"],
+    image_tags=["2.4.2", "latest"],
 )

--- a/gear/identifier_lookup/src/docker/manifest.json
+++ b/gear/identifier_lookup/src/docker/manifest.json
@@ -2,7 +2,7 @@
   "name": "identifier-lookup",
   "label": "Identifier Lookup",
   "description": "Gear to look up participant identifiers for incoming data and capture visit events when QC logging is enabled",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "author": "NACC",
   "maintainer": "NACC <nacchelp@uw.edu>",
   "cite": "",
@@ -15,7 +15,7 @@
   "custom": {
     "gear-builder": {
       "category": "utility",
-      "image": "naccdata/identifier-lookup:2.4.1"
+      "image": "naccdata/identifier-lookup:2.4.2"
     },
     "flywheel": {
       "suite": "NACC Data Gears",


### PR DESCRIPTION
Add singleton preprocessing check to restrict BDS and NP to single submission
Update legacy form lookups to include both QC gear tags to support the retrospective modules uploaded in the new portal.
