### PR TITLE
Update disabling inactive users in REDCap projects

### DIFF
--- a/common/src/python/users/redcap_user_operations.py
+++ b/common/src/python/users/redcap_user_operations.py
@@ -40,3 +40,19 @@ def user_has_role_assignment(redcap_project: REDCapProject, username: str) -> bo
     """
     assignments = redcap_project.export_user_role_assignments()
     return any(assignment["username"] == username for assignment in assignments)
+
+
+def delete_user(redcap_project: REDCapProject, username: str) -> int:
+    """Remove a user from a REDCap project.
+
+    Args:
+        redcap_project: The REDCap project instance
+        username: The REDCap username (typically the auth_email)
+
+    Returns:
+        Number of users removed
+
+    Raises:
+        REDCapConnectionError: If the underlying API call fails
+    """
+    return redcap_project.delete_user(username=username)

--- a/common/src/python/users/redcap_user_operations.py
+++ b/common/src/python/users/redcap_user_operations.py
@@ -1,5 +1,7 @@
 """Helper functions for REDCap user operations."""
 
+from typing import Optional
+
 from redcap_api.redcap_project import REDCapProject
 
 
@@ -22,7 +24,9 @@ def unassign_user_role(redcap_project: REDCapProject, username: str) -> int:
     return redcap_project.assign_user_role(username, "")
 
 
-def user_has_role_assignment(redcap_project: REDCapProject, username: str) -> bool:
+def user_has_role_assignment(
+    redcap_project: REDCapProject, username: str, include_empty: Optional[bool] = True
+) -> bool:
     """Check whether a user has a role assignment in a REDCap project.
 
     Queries the project's user-role mappings and checks whether the
@@ -31,15 +35,24 @@ def user_has_role_assignment(redcap_project: REDCapProject, username: str) -> bo
     Args:
         redcap_project: The REDCap project instance
         username: The REDCap username to look up
+        include_empty (optional): Whether to include users with empty role assignments.
+                                  Default True
 
     Returns:
