### PR TITLE
Attribute Curator: Delete uds-participant tag

### DIFF
--- a/docs/attribute_curator/CHANGELOG.md
+++ b/docs/attribute_curator/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this gear are documented in this file.
 
+## Unreleased
+
+* Deletes `uds-participant` tag from subjects who had all their UDS visits deleted
+
 ## 1.3.7 - 1.3.9
 
 * Updates `nacc-attribute-deriver` to `2.3.4` - includes D1b-relatex bugfixes

--- a/gear/attribute_curator/src/python/attribute_curator_app/form_curator.py
+++ b/gear/attribute_curator/src/python/attribute_curator_app/form_curator.py
@@ -496,7 +496,7 @@ class FormCurator(Curator):
             subject.add_tag(uds_tag)
 
         # sometimes deletion events can cause an orphaned uds-participant
-        # tag with no UDS data, so need to clean up tags as well
+        # tag on subjec with no UDS data, so need to clean up tags as well
         elif FormScope.UDS not in curated_scopes and uds_tag in subject.tags:
             log.debug(f"Removing UDS participant: {subject.label}")
             subject.delete_tag(uds_tag)

--- a/gear/attribute_curator/src/python/attribute_curator_app/form_curator.py
+++ b/gear/attribute_curator/src/python/attribute_curator_app/form_curator.py
@@ -489,13 +489,17 @@ class FormCurator(Curator):
         elif affiliate != 1 and affiliate_tag in subject.tags:
             subject.delete_tag(affiliate_tag)
 
-        # add uds-participant tag
-        # once a UDS participant always a participant so don't
-        # really need to delete tags
+        # add or deletes uds-participant tag
         uds_tag = FormCurationTags.UDS_PARTICIPANT
         if FormScope.UDS in curated_scopes and uds_tag not in subject.tags:
             log.debug(f"Tagging UDS participant: {subject.label}")
             subject.add_tag(uds_tag)
+
+        # sometimes deletion events can cause an orphaned uds-participant
+        # tag with no UDS data, so need to clean up tags as well
+        elif FormScope.UDS not in curated_scopes and uds_tag in subject.tags:
+            log.debug(f"Removing UDS participant: {subject.label}")
+            subject.delete_tag(uds_tag)
 
     def back_propagate_scopes(  # noqa: C901
         self,

--- a/gear/attribute_curator/src/python/attribute_curator_app/form_curator.py
+++ b/gear/attribute_curator/src/python/attribute_curator_app/form_curator.py
@@ -498,7 +498,7 @@ class FormCurator(Curator):
         # sometimes deletion events can cause an orphaned uds-participant
         # tag on subjec with no UDS data, so need to clean up tags as well
         elif FormScope.UDS not in curated_scopes and uds_tag in subject.tags:
-            log.debug(f"Removing UDS participant: {subject.label}")
+            log.debug(f"Untagging non-UDS participant: {subject.label}")
             subject.delete_tag(uds_tag)
 
     def back_propagate_scopes(  # noqa: C901


### PR DESCRIPTION
Sometimes deletion events can cause an orphaned uds-participant tag on subject with no UDS data, so need to clean up.