-        True if the username has a role assignment, False otherwise
+        True if the username has a role assignment, or empty role (include_empty=True).
+        False otherwise
 
     Raises:
         REDCapConnectionError: If the underlying API call fails
     """
     assignments = redcap_project.export_user_role_assignments()
-    return any(assignment["username"] == username for assignment in assignments)
+    if include_empty:
+        return any(assignment["username"] == username for assignment in assignments)
+
+    return any(
+        assignment["username"] == username and assignment.get("unique_role_name")
+        for assignment in assignments
+    )
 
 
 def delete_user(redcap_project: REDCapProject, username: str) -> int:

--- a/common/src/python/users/user_processes.py
+++ b/common/src/python/users/user_processes.py
@@ -29,7 +29,7 @@ from users.event_models import (
 )
 from users.failure_analyzer import FailureAnalyzer
 from users.redcap_disable_visitor import REDCapDisableVisitor
-from users.redcap_user_operations import unassign_user_role, user_has_role_assignment
+from users.redcap_user_operations import delete_user, user_has_role_assignment
 from users.user_entry import ActiveUserEntry, CenterUserEntry, UserEntry
 from users.user_process_environment import NotificationClient, UserProcessEnvironment
 from users.user_registry import DomainCandidate, RegistryError, RegistryPerson
@@ -207,7 +207,8 @@ class InactiveUserProcess(BaseUserProcess[UserEntry]):
         username: str,
         user_context: UserContext,
     ) -> None:
-        """Attempt to unassign a user's role from a single REDCap project.
+        """Attempt to delete the user from the REDCap project with the
+        specified PID.
 
         Args:
             center_group: The center group providing REDCap project access
@@ -271,7 +272,7 @@ class InactiveUserProcess(BaseUserProcess[UserEntry]):
 
         if self.__env.proxy.dry_run:
             log.info(
-                "DRY RUN: Would unassign role for %s in REDCap project %s (PID %s)",
+                "DRY RUN: Would remove user %s from REDCap project %s (PID %s)",
                 username,
                 title,
                 pid,
@@ -281,17 +282,17 @@ class InactiveUserProcess(BaseUserProcess[UserEntry]):
                 category=EventCategory.REDCAP_USER_DISABLED,
                 user_context=user_context,
                 message=(
-                    f"DRY RUN: Would unassign role for {username} "
-                    f"in REDCap project {title} (PID {pid})"
+                    f"DRY RUN: Would remove user {username} "
+                    f"from REDCap project {title} (PID {pid})"
                 ),
             )
             self.collector.collect(success_event)
             return
 
         try:
-            unassign_user_role(redcap_project, username)
+            delete_user(redcap_project, username)
             log.info(
-                "unassigned role for %s in REDCap project %s (PID %s)",
+                "removed user %s from REDCap project %s (PID %s)",
                 username,
                 title,
                 pid,
@@ -301,14 +302,13 @@ class InactiveUserProcess(BaseUserProcess[UserEntry]):
                 category=EventCategory.REDCAP_USER_DISABLED,
                 user_context=user_context,
                 message=(
-                    f"Unassigned role for {username} "
-                    f"in REDCap project {title} (PID {pid})"
+                    f"Removed user {username} from REDCap project {title} (PID {pid})"
                 ),
             )
             self.collector.collect(success_event)
         except REDCapConnectionError as error:
             log.error(
-                "failed to unassign role for %s in REDCap project %s (PID %s): %s",
+                "failed to remove user %s from REDCap project %s (PID %s): %s",
                 username,
                 title,
                 pid,
@@ -319,8 +319,8 @@ class InactiveUserProcess(BaseUserProcess[UserEntry]):
                 category=EventCategory.REDCAP_USER_DISABLED,
                 user_context=user_context,
                 message=(
-                    f"Failed to unassign role for {username} "
-                    f"in REDCap project {title} (PID {pid}): {error}"
+                    f"Failed to remove user {username} "
+                    f"from REDCap project {title} (PID {pid}): {error}"
                 ),
             )
             self.collector.collect(error_event)
@@ -331,10 +331,10 @@ class InactiveUserProcess(BaseUserProcess[UserEntry]):
         user_context: UserContext,
         auth_email: Optional[str],
     ) -> None:
-        """Step 3: Remove user roles from all REDCap projects.
+        """Step 3: Remove user from all REDCap projects.
 
         Iterates over all centers, finds REDCap projects via the visitor
-        pattern, and unassigns the user's role from each project.
+        pattern, and removes the user from each project (if present).
 
         Args:
             entry: The inactive user entry

--- a/common/test/python/user_test/test_inactive_user_process_redcap.py
+++ b/common/test/python/user_test/test_inactive_user_process_redcap.py
@@ -223,8 +223,8 @@ class TestAuthEmailResolution:
 
         process.visit(entry)
 
-        # unassign_user_role should be called with the entry's auth_email
-        mock_redcap.assign_user_role.assert_called_once_with("entry-auth@uni.edu", "")
+        # delete_user should be called with the entry's auth_email
+        mock_redcap.delete_user.assert_called_once_with(username="entry-auth@uni.edu")
 
     def test_comanage_auth_email_used_when_entry_has_none(self) -> None:
         """When entry has no auth_email but COmanage lookup returns one, the
@@ -249,8 +249,8 @@ class TestAuthEmailResolution:
 
         process.visit(entry)
 
-        mock_redcap.assign_user_role.assert_called_once_with(
-            "comanage-auth@uni.edu", ""
+        mock_redcap.delete_user.assert_called_once_with(
+            username="comanage-auth@uni.edu"
         )
 
     def test_directory_email_fallback_when_no_registry_match(self) -> None:
@@ -275,7 +275,7 @@ class TestAuthEmailResolution:
 
         process.visit(entry)
 
-        mock_redcap.assign_user_role.assert_called_once_with("dir@example.com", "")
+        mock_redcap.delete_user.assert_called_once_with(username="dir@example.com")
 
 
 # ===========================================================================
@@ -349,11 +349,11 @@ class TestCenterIteration:
         metadata = _build_center_metadata_with_redcap([100, 200])
 
         mock_redcap_100 = _build_mock_redcap(title="Project 100")
-        mock_redcap_100.assign_user_role.side_effect = REDCapConnectionError(
+        mock_redcap_100.delete_user.side_effect = REDCapConnectionError(
             "connection failed"
         )
         mock_redcap_200 = _build_mock_redcap(title="Project 200")
-        mock_redcap_200.assign_user_role.return_value = 1
+        mock_redcap_200.delete_user.return_value = 1
 
         center_groups = _setup_center_map_with_centers(
             mock_env,
@@ -371,8 +371,8 @@ class TestCenterIteration:
         process.visit(entry)
 
         # Both projects should have been attempted
-        mock_redcap_100.assign_user_role.assert_called_once()
-        mock_redcap_200.assign_user_role.assert_called_once()
+        mock_redcap_100.delete_user.assert_called_once()
+        mock_redcap_200.delete_user.assert_called_once()
 
         # One error, one success
         redcap_events = [
@@ -418,7 +418,7 @@ class TestCenterIteration:
         process.visit(entry)
 
         # Center 2's project should still be processed
-        mock_redcap.assign_user_role.assert_called_once()
+        mock_redcap.delete_user.assert_called_once()
 
 
 # ===========================================================================
@@ -431,7 +431,7 @@ class TestDryRunMode:
     """Test dry-run mode behavior."""
 
     def test_dry_run_does_not_call_unassign(self) -> None:
-        """In dry-run mode, unassign_user_role is not called.
+        """In dry-run mode, delete_user is not called.
 
         Validates: Requirement 3.7
         """
@@ -449,8 +449,8 @@ class TestDryRunMode:
 
         process.visit(entry)
 
-        # assign_user_role should NOT be called
-        mock_redcap.assign_user_role.assert_not_called()
+        # delete_user should NOT be called
+        mock_redcap.delete_user.assert_not_called()
 
     def test_dry_run_collects_success_event(self) -> None:
         """In dry-run mode, a success event is still collected.
@@ -528,7 +528,7 @@ class TestEventCollection:
         """
         mock_env = _build_mock_env()
         mock_redcap = _build_mock_redcap(title="UDS Forms")
-        mock_redcap.assign_user_role.side_effect = REDCapConnectionError("timeout")
+        mock_redcap.delete_user.side_effect = REDCapConnectionError("timeout")
         metadata = _build_center_metadata_with_redcap([100])
         _setup_center_map_with_centers(
             mock_env,
@@ -615,7 +615,7 @@ class TestStepIndependence:
         process.visit(entry)
 
         # REDCap unassignment was still attempted
-        mock_redcap.assign_user_role.assert_called_once()
+        mock_redcap.delete_user.assert_called_once()
 
     def test_comanage_suspend_runs_even_if_redcap_step_fails(self) -> None:
         """COmanage suspend runs even when the REDCap step raises.
@@ -678,7 +678,7 @@ class TestFourStepOrdering:
         process.visit(entry)
 
         # The REDCap step should use the auth_email from COmanage lookup
-        mock_redcap.assign_user_role.assert_called_once_with("looked-up@uni.edu", "")
+        mock_redcap.delete_user.assert_called_once_with(username="looked-up@uni.edu")
 
     def test_comanage_suspend_happens_after_redcap_step(self) -> None:
         """COmanage suspend (Step 4) happens after REDCap step (Step 3).
@@ -698,13 +698,13 @@ class TestFourStepOrdering:
         mock_env.user_registry.get.return_value = [person]
 
         call_order: list[str] = []
-        original_assign = mock_redcap.assign_user_role
+        original_delete = mock_redcap.delete_user
 
         def track_assign(*args, **kwargs):
             call_order.append("redcap_unassign")
-            return original_assign.return_value
+            return original_delete.return_value
 
-        mock_redcap.assign_user_role.side_effect = track_assign
+        mock_redcap.delete_user.side_effect = track_assign
 
         original_suspend = mock_env.user_registry.suspend
 
@@ -734,23 +734,16 @@ class TestFourStepOrdering:
 
 
 class TestBugConditionExploration:
-    """Explore the bug condition where unassign_user_role is called for
-    projects where the user has no role assignment.
+    """Tests for the membership-guard behavior: delete_user should only be
+    called for projects where the user actually has a role assignment.
 
-    These tests encode the EXPECTED (correct) behavior. On unfixed code
-    they are expected to FAIL, which confirms the bug exists.
-
-    Bug condition: assign_user_role is called unconditionally for every
-    REDCap project, even when the user has no role assignment in that
-    project.
+    These tests encode the EXPECTED (correct) behavior and should PASS
+    against the fixed implementation.
     """
 
     def test_non_member_user_should_not_be_unassigned(self) -> None:
-        """When a user has no role assignment in a REDCap project,
-        assign_user_role should NOT be called for that project.
-
-        Bug condition: on unfixed code assign_user_role IS called
-        unconditionally, so this assertion will fail.
+        """When a user has no role assignment in a REDCap project, delete_user
+        should NOT be called for that project.
 
         Validates: Requirements 1.1, 2.1
         """
@@ -772,17 +765,13 @@ class TestBugConditionExploration:
 
         process.visit(entry)
 
-        # Expected: assign_user_role should NOT be called because user
+        # Expected: delete_user should NOT be called because user
         # has no role assignment in this project.
-        # Bug: on unfixed code it IS called with ("user@example.com", "")
-        mock_redcap.assign_user_role.assert_not_called()
+        mock_redcap.delete_user.assert_not_called()
 
     def test_non_member_user_should_not_emit_success_event(self) -> None:
         """When a user has no role assignment in a REDCap project, no success
         event with REDCAP_USER_DISABLED should be emitted.
-
-        Bug condition: on unfixed code a success event IS emitted,
-        so this assertion will fail.
 
         Validates: Requirements 1.2, 2.2
         """
@@ -818,10 +807,7 @@ class TestBugConditionExploration:
 
     def test_mixed_membership_only_unassigns_member_projects(self) -> None:
         """When a user is a member of PID 100 but NOT PID 200 or PID 300,
-        assign_user_role should be called exactly once (for PID 100 only).
-
-        Bug condition: on unfixed code assign_user_role is called for
-        all 3 projects, so the call count assertion will fail.
+        delete_user should be called exactly once (for PID 100 only).
 
         Validates: Requirements 1.3, 2.1, 2.2
         """
@@ -863,11 +849,10 @@ class TestBugConditionExploration:
 
         process.visit(entry)
 
-        # Expected: assign_user_role called exactly once (PID 100 only)
-        # Bug: on unfixed code it is called 3 times (all projects)
-        mock_redcap_100.assign_user_role.assert_called_once()
-        mock_redcap_200.assign_user_role.assert_not_called()
-        mock_redcap_300.assign_user_role.assert_not_called()
+        # Expected: delete_user called exactly once (PID 100 only)
+        mock_redcap_100.delete_user.assert_called_once_with(username="user@example.com")
+        mock_redcap_200.delete_user.assert_not_called()
+        mock_redcap_300.delete_user.assert_not_called()
 
         # Expected: exactly 1 success event (for PID 100 only)
         redcap_successes = [
@@ -936,7 +921,7 @@ class TestPreservationProperties:
     """
 
     # -----------------------------------------------------------------------
-    # Property 2a: Member user unassignment — assign_user_role is called
+    # Property 2a: Member user unassignment — delete_user is called
     # and a success event with REDCAP_USER_DISABLED is emitted
     # Validates: Requirements 3.1
     # -----------------------------------------------------------------------
@@ -947,9 +932,9 @@ class TestPreservationProperties:
         username: str,
         role_mappings: list,
     ) -> None:
-        """When a user IS a member of a REDCap project, assign_user_role is
-        called with (username, "") and a success event with
-        REDCAP_USER_DISABLED category is emitted.
+        """When a user IS a member of a REDCap project, delete_user is called
+        with the username and a success event with REDCAP_USER_DISABLED
+        category is emitted.
 
         **Validates: Requirements 3.1**
         """
@@ -968,8 +953,8 @@ class TestPreservationProperties:
 
         process.visit(entry)
 
-        # assign_user_role must be called with (username, "")
-        mock_redcap.assign_user_role.assert_called_once_with(username, "")
+        # delete_user must be called with the username
+        mock_redcap.delete_user.assert_called_once_with(username=username)
 
         # A success event with REDCAP_USER_DISABLED must be emitted
         redcap_successes = [
@@ -982,7 +967,7 @@ class TestPreservationProperties:
         assert "Preservation Project" in redcap_successes[0].message
 
     # -----------------------------------------------------------------------
-    # Property 2b: Dry-run mode — assign_user_role is NOT called but a
+    # Property 2b: Dry-run mode — delete_user is NOT called but a
     # dry-run success event IS emitted
     # Validates: Requirements 3.3
     # -----------------------------------------------------------------------
@@ -993,8 +978,8 @@ class TestPreservationProperties:
         username: str,
         role_mappings: list,
     ) -> None:
-        """In dry-run mode with a member user, assign_user_role is NOT called
-        but a dry-run success event with REDCAP_USER_DISABLED IS emitted.
+        """In dry-run mode with a member user, delete_user is NOT called but a
+        dry-run success event with REDCAP_USER_DISABLED IS emitted.
 
         **Validates: Requirements 3.3**
         """
@@ -1013,8 +998,8 @@ class TestPreservationProperties:
 
         process.visit(entry)
 
-        # assign_user_role must NOT be called in dry-run mode
-        mock_redcap.assign_user_role.assert_not_called()
+        # delete_user must NOT be called in dry-run mode
+        mock_redcap.delete_user.assert_not_called()
 
         # A dry-run success event must be emitted
         redcap_successes = [
@@ -1027,7 +1012,7 @@ class TestPreservationProperties:
 
     # -----------------------------------------------------------------------
     # Property 2c: Error handling — REDCapConnectionError from
-    # assign_user_role emits an error event and processing continues
+    # delete_user emits an error event and processing continues
     # Validates: Requirements 3.4
     # -----------------------------------------------------------------------
 
@@ -1037,18 +1022,18 @@ class TestPreservationProperties:
         username: str,
         role_mappings: list,
     ) -> None:
-        """When assign_user_role raises REDCapConnectionError for a member
-        user, an error event with REDCAP_USER_DISABLED category is emitted and
+        """When delete_user raises REDCapConnectionError for a member user, an
+        error event with REDCAP_USER_DISABLED category is emitted and
         processing continues to the next project.
 
         **Validates: Requirements 3.4**
         """
         mock_env = _build_mock_env()
 
-        # First project: assign_user_role raises REDCapConnectionError
+        # First project: delete_user raises REDCapConnectionError
         mock_redcap_100 = _build_mock_redcap(title="Error Project")
         mock_redcap_100.export_user_role_assignments.return_value = role_mappings
-        mock_redcap_100.assign_user_role.side_effect = REDCapConnectionError(
+        mock_redcap_100.delete_user.side_effect = REDCapConnectionError(
             "connection timeout"
         )
 
@@ -1057,7 +1042,7 @@ class TestPreservationProperties:
         mock_redcap_200.export_user_role_assignments.return_value = [
             {"username": username, "unique_role_name": "U-role1"},
         ]
-        mock_redcap_200.assign_user_role.return_value = 1
+        mock_redcap_200.delete_user.return_value = 1
 
         metadata = _build_center_metadata_with_redcap([100, 200])
         center_groups = _setup_center_map_with_centers(
@@ -1075,8 +1060,8 @@ class TestPreservationProperties:
         process.visit(entry)
 
         # Both projects should have been attempted
-        mock_redcap_100.assign_user_role.assert_called_once()
-        mock_redcap_200.assign_user_role.assert_called_once()
+        mock_redcap_100.delete_user.assert_called_once()
+        mock_redcap_200.delete_user.assert_called_once()
 
         # One error event for the failed project
         redcap_events = [
@@ -1188,4 +1173,4 @@ class TestPreservationProperties:
         process.visit(entry)
 
         # Center 2's project should still be processed
-        mock_redcap.assign_user_role.assert_called_once()
+        mock_redcap.delete_user.assert_called_once()

--- a/common/test/python/user_test/test_redcap_user_operations.py
+++ b/common/test/python/user_test/test_redcap_user_operations.py
@@ -53,7 +53,7 @@ class TestUnassignUserRole:
 
         delete_user(mock_project, "user@example.com")
 
-        mock_project.delete_user.assert_called_once_with("user@example.com")
+        mock_project.delete_user.assert_called_once_with(username="user@example.com")
 
 
 class TestUserHasRoleAssignment:
@@ -117,9 +117,7 @@ class TestUserHasRoleAssignment:
             {"username": "carol@uni.edu", "unique_role_name": ""},
         ]
 
-        result = user_has_role_assignment(
-            mock_project, "carol@uni.edu", include_empty=False
-        )
+        result = user_has_role_assignment(mock_project, "carol@uni.edu")
 
         assert result is True
 

--- a/common/test/python/user_test/test_redcap_user_operations.py
+++ b/common/test/python/user_test/test_redcap_user_operations.py
@@ -5,7 +5,11 @@ from unittest.mock import Mock
 import pytest
 from redcap_api.redcap_connection import REDCapConnectionError
 from redcap_api.redcap_project import REDCapProject
-from users.redcap_user_operations import unassign_user_role, user_has_role_assignment
+from users.redcap_user_operations import (
+    delete_user,
+    unassign_user_role,
+    user_has_role_assignment,
+)
 
 
 class TestUnassignUserRole:
@@ -41,6 +45,15 @@ class TestUnassignUserRole:
 
         with pytest.raises(REDCapConnectionError):
             unassign_user_role(mock_project, "user@example.com")
+
+    def test_delete_user(self):
+        """Test delete_user calls delete_user with the username."""
+        mock_project = Mock(spec=REDCapProject)
+        mock_project.delete_user.return_value = 1
+
+        delete_user(mock_project, "user@example.com")
+
+        mock_project.delete_user.assert_called_once_with("user@example.com")
 
 
 class TestUserHasRoleAssignment:
@@ -78,6 +91,51 @@ class TestUserHasRoleAssignment:
         mock_project.export_user_role_assignments.return_value = []
 
         result = user_has_role_assignment(mock_project, "user@example.com")
+
+        assert result is False
+
+    def test_returns_false_when_user_does_not_exist(self):
+        """When the username does not appear in the role assignment list,
+        returns False."""
+        mock_project = Mock(spec=REDCapProject)
+        mock_project.export_user_role_assignments.return_value = [
+            {"username": "alice@uni.edu", "unique_role_name": "U-role1"},
+            {"username": "bob@uni.edu", "unique_role_name": "U-role2"},
+        ]
+
+        result = user_has_role_assignment(mock_project, "carol@uni.edu")
+
+        assert result is False
+
+    def test_include_empty_true(self):
+        """Returns True if username appears in the role assignment list with an
+        empty role."""
+        mock_project = Mock(spec=REDCapProject)
+        mock_project.export_user_role_assignments.return_value = [
+            {"username": "alice@uni.edu", "unique_role_name": "U-role1"},
+            {"username": "bob@uni.edu", "unique_role_name": "U-role2"},
+            {"username": "carol@uni.edu", "unique_role_name": ""},
+        ]
+
+        result = user_has_role_assignment(
+            mock_project, "carol@uni.edu", include_empty=False
+        )
+
+        assert result is True
+
+    def test_include_empty_false(self):
+        """Returns False if username appears in the role assignment list with
+        an empty role."""
+        mock_project = Mock(spec=REDCapProject)
+        mock_project.export_user_role_assignments.return_value = [
+            {"username": "alice@uni.edu", "unique_role_name": "U-role1"},
+            {"username": "bob@uni.edu", "unique_role_name": "U-role2"},
+            {"username": "carol@uni.edu", "unique_role_name": ""},
+        ]
+
+        result = user_has_role_assignment(
+            mock_project, "carol@uni.edu", include_empty=False
+        )
 
         assert result is False
 

--- a/python-default.lock
+++ b/python-default.lock
@@ -33,7 +33,7 @@
 //     "pyyaml>=6.0.1",
 //     "ratelimit-types>=0.0.1",
 //     "ratelimit>=2.2.1",
-//     "redcap_api@ https://github.com/naccdata/redcap-api/releases/download/v0.3.0/redcap_api-0.3.0-py3-none-any.whl",
+//     "redcap_api@ https://github.com/naccdata/redcap-api/releases/download/v0.4.0/redcap_api-0.4.0-py3-none-any.whl",
 //     "requests-oauthlib>=2.0.0",
 //     "requests>=2.18.4",
 //     "setuptools>=68.3.0",
@@ -147,42 +147,42 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "7b62ce5c0a51428d692aa4f2adc9dc2a4a4c2989bf65a0a12834eeffa99b0b84",
-              "url": "https://files.pythonhosted.org/packages/a7/75/fcb2c10d516496536c50e397248de42a673d8ea8137caf5b578a72b11293/boto3-1.43.18-py3-none-any.whl"
+              "hash": "8bb863b32dabe5baa4f2e3701778c259243ba117e4811a595411819958c4fb1b",
+              "url": "https://files.pythonhosted.org/packages/01/ea/5352950cbee9d1e8392e5396ddbc6defc982414e2abc004b501139bce13c/boto3-1.43.21-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "33138883e984eb1937d1553da699182c8ad2099138091e885b65c9accbccea16",
-              "url": "https://files.pythonhosted.org/packages/22/37/2ae45d06423182b4561c03bc33494fafa21a0d1e847f0554f590e3cbbc62/boto3-1.43.18.tar.gz"
+              "hash": "6dfeb70bf4f9a3514b91c7199f475f71f939199d62f9c63cd555b033fb283f89",
+              "url": "https://files.pythonhosted.org/packages/1e/f2/0ef88b6584285002a8a8000e34340f56e82681ad2b8a76ea8bd3ecaa5cb9/boto3-1.43.21.tar.gz"
             }
           ],
           "project_name": "boto3",
           "requires_dists": [
-            "botocore<1.44.0,>=1.43.18",
+            "botocore<1.44.0,>=1.43.21",
             "botocore[crt]<2.0a0,>=1.21.0; extra == \"crt\"",
             "jmespath<2.0.0,>=0.7.1",
             "s3transfer<0.19.0,>=0.18.0"
           ],
           "requires_python": ">=3.10",
-          "version": "1.43.18"
+          "version": "1.43.21"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "c4215090a2945339d0f32065520fb2df54fec25fc5cbc8b266779984c2c5540d",
-              "url": "https://files.pythonhosted.org/packages/83/fd/981298cc78006bb1e396bff3a78afff8d9f1ae0cfeb376179c9d03873e7c/boto3_stubs-1.43.18-py3-none-any.whl"
+              "hash": "ee22423baf9d851b153359d3a2084bd72791a275613e024472de20cec914df11",
+              "url": "https://files.pythonhosted.org/packages/b9/19/0fbd0180e7079ddaa0355bb9aa480fc3c3789b8d3f19e78bd345ae22d0ce/boto3_stubs-1.43.21-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "09bf480c62bc54cf59bd0ad13b3db0ed9a00592675fd01248bcba4f93eaa7660",
-              "url": "https://files.pythonhosted.org/packages/9f/9d/1c492f6f1b52c977516401a6ab6782e619431b2925e049d8d3327af7d1f5/boto3_stubs-1.43.18.tar.gz"
+              "hash": "3d19abddee803df1f7b430b67f64fcd0b965a1eeeb7aea73a736a4c9af19a81c",
+              "url": "https://files.pythonhosted.org/packages/89/ed/532a5ca23314be6aa741f93a0ee4a705ead754abb72ca90156bc64421924/boto3_stubs-1.43.21.tar.gz"
             }
           ],
           "project_name": "boto3-stubs",
           "requires_dists": [
             "boto3-stubs-full<1.44.0,>=1.43.0; extra == \"full\"",
-            "boto3==1.43.18; extra == \"boto3\"",
+            "boto3==1.43.21; extra == \"boto3\"",
             "botocore-stubs",
             "mypy-boto3-accessanalyzer<1.44.0,>=1.43.0; extra == \"accessanalyzer\"",
             "mypy-boto3-accessanalyzer<1.44.0,>=1.43.0; extra == \"all\"",
@@ -892,6 +892,8 @@
             "mypy-boto3-sagemaker-runtime<1.44.0,>=1.43.0; extra == \"sagemaker-runtime\"",
             "mypy-boto3-sagemaker<1.44.0,>=1.43.0; extra == \"all\"",
             "mypy-boto3-sagemaker<1.44.0,>=1.43.0; extra == \"sagemaker\"",
+            "mypy-boto3-sagemakerjobruntime<1.44.0,>=1.43.0; extra == \"all\"",
+            "mypy-boto3-sagemakerjobruntime<1.44.0,>=1.43.0; extra == \"sagemakerjobruntime\"",
             "mypy-boto3-savingsplans<1.44.0,>=1.43.0; extra == \"all\"",
             "mypy-boto3-savingsplans<1.44.0,>=1.43.0; extra == \"savingsplans\"",
             "mypy-boto3-scheduler<1.44.0,>=1.43.0; extra == \"all\"",
@@ -1043,19 +1045,19 @@
             "typing-extensions>=4.1.0; python_version < \"3.12\""
           ],
           "requires_python": ">=3.9",
-          "version": "1.43.18"
+          "version": "1.43.21"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "e2610fce16df9f89deab5f3c163430a814e6804034eb95bef8957c8db60b7dbc",
-              "url": "https://files.pythonhosted.org/packages/21/5a/35c92c0af1514581031fe66c398b622176b3c928a6d5cf8133c7207e3bd7/botocore-1.43.18-py3-none-any.whl"
+              "hash": "f021ba3e844c36031106fc531ec90259ef005ba5d04f691df53bc4ecbd08f0dd",
+              "url": "https://files.pythonhosted.org/packages/bb/c7/8c60049357e96d663980d66b98a44cb3626a7e5eaca66480b97826eb5379/botocore-1.43.21-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "dc8c105351b49688c667065cd5a45fc5b9db982657cefc9e3fbfb9417a55c7df",
-              "url": "https://files.pythonhosted.org/packages/01/6d/436d69ec484ffc43635b38d7fb7d717d38824671f10e12e77924019ca929/botocore-1.43.18.tar.gz"
+              "hash": "17604607efe28894e947401379e569cc8f0fe2d69337ece98bd0c82d1bcfaf92",
+              "url": "https://files.pythonhosted.org/packages/7b/97/d9d26cebf0a8533105e183d8438931c0b196e52484cd5bf00e8443ac1b2d/botocore-1.43.21.tar.gz"
             }
           ],
           "project_name": "botocore",
@@ -1066,7 +1068,7 @@
             "urllib3!=2.2.0,<3,>=1.25.4"
           ],
           "requires_python": ">=3.10",
-          "version": "1.43.18"
+          "version": "1.43.21"
         },
         {
           "artifacts": [
@@ -1718,13 +1720,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c",
-              "url": "https://files.pythonhosted.org/packages/de/a7/f76514cc40ad6234098ecdebda08732d75964776c51a42845b7da10649e2/idna-3.17-py3-none-any.whl"
+              "hash": "7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2",
+              "url": "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5eb0cb53bc467c12eadcf6de83163ad8527cec9416f44b9b61b19caedad2b87f",
-              "url": "https://files.pythonhosted.org/packages/b9/28/99c51f664567218d824af024c0251650fb27e4ca066df188dab0769c5b91/idna-3.17.tar.gz"
+              "hash": "ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848",
+              "url": "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz"
             }
           ],
           "project_name": "idna",
@@ -1734,7 +1736,7 @@
             "ruff>=0.6.2; extra == \"all\""
           ],
           "requires_python": ">=3.9",
-          "version": "3.17"
+          "version": "3.18"
         },
         {
           "artifacts": [
@@ -2768,8 +2770,8 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "e9db5166d5fb0d1567edd3da80589c8ad86ade732e4300c103ea16b370f11a77",
-              "url": "https://github.com/naccdata/redcap-api/releases/download/v0.3.0/redcap_api-0.3.0-py3-none-any.whl"
+              "hash": "29a67e0e6806ba8a8970972692f2702bbd6e4c3c9579316fc00f114c255187e9",
+              "url": "https://github.com/naccdata/redcap-api/releases/download/v0.4.0/redcap_api-0.4.0-py3-none-any.whl"
             }
           ],
           "project_name": "redcap-api",
@@ -2779,7 +2781,7 @@
             "requests>=2.18.4"
           ],
           "requires_python": "==3.12.*",
-          "version": "0.3.0"
+          "version": "0.4.0"
         },
         {
           "artifacts": [
@@ -3433,7 +3435,7 @@
     "pyyaml>=6.0.1",
     "ratelimit-types>=0.0.1",
     "ratelimit>=2.2.1",
-    "redcap_api@ https://github.com/naccdata/redcap-api/releases/download/v0.3.0/redcap_api-0.3.0-py3-none-any.whl",
+    "redcap_api@ https://github.com/naccdata/redcap-api/releases/download/v0.4.0/redcap_api-0.4.0-py3-none-any.whl",
     "requests-oauthlib>=2.0.0",
     "requests>=2.18.4",
     "setuptools>=68.3.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,6 @@ types-pytz
 urllib3 >= 2.2.1
 ratelimit>=2.2.1
 ratelimit-types>=0.0.1
-redcap_api@ https://github.com/naccdata/redcap-api/releases/download/v0.3.0/redcap_api-0.3.0-py3-none-any.whl
+redcap_api@ https://github.com/naccdata/redcap-api/releases/download/v0.4.0/redcap_api-0.4.0-py3-none-any.whl
 nacc_form_validator@ https://github.com/naccdata/nacc-form-validator/releases/download/v0.6.3/nacc_form_validator-0.6.3-py3-none-any.whl
 nacc_attribute_deriver@ https://github.com/naccdata/nacc-attribute-deriver/releases/download/v2.3.1/nacc_attribute_deriver-2.3.1-py3-none-any.whl


### PR DESCRIPTION
- Delete inactive users from REDCap project instead of unassigning from role
- Add include_empty flag to user_has_role_assignment method
- Update redcap-api to 0.4.0

==                    Upgraded dependencies                     ==

  boto3                          1.43.18      -->   1.43.21
  boto3-stubs                    1.43.18      -->   1.43.21
  botocore                       1.43.18      -->   1.43.21
  idna                           3.17         -->   3.18
  redcap-api                     0.3.0        -->   0.4.0