### PR TITLE
Update event logging

### DIFF
--- a/common/src/python/event_capture/event_processor.py
+++ b/common/src/python/event_capture/event_processor.py
@@ -307,22 +307,13 @@ class QCEventProcessor:
         Returns:
             QCEventData if extraction successful, None otherwise
         """
-        # Reload file to ensure .info metadata is populated
-        # (files.find() returns FileOutput objects without full metadata)
-        json_file = json_file.reload()
-
         # Extract visit metadata from JSON file (includes packet)
-        # Note: DataIdentificationExtractor is imported from
-        # event_capture.visit_extractor
+        # Note: from_json_file_metadata handles reload() internally
         visit_metadata = DataIdentificationExtractor.from_json_file_metadata(
             json_file, form_configs=self._form_configs
         )
         if not visit_metadata:
-            info_keys = list(json_file.info.keys()) if json_file.info else None
-            log.warning(
-                f"No forms.json metadata found for {json_file.name} "
-                f"(info keys: {info_keys})"
-            )
+            log.warning(f"No forms.json metadata found for {json_file.name}")
             return None
 
         # Find corresponding QC status log

--- a/common/src/python/event_capture/event_processor.py
+++ b/common/src/python/event_capture/event_processor.py
@@ -307,6 +307,10 @@ class QCEventProcessor:
         Returns:
             QCEventData if extraction successful, None otherwise
         """
+        # Reload file to ensure .info metadata is populated
+        # (files.find() returns FileOutput objects without full metadata)
+        json_file = json_file.reload()
+
         # Extract visit metadata from JSON file (includes packet)
         # Note: DataIdentificationExtractor is imported from
         # event_capture.visit_extractor

--- a/common/src/python/event_capture/event_processor.py
+++ b/common/src/python/event_capture/event_processor.py
@@ -27,6 +27,7 @@ and packet information, which are stored in different source files.
 import logging
 from typing import List, Optional
 
+from configs.ingest_configs import FormProjectConfigs
 from error_logging.error_logger import ErrorLogTemplate
 from flywheel.models.file_entry import FileEntry
 from flywheel.rest import ApiException
@@ -35,6 +36,7 @@ from nacc_common.data_identification import DataIdentification
 from nacc_common.error_models import (
     FileQCModel,
 )
+from nacc_common.field_names import FieldNames
 
 from event_capture.event_capture import VisitEventCapture
 from event_capture.event_generator import EventGenerator
@@ -189,6 +191,7 @@ class QCEventProcessor:
         event_capture: Optional[VisitEventCapture],
         dry_run: bool = False,
         date_filter: Optional[DateRange] = None,
+        form_configs: Optional[FormProjectConfigs] = None,
     ):
         """Initialize the QCEventProcessor.
 
@@ -199,6 +202,10 @@ class QCEventProcessor:
             event_capture: Event capture for storing events to S3 (None for dry-run)
             dry_run: Whether to perform a dry run without capturing events
             date_filter: Optional date range for filtering files by creation time
+            form_configs: optional form module configs used to resolve the
+                module-specific date field when extracting visit metadata from
+                forms.json. Falls back to auto-detection when configs are not
+                provided or the module is unknown.
         """
         self._project = project
         self._event_generator = event_generator
@@ -207,6 +214,41 @@ class QCEventProcessor:
         self._dry_run = dry_run
         self._date_filter = date_filter
         self._error_log_template = ErrorLogTemplate()
+        self._form_configs = form_configs
+
+    def _date_field_for(self, json_file: FileEntry) -> Optional[str]:
+        """Return the configured module-specific date field for the file.
+
+        Reads the module from the file's forms.json metadata and looks up its
+        date field in the form module configs. Returns None when configs are
+        unavailable or the module is unknown, letting the extractor auto-detect
+        the date column.
+
+        Args:
+            json_file: the JSON file with forms metadata
+
+        Returns:
+            the module-specific date field, or None if it cannot be resolved
+        """
+        if not self._form_configs:
+            return None
+
+        try:
+            json_file = json_file.reload()
+            forms_json = (
+                json_file.info.get("forms", {}).get("json", {})
+                if json_file.info
+                else {}
+            )
+        except Exception:  # best-effort; fall back to auto-detection
+            return None
+
+        module = forms_json.get(FieldNames.MODULE)
+        if not module:
+            return None
+
+        module_configs = self._form_configs.module_configs.get(module.upper())
+        return module_configs.date_field if module_configs else None
 
     def process_json_files(self) -> None:
         """Discover and process all JSON files.
@@ -300,14 +342,12 @@ class QCEventProcessor:
         Returns:
             QCEventData if extraction successful, None otherwise
         """
-        # Reload file to ensure .info metadata is populated
-        # (files.find() returns FileOutput objects without full metadata)
-        json_file = json_file.reload()
-
         # Extract visit metadata from JSON file (includes packet)
         # Note: DataIdentificationExtractor is imported from
         # event_capture.visit_extractor
-        visit_metadata = DataIdentificationExtractor.from_json_file_metadata(json_file)
+        visit_metadata = DataIdentificationExtractor.from_json_file_metadata(
+            json_file, date_field=self._date_field_for(json_file)
+        )
         if not visit_metadata:
             info_keys = list(json_file.info.keys()) if json_file.info else None
             log.warning(

--- a/common/src/python/event_capture/event_processor.py
+++ b/common/src/python/event_capture/event_processor.py
@@ -36,7 +36,6 @@ from nacc_common.data_identification import DataIdentification
 from nacc_common.error_models import (
     FileQCModel,
 )
-from nacc_common.field_names import FieldNames
 
 from event_capture.event_capture import VisitEventCapture
 from event_capture.event_generator import EventGenerator
@@ -216,40 +215,6 @@ class QCEventProcessor:
         self._error_log_template = ErrorLogTemplate()
         self._form_configs = form_configs
 
-    def _date_field_for(self, json_file: FileEntry) -> Optional[str]:
-        """Return the configured module-specific date field for the file.
-
-        Reads the module from the file's forms.json metadata and looks up its
-        date field in the form module configs. Returns None when configs are
-        unavailable or the module is unknown, letting the extractor auto-detect
-        the date column.
-
-        Args:
-            json_file: the JSON file with forms metadata
-
-        Returns:
-            the module-specific date field, or None if it cannot be resolved
-        """
-        if not self._form_configs:
-            return None
-
-        try:
-            json_file = json_file.reload()
-            forms_json = (
-                json_file.info.get("forms", {}).get("json", {})
-                if json_file.info
-                else {}
-            )
-        except Exception:  # best-effort; fall back to auto-detection
-            return None
-
-        module = forms_json.get(FieldNames.MODULE)
-        if not module:
-            return None
-
-        module_configs = self._form_configs.module_configs.get(module.upper())
-        return module_configs.date_field if module_configs else None
-
     def process_json_files(self) -> None:
         """Discover and process all JSON files.
 
@@ -346,7 +311,7 @@ class QCEventProcessor:
         # Note: DataIdentificationExtractor is imported from
         # event_capture.visit_extractor
         visit_metadata = DataIdentificationExtractor.from_json_file_metadata(
-            json_file, date_field=self._date_field_for(json_file)
+            json_file, form_configs=self._form_configs
         )
         if not visit_metadata:
             info_keys = list(json_file.info.keys()) if json_file.info else None

--- a/common/src/python/event_capture/visit_extractor.py
+++ b/common/src/python/event_capture/visit_extractor.py
@@ -4,9 +4,15 @@ from typing import Any, Dict, Optional
 from deletions.models import DeleteRequest
 from flywheel.models.file_entry import FileEntry
 from nacc_common.data_identification import DataIdentification
+from nacc_common.field_names import FieldNames
 from pydantic import ValidationError
 
 log = logging.getLogger(__name__)
+
+# forms.json stores the raw form record, so the visit date lives under the
+# module-specific date column. Most modules use FieldNames.DATE_COLUMN
+# ("visitdate"); some (e.g. NP) use a module-specific field (FieldNames.NPDATE).
+KNOWN_DATE_FIELDS = (FieldNames.DATE_COLUMN, FieldNames.NPDATE)
 
 
 class DataIdentificationExtractor:
@@ -38,14 +44,17 @@ class DataIdentificationExtractor:
             return None
 
     @staticmethod
-    def from_json_file_metadata(json_file: FileEntry) -> Optional[DataIdentification]:
-        """Extract DataIdentification from JSON file forms metadata.
+    def from_json_file_metadata(
+        json_file: FileEntry, date_field: Optional[str] = None
+    ) -> Optional[DataIdentification]:
+        """Extract DataIdentification from a JSON file's forms.json metadata.
 
-        The forms.json metadata uses normalized field names (visitdate, not
-        module-specific date fields) since it's been processed during upload.
+        If date_field is not provided, the date is auto-detected from the known date fields.
 
         Args:
             json_file: JSON file with forms metadata
+            date_field: the module-specific date column name. If None, the date is
+                auto-detected from the known date fields in the record.
 
         Returns:
             DataIdentification instance or None if not found/invalid
@@ -62,7 +71,9 @@ class DataIdentificationExtractor:
         if not forms_json:
             return None
 
-        return DataIdentificationExtractor.from_forms_json(forms_json)
+        return DataIdentificationExtractor.from_forms_json(
+            forms_json, date_field=date_field
+        )
 
     @staticmethod
     def from_deletion_request_file(
@@ -99,12 +110,15 @@ class DataIdentificationExtractor:
             return None
 
     @staticmethod
-    def from_forms_json(forms_json: dict[str, Any]) -> Optional[DataIdentification]:
-        """Extract DataIdentification from forms.json dict.
+    def from_forms_json(
+        forms_json: dict[str, Any], date_field: Optional[str] = None
+    ) -> Optional[DataIdentification]:
+        """Extract DataIdentification from a forms.json record.
 
         Args:
-            forms_json: Dictionary with forms metadata (ptid, visitdate, module, etc.)
-                May contain the full form data payload or just metadata fields.
+            forms_json: the forms.json record (raw visit record)
+            date_field: the module-specific date column name. If None, the date is
+                auto-detected from the known date fields present in the record.
 
         Returns:
             DataIdentification instance or None if required fields are missing/invalid
@@ -112,34 +126,39 @@ class DataIdentificationExtractor:
         if not forms_json:
             return None
 
-        # Check for required fields before attempting to create DataIdentification
-        module = forms_json.get("module")
-        if not module:
+        # module is required to build a DataIdentification
+        if not forms_json.get(FieldNames.MODULE):
+            log.warning(
+                "Failed to extract DataIdentification: "
+                "Missing 'module' field in forms.json metadata"
+            )
             return None
 
+        # Resolve the visit date from the module-specific date column.
+        if date_field:
+            date_value = forms_json.get(date_field)
+        else:
+            date_value = next(
+                (
+                    forms_json[field]
+                    for field in KNOWN_DATE_FIELDS
+                    if forms_json.get(field)
+                ),
+                None,
+            )
+
+        # Map only the identification fields (forms.json also carries many other
+        # form columns that are not from_visit_metadata parameters).
         try:
-            # Extract only the fields relevant to DataIdentification.
-            # forms.json may contain the full form data (hundreds of fields),
-            # so we must select only the keys that from_visit_metadata accepts.
-            relevant_keys = {
-                "adcid",
-                "ptid",
-                "naccid",
-                "visitnum",
-                "module",
-                "packet",
-                "modality",
-            }
-            mapped_data = {k: forms_json[k] for k in relevant_keys if k in forms_json}
-
-            # Resolve the date field based on module.
-            # NP module uses npformdate; all others use visitdate.
-            # Fall back to visitdate if module-specific field is not present.
-            date_field = "npformdate" if module.upper() == "NP" else "visitdate"
-            date_value = forms_json.get(date_field) or forms_json.get("visitdate")
-            if date_value:
-                mapped_data["date"] = date_value
-
-            return DataIdentification.from_visit_metadata(**mapped_data)
-        except (ValidationError, ValueError, TypeError):
+            return DataIdentification.from_visit_metadata(
+                ptid=forms_json.get(FieldNames.PTID),
+                date=date_value,
+                module=forms_json.get(FieldNames.MODULE),
+                visitnum=forms_json.get(FieldNames.VISITNUM),
+                packet=forms_json.get(FieldNames.PACKET),
+                naccid=forms_json.get(FieldNames.NACCID),
+                adcid=forms_json.get(FieldNames.ADCID),
+            )
+        except (ValidationError, ValueError, TypeError) as err:
+            log.warning("Invalid forms.json metadata: %s", err)
             return None

--- a/common/src/python/event_capture/visit_extractor.py
+++ b/common/src/python/event_capture/visit_extractor.py
@@ -50,7 +50,12 @@ class DataIdentificationExtractor:
         Returns:
             DataIdentification instance or None if not found/invalid
         """
-        if not json_file or not json_file.info:
+
+        if not json_file:
+            return None
+
+        json_file = json_file.reload()
+        if not json_file.info:
             return None
 
         forms_json = json_file.info.get("forms", {}).get("json", {})

--- a/common/src/python/event_capture/visit_extractor.py
+++ b/common/src/python/event_capture/visit_extractor.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Any, Dict, Optional
 
+from configs.ingest_configs import FormProjectConfigs
 from deletions.models import DeleteRequest
 from flywheel.models.file_entry import FileEntry
 from nacc_common.data_identification import DataIdentification
@@ -45,16 +46,19 @@ class DataIdentificationExtractor:
 
     @staticmethod
     def from_json_file_metadata(
-        json_file: FileEntry, date_field: Optional[str] = None
+        json_file: FileEntry, form_configs: Optional[FormProjectConfigs] = None
     ) -> Optional[DataIdentification]:
         """Extract DataIdentification from a JSON file's forms.json metadata.
 
-        If date_field is not provided, the date is auto-detected from the known date fields.
+        The visit date is resolved from the module-specific date column. When
+        form_configs is provided and the file's module is known, the configured
+        date field is used; otherwise the date column is auto-detected from the
+        known module date fields.
 
         Args:
             json_file: JSON file with forms metadata
-            date_field: the module-specific date column name. If None, the date is
-                auto-detected from the known date fields in the record.
+            form_configs: optional form module configs used to resolve the
+                module-specific date field
 
         Returns:
             DataIdentification instance or None if not found/invalid
@@ -71,9 +75,40 @@ class DataIdentificationExtractor:
         if not forms_json:
             return None
 
+        date_field = DataIdentificationExtractor._date_field_from_configs(
+            forms_json, form_configs
+        )
         return DataIdentificationExtractor.from_forms_json(
             forms_json, date_field=date_field
         )
+
+    @staticmethod
+    def _date_field_from_configs(
+        forms_json: dict[str, Any],
+        form_configs: Optional[FormProjectConfigs],
+    ) -> Optional[str]:
+        """Resolve the module-specific date field for a forms.json record.
+
+        Looks up the record's module in the form module configs. Returns None
+        when configs are unavailable or the module is unknown, letting the
+        extractor auto-detect the date column.
+
+        Args:
+            forms_json: the forms.json record (raw visit record)
+            form_configs: optional form module configs
+
+        Returns:
+            the module-specific date field, or None if it cannot be resolved
+        """
+        if not form_configs:
+            return None
+
+        module = forms_json.get(FieldNames.MODULE)
+        if not module:
+            return None
+
+        module_configs = form_configs.module_configs.get(module.upper())
+        return module_configs.date_field if module_configs else None
 
     @staticmethod
     def from_deletion_request_file(

--- a/common/src/python/test_mocks/mock_factories.py
+++ b/common/src/python/test_mocks/mock_factories.py
@@ -25,6 +25,9 @@ def create_mock_file_entry(
     file_entry.info = info or {}
     file_entry.modified = datetime.now()
     file_entry.created = datetime.now()
+    # reload() must return the same mock so reload-aware extractors
+    # (e.g. DataIdentificationExtractor.from_json_file_metadata) see the info.
+    file_entry.reload.return_value = file_entry
     return file_entry
 
 

--- a/common/src/python/test_mocks/mock_factories.py
+++ b/common/src/python/test_mocks/mock_factories.py
@@ -48,7 +48,7 @@ class QCMetadataFactory:
         for gear_name, state in gears.items():
             # Create ValidationModel with specified state
             validation_model = ValidationModel(
-                state=state,
+                state=state,  # type: ignore
                 data=[],  # No errors for PASS status
                 cleared=[],  # No cleared alerts needed
             )
@@ -212,7 +212,8 @@ class FileEntryFactory:
         qc_data = {
             "test-gear": GearQCModel(
                 validation=ValidationModel(
-                    state=qc_status,
+                    state=qc_status,  # type: ignore
+                    cleared=[],
                     data=[],
                 )
             )
@@ -226,6 +227,10 @@ class FileEntryFactory:
         # Put QC data in custom info, not file contents
         file_entry.info = custom_info or {}
         file_entry.info["qc"] = qc_data
+
+        # reload() must return the same object so callers that call reload()
+        # before reading info (e.g. _check_qc_status) see the populated info.
+        file_entry.reload.return_value = file_entry
 
         return file_entry
 

--- a/common/src/python/test_mocks/mock_factories.py
+++ b/common/src/python/test_mocks/mock_factories.py
@@ -51,7 +51,7 @@ class QCMetadataFactory:
         for gear_name, state in gears.items():
             # Create ValidationModel with specified state
             validation_model = ValidationModel(
-                state=state,  # type: ignore
+                state=state,
                 data=[],  # No errors for PASS status
                 cleared=[],  # No cleared alerts needed
             )
@@ -215,7 +215,7 @@ class FileEntryFactory:
         qc_data = {
             "test-gear": GearQCModel(
                 validation=ValidationModel(
-                    state=qc_status,  # type: ignore
+                    state=qc_status,
                     cleared=[],
                     data=[],
                 )

--- a/docs/form_scheduler/CHANGELOG.md
+++ b/docs/form_scheduler/CHANGELOG.md
@@ -2,9 +2,8 @@
 
 All notable changes to this gear are documented in this file.
 
-## 1.5.0
-* Removes unused input file `form_configs_file`
-* Fixes logging `pass-qc` event
+## 1.4.1
+* Fixes event logging
   
 ## 1.4.0
 * Adds deletion workflow

--- a/docs/form_scheduler/CHANGELOG.md
+++ b/docs/form_scheduler/CHANGELOG.md
@@ -3,7 +3,10 @@
 All notable changes to this gear are documented in this file.
 
 ## 1.4.1
-* Fixes event logging
+* Fixes pass-qc event logging: reloads QC status log file before reading metadata to avoid stale/empty info from Flywheel SDK
+* Resolves module-specific date field (e.g. `npformdate` for NP) when extracting visit metadata from forms.json
+* Makes `form_configs_file` input optional — falls back to auto-detection of date fields when not provided
+* Improves operational logging: upgrades debug messages to warning/info for QC metadata failures
   
 ## 1.4.0
 * Adds deletion workflow

--- a/docs/form_scheduler/CHANGELOG.md
+++ b/docs/form_scheduler/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this gear are documented in this file.
 
+## 1.5.0
+* Removes unused input file `form_configs_file`
+* Fixes logging `pass-qc` event
+  
 ## 1.4.0
 * Adds deletion workflow
 * Rebuilt for log file naming format update

--- a/docs/transactional_event_scraper/CHANGELOG.md
+++ b/docs/transactional_event_scraper/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 All notable changes to this gear are documented in this file.
 
-## 1.1.0
+## 1.2.0
 
-* Adds new optional input file `form_configs_file` to the manifest
+* Adds new optional input file `form_configs_file` to resolve module-specific date fields when extracting visit metadata
+* Uses configured date field from form module configs when available, falls back to auto-detection
+
+## 1.1.0
 * Push unmatched submit events in Phase 3 instead of only warning — mirrors live pipeline where submit events are independent of JSON file availability
 * Remove date filter from Phase 2 JSON file processing — date range now only controls which submissions are scraped, maximizing QC event matching
 * Updates to Python 3.12 and switches to use `fw-gear` instead of `flywheel-gear-toolkit` (now deprecated)

--- a/docs/transactional_event_scraper/CHANGELOG.md
+++ b/docs/transactional_event_scraper/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this gear are documented in this file.
 
 ## 1.1.0
 
+* Adds new optional input file `form_configs_file` to the manifest
 * Push unmatched submit events in Phase 3 instead of only warning — mirrors live pipeline where submit events are independent of JSON file availability
 * Remove date filter from Phase 2 JSON file processing — date range now only controls which submissions are scraped, maximizing QC event matching
 * Updates to Python 3.12 and switches to use `fw-gear` instead of `flywheel-gear-toolkit` (now deprecated)

--- a/gear/form_scheduler/src/docker/BUILD
+++ b/gear/form_scheduler/src/docker/BUILD
@@ -4,5 +4,5 @@ docker_image(
     name="form-scheduler",
     source="Dockerfile",
     dependencies=[":manifest", "gear/form_scheduler/src/python/form_scheduler_app:bin"],
-    image_tags=["1.4.0", "latest"],
+    image_tags=["1.5.0", "latest"],
 )

--- a/gear/form_scheduler/src/docker/BUILD
+++ b/gear/form_scheduler/src/docker/BUILD
@@ -4,5 +4,5 @@ docker_image(
     name="form-scheduler",
     source="Dockerfile",
     dependencies=[":manifest", "gear/form_scheduler/src/python/form_scheduler_app:bin"],
-    image_tags=["1.5.0", "latest"],
+    image_tags=["1.4.1", "latest"],
 )

--- a/gear/form_scheduler/src/docker/manifest.json
+++ b/gear/form_scheduler/src/docker/manifest.json
@@ -34,6 +34,16 @@
                     "source code"
                 ]
             }
+        },
+        "form_configs_file": {
+            "description": "A JSON file with form module configurations",
+            "base": "file",
+            "optional": true,
+            "type": {
+                "enum": [
+                    "source code"
+                ]
+            }
         }
     },
     "config": {

--- a/gear/form_scheduler/src/docker/manifest.json
+++ b/gear/form_scheduler/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "form-scheduler",
     "label": "Form Scheduler",
     "description": "Queues project files for the submission pipeline",
-    "version": "1.4.0",
+    "version": "1.5.0",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/form-scheduler:1.4.0"
+            "image": "naccdata/form-scheduler:1.5.0"
         },
         "flywheel": {
             "suite": "NACC Admin Gears",
@@ -28,15 +28,6 @@
         },
         "pipeline_configs_file": {
             "description": "A JSON file with pipeline configurations",
-            "base": "file",
-            "type": {
-                "enum": [
-                    "source code"
-                ]
-            }
-        },
-        "form_configs_file": {
-            "description": "A JSON file with form module configurations",
             "base": "file",
             "type": {
                 "enum": [

--- a/gear/form_scheduler/src/docker/manifest.json
+++ b/gear/form_scheduler/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "form-scheduler",
     "label": "Form Scheduler",
     "description": "Queues project files for the submission pipeline",
-    "version": "1.5.0",
+    "version": "1.4.1",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/form-scheduler:1.5.0"
+            "image": "naccdata/form-scheduler:1.4.1"
         },
         "flywheel": {
             "suite": "NACC Admin Gears",

--- a/gear/form_scheduler/src/python/form_scheduler_app/event_accumulator.py
+++ b/gear/form_scheduler/src/python/form_scheduler_app/event_accumulator.py
@@ -136,8 +136,16 @@ class EventAccumulator:
             QC completion timestamp if status is PASS, None otherwise
         """
         try:
+            # Reload to ensure we have the latest QC info from Flywheel.
+            qc_log_file = qc_log_file.reload()
+            if not qc_log_file.info or "qc" not in qc_log_file.info:
+                log.info("No QC metadata found in %s", qc_log_file.name)
+                return False
             qc_model = FileQCModel.model_validate(qc_log_file.info)
-        except ValidationError:
+        except ValidationError as err:
+            log.warning(
+                "Failed to parse QC metadata for %s: %s", qc_log_file.name, err
+            )
             return False
 
         # Check if QC status is PASS
@@ -163,12 +171,12 @@ class EventAccumulator:
             # Find corresponding QC status log
             qc_log_file = self.find_qc_status_for_json_file(json_file, project)
             if not qc_log_file:
-                log.debug("No QC status log found for %s", json_file.name)
+                log.warning("No QC status log found for %s", json_file.name)
                 return
 
             # Check QC status - only proceed if PASS
             if not self._check_qc_status(qc_log_file):
-                log.debug("QC status is not PASS for %s", json_file.name)
+                log.info("QC status is not PASS for %s", json_file.name)
                 return
 
             # Extract visit metadata
@@ -233,7 +241,7 @@ class EventAccumulator:
             )
 
             if not delete_info or delete_info.delete_response.state != "PASS":
-                log.debug(
+                log.info(
                     "Skipping failed or incomplete delete event for %s",
                     request_file.name,
                 )

--- a/gear/form_scheduler/src/python/form_scheduler_app/event_accumulator.py
+++ b/gear/form_scheduler/src/python/form_scheduler_app/event_accumulator.py
@@ -20,7 +20,6 @@ from nacc_common.error_models import (
     DataIdentification,
     FileQCModel,
 )
-from nacc_common.field_names import FieldNames
 from pydantic import ValidationError
 
 log = logging.getLogger(__name__)
@@ -47,40 +46,6 @@ class EventAccumulator:
         self.__error_log_template = ErrorLogTemplate()
         self.__form_configs = form_configs
 
-    def _date_field_for(self, json_file: FileEntry) -> Optional[str]:
-        """Return the configured module-specific date field for the file.
-
-        Reads the module from the file's forms.json metadata and looks up its
-        date field in the form module configs. Returns None when configs are
-        unavailable or the module is unknown, letting the extractor auto-detect
-        the date column.
-
-        Args:
-            json_file: the JSON file with forms metadata
-
-        Returns:
-            the module-specific date field, or None if it cannot be resolved
-        """
-        if not self.__form_configs:
-            return None
-
-        try:
-            json_file = json_file.reload()
-            forms_json = (
-                json_file.info.get("forms", {}).get("json", {})
-                if json_file.info
-                else {}
-            )
-        except Exception:  # best-effort; fall back to auto-detection
-            return None
-
-        module = forms_json.get(FieldNames.MODULE)
-        if not module:
-            return None
-
-        module_configs = self.__form_configs.module_configs.get(module.upper())
-        return module_configs.date_field if module_configs else None
-
     def create_qc_status_file_name(self, json_file: FileEntry) -> Optional[str]:
         """Creates the qc status log file from the form metadata for the file.
 
@@ -91,7 +56,7 @@ class EventAccumulator:
         """
         # Extract DataIdentification from JSON file metadata
         data_id = DataIdentificationExtractor.from_json_file_metadata(
-            json_file, date_field=self._date_field_for(json_file)
+            json_file, form_configs=self.__form_configs
         )
         if not data_id:
             return None
@@ -117,7 +82,7 @@ class EventAccumulator:
         """
         # Extract DataIdentification from JSON file metadata
         data_id = DataIdentificationExtractor.from_json_file_metadata(
-            json_file, date_field=self._date_field_for(json_file)
+            json_file, form_configs=self.__form_configs
         )
         if not data_id:
             log.warning("Could not extract data identification for %s", json_file.name)
@@ -170,7 +135,7 @@ class EventAccumulator:
 
         # Fall back to JSON file metadata
         visit_metadata = DataIdentificationExtractor.from_json_file_metadata(
-            json_file, date_field=self._date_field_for(json_file)
+            json_file, form_configs=self.__form_configs
         )
         if visit_metadata:
             return visit_metadata

--- a/gear/form_scheduler/src/python/form_scheduler_app/event_accumulator.py
+++ b/gear/form_scheduler/src/python/form_scheduler_app/event_accumulator.py
@@ -143,9 +143,7 @@ class EventAccumulator:
                 return False
             qc_model = FileQCModel.model_validate(qc_log_file.info)
         except ValidationError as err:
-            log.warning(
-                "Failed to parse QC metadata for %s: %s", qc_log_file.name, err
-            )
+            log.warning("Failed to parse QC metadata for %s: %s", qc_log_file.name, err)
             return False
 
         # Check if QC status is PASS

--- a/gear/form_scheduler/src/python/form_scheduler_app/event_accumulator.py
+++ b/gear/form_scheduler/src/python/form_scheduler_app/event_accumulator.py
@@ -72,6 +72,7 @@ class EventAccumulator:
         # Extract DataIdentification from JSON file metadata
         data_id = DataIdentificationExtractor.from_json_file_metadata(json_file)
         if not data_id:
+            log.warning("Could not extract data identification for %s", json_file.name)
             return None
 
         # Try new format first (with visitnum and packet if present)
@@ -169,7 +170,7 @@ class EventAccumulator:
             # Find corresponding QC status log
             qc_log_file = self.find_qc_status_for_json_file(json_file, project)
             if not qc_log_file:
-                log.warning("No QC status log found for %s", json_file.name)
+                log.warning("Failed to find the error log file for %s", json_file.name)
                 return
 
             # Check QC status - only proceed if PASS

--- a/gear/form_scheduler/src/python/form_scheduler_app/event_accumulator.py
+++ b/gear/form_scheduler/src/python/form_scheduler_app/event_accumulator.py
@@ -3,6 +3,7 @@
 import logging
 from typing import Optional
 
+from configs.ingest_configs import FormProjectConfigs
 from deletions.models import DeleteInfoModel
 from error_logging.error_logger import ErrorLogTemplate
 from event_capture.event_capture import VisitEventCapture
@@ -19,6 +20,7 @@ from nacc_common.error_models import (
     DataIdentification,
     FileQCModel,
 )
+from nacc_common.field_names import FieldNames
 from pydantic import ValidationError
 
 log = logging.getLogger(__name__)
@@ -27,15 +29,57 @@ log = logging.getLogger(__name__)
 class EventAccumulator:
     """Simplified event accumulator for QC-pass events only."""
 
-    def __init__(self, event_capture: VisitEventCapture) -> None:
+    def __init__(
+        self,
+        event_capture: VisitEventCapture,
+        form_configs: Optional[FormProjectConfigs] = None,
+    ) -> None:
         """Initialize the simplified EventAccumulator.
 
         Args:
             event_capture: Logger for visit events
-            datatype: Type of data being processed (default: "form")
+            form_configs: optional form module configs used to resolve the
+                module-specific date field when extracting visit metadata from
+                forms.json. Falls back to auto-detection when configs are not
+                provided or the module is unknown.
         """
         self.__event_capture = event_capture
         self.__error_log_template = ErrorLogTemplate()
+        self.__form_configs = form_configs
+
+    def _date_field_for(self, json_file: FileEntry) -> Optional[str]:
+        """Return the configured module-specific date field for the file.
+
+        Reads the module from the file's forms.json metadata and looks up its
+        date field in the form module configs. Returns None when configs are
+        unavailable or the module is unknown, letting the extractor auto-detect
+        the date column.
+
+        Args:
+            json_file: the JSON file with forms metadata
+
+        Returns:
+            the module-specific date field, or None if it cannot be resolved
+        """
+        if not self.__form_configs:
+            return None
+
+        try:
+            json_file = json_file.reload()
+            forms_json = (
+                json_file.info.get("forms", {}).get("json", {})
+                if json_file.info
+                else {}
+            )
+        except Exception:  # best-effort; fall back to auto-detection
+            return None
+
+        module = forms_json.get(FieldNames.MODULE)
+        if not module:
+            return None
+
+        module_configs = self.__form_configs.module_configs.get(module.upper())
+        return module_configs.date_field if module_configs else None
 
     def create_qc_status_file_name(self, json_file: FileEntry) -> Optional[str]:
         """Creates the qc status log file from the form metadata for the file.
@@ -46,7 +90,9 @@ class EventAccumulator:
           the QC status file for the visit in the file.
         """
         # Extract DataIdentification from JSON file metadata
-        data_id = DataIdentificationExtractor.from_json_file_metadata(json_file)
+        data_id = DataIdentificationExtractor.from_json_file_metadata(
+            json_file, date_field=self._date_field_for(json_file)
+        )
         if not data_id:
             return None
 
@@ -70,7 +116,9 @@ class EventAccumulator:
             The corresponding QC status log file, or None if not found
         """
         # Extract DataIdentification from JSON file metadata
-        data_id = DataIdentificationExtractor.from_json_file_metadata(json_file)
+        data_id = DataIdentificationExtractor.from_json_file_metadata(
+            json_file, date_field=self._date_field_for(json_file)
+        )
         if not data_id:
             log.warning("Could not extract data identification for %s", json_file.name)
             return None
@@ -121,7 +169,9 @@ class EventAccumulator:
                 return visit_metadata
 
         # Fall back to JSON file metadata
-        visit_metadata = DataIdentificationExtractor.from_json_file_metadata(json_file)
+        visit_metadata = DataIdentificationExtractor.from_json_file_metadata(
+            json_file, date_field=self._date_field_for(json_file)
+        )
         if visit_metadata:
             return visit_metadata
 

--- a/gear/form_scheduler/src/python/form_scheduler_app/event_accumulator.py
+++ b/gear/form_scheduler/src/python/form_scheduler_app/event_accumulator.py
@@ -130,6 +130,9 @@ class EventAccumulator:
     def _check_qc_status(self, qc_log_file: FileEntry) -> bool:
         """Check if QC status is PASS and return completion timestamp.
 
+        Assumes qc_log_file has already been reloaded by the caller so that
+        its custom info is populated.
+
         Args:
             qc_log_file: The QC status log file
 
@@ -137,8 +140,6 @@ class EventAccumulator:
             QC completion timestamp if status is PASS, None otherwise
         """
         try:
-            # Reload to ensure we have the latest QC info from Flywheel.
-            qc_log_file = qc_log_file.reload()
             if not qc_log_file.info or "qc" not in qc_log_file.info:
                 log.info("No QC metadata found in %s", qc_log_file.name)
                 return False
@@ -172,6 +173,9 @@ class EventAccumulator:
             if not qc_log_file:
                 log.warning("Failed to find the error log file for %s", json_file.name)
                 return
+
+            # Reload to get the latest file.info from Flywheel.
+            qc_log_file = qc_log_file.reload()
 
             # Check QC status - only proceed if PASS
             if not self._check_qc_status(qc_log_file):

--- a/gear/form_scheduler/src/python/form_scheduler_app/form_scheduler_queue.py
+++ b/gear/form_scheduler/src/python/form_scheduler_app/form_scheduler_queue.py
@@ -14,7 +14,12 @@ from collections import defaultdict
 from json.decoder import JSONDecodeError
 from typing import Callable, Dict, List, Optional, Tuple
 
-from configs.ingest_configs import Pipeline, PipelineConfigs, PipelineType
+from configs.ingest_configs import (
+    FormProjectConfigs,
+    Pipeline,
+    PipelineConfigs,
+    PipelineType,
+)
 from data.dataview import ColumnModel, make_builder
 from event_capture.event_capture import VisitEventCapture
 from flywheel.models.file_entry import FileEntry
@@ -463,6 +468,7 @@ class FormSchedulerQueue:
         project: ProjectAdaptor,
         pipeline_configs: PipelineConfigs,
         event_capture: VisitEventCapture,
+        form_configs: Optional[FormProjectConfigs] = None,
         email_client: Optional[EmailClient] = None,
         portal_url: Optional[URLParameter] = None,
     ) -> None:
@@ -473,6 +479,8 @@ class FormSchedulerQueue:
             project: Flywheel project container
             pipeline_configs: form pipeline configurations
             event_capture: VisitEventCapture for capturing visit events
+            form_configs: optional form module configs used to resolve the
+                module-specific date field for visit extraction
             email_client: EmailClient to send emails from
             portal_url: The portal URL
         """
@@ -480,6 +488,7 @@ class FormSchedulerQueue:
         self.__project = project
         self.__pipeline_configs = pipeline_configs
         self.__event_capture = event_capture
+        self.__form_configs = form_configs
         self.__email_client = email_client
         self.__portal_url = portal_url
         self.__pipeline_queues: Dict[str, PipelineQueue] = {}
@@ -574,7 +583,10 @@ class FormSchedulerQueue:
             pipeline_name: Name of the pipeline
         """
         try:
-            event_accumulator = EventAccumulator(event_capture=self.__event_capture)
+            event_accumulator = EventAccumulator(
+                event_capture=self.__event_capture,
+                form_configs=self.__form_configs,
+            )
 
             if pipeline_name == DefaultValues.DELETION_PIPELINE:
                 event_accumulator.capture_delete_event(

--- a/gear/form_scheduler/src/python/form_scheduler_app/run.py
+++ b/gear/form_scheduler/src/python/form_scheduler_app/run.py
@@ -4,7 +4,12 @@ import logging
 from typing import Any, Literal, Optional
 
 from botocore.exceptions import ClientError
-from configs.ingest_configs import ConfigsError, PipelineConfigs
+from configs.ingest_configs import (
+    ConfigsError,
+    FormProjectConfigs,
+    PipelineConfigs,
+    load_form_ingest_configurations,
+)
 from event_capture.event_capture import VisitEventCapture
 from flywheel.rest import ApiException
 from flywheel_adaptor.flywheel_proxy import ProjectAdaptor
@@ -24,6 +29,7 @@ from inputs.parameter_store import (
 )
 from jobs.job_poll import JobPoll
 from notifications.email import EmailClient, create_ses_client
+from pydantic import ValidationError
 from s3.s3_bucket import S3BucketInterface
 
 from form_scheduler_app.form_scheduler_queue import (
@@ -44,12 +50,14 @@ class FormSchedulerVisitor(GearExecutionEnvironment):
         pipeline_configs_input: InputFileWrapper,
         event_bucket: S3BucketInterface,
         event_environment: Literal["prod", "dev"],
+        form_configs_input: Optional[InputFileWrapper] = None,
         source_email: Optional[str] = None,
         portal_url: Optional[URLParameter] = None,
     ):
         super().__init__(client=client)
 
         self.__configs_input = pipeline_configs_input
+        self.__form_configs_input = form_configs_input
         self.__source_email = source_email
         self.__portal_url = portal_url
         self.__event_bucket = event_bucket
@@ -77,6 +85,12 @@ class FormSchedulerVisitor(GearExecutionEnvironment):
             input_name="pipeline_configs_file", context=context
         )
         assert pipeline_configs_input, "missing expected input, pipeline_configs_file"
+
+        # Optional: form module configs, used to resolve the module-specific
+        # date field when capturing visit events.
+        form_configs_input = InputFileWrapper.create(
+            input_name="form_configs_file", context=context
+        )
 
         options = context.config.opts
         source_email = options.get("source_email", "nacchelp@uw.edu")
@@ -109,6 +123,7 @@ class FormSchedulerVisitor(GearExecutionEnvironment):
             pipeline_configs_input=pipeline_configs_input,
             event_bucket=event_bucket,
             event_environment=event_environment,
+            form_configs_input=form_configs_input,
             source_email=source_email,
             portal_url=portal_url,
         )
@@ -159,6 +174,20 @@ class FormSchedulerVisitor(GearExecutionEnvironment):
             s3_bucket=self.__event_bucket, environment=self.__event_environment
         )
 
+        # Load form module configs (if provided) so visit-event extraction can
+        # resolve the module-specific date column.
+        form_configs: Optional[FormProjectConfigs] = None
+        if self.__form_configs_input:
+            try:
+                form_configs = load_form_ingest_configurations(
+                    self.__form_configs_input.filepath
+                )
+            except ValidationError as error:
+                raise GearExecutionError(
+                    "Error reading form configurations file "
+                    f"{self.__form_configs_input.filename}: {error}"
+                ) from error
+
         # if source email specified, set up client to send emails
         email_client = (
             EmailClient(client=create_ses_client(), source=self.__source_email)
@@ -178,6 +207,7 @@ class FormSchedulerVisitor(GearExecutionEnvironment):
             project=project,
             pipeline_configs=pipeline_configs,
             event_capture=event_logger,
+            form_configs=form_configs,
             email_client=email_client,
             portal_url=self.__portal_url,
         )

--- a/gear/form_scheduler/src/python/form_scheduler_app/run.py
+++ b/gear/form_scheduler/src/python/form_scheduler_app/run.py
@@ -42,7 +42,6 @@ class FormSchedulerVisitor(GearExecutionEnvironment):
         self,
         client: ClientWrapper,
         pipeline_configs_input: InputFileWrapper,
-        form_configs_input: InputFileWrapper,
         event_bucket: S3BucketInterface,
         event_environment: Literal["prod", "dev"],
         source_email: Optional[str] = None,
@@ -51,7 +50,6 @@ class FormSchedulerVisitor(GearExecutionEnvironment):
         super().__init__(client=client)
 
         self.__configs_input = pipeline_configs_input
-        self.__form_configs_input = form_configs_input
         self.__source_email = source_email
         self.__portal_url = portal_url
         self.__event_bucket = event_bucket
@@ -79,11 +77,6 @@ class FormSchedulerVisitor(GearExecutionEnvironment):
             input_name="pipeline_configs_file", context=context
         )
         assert pipeline_configs_input, "missing expected input, pipeline_configs_file"
-
-        form_configs_input = InputFileWrapper.create(
-            input_name="form_configs_file", context=context
-        )
-        assert form_configs_input, "missing expected input, form_configs_file"
 
         options = context.config.opts
         source_email = options.get("source_email", "nacchelp@uw.edu")
@@ -114,7 +107,6 @@ class FormSchedulerVisitor(GearExecutionEnvironment):
         return FormSchedulerVisitor(
             client=client,
             pipeline_configs_input=pipeline_configs_input,
-            form_configs_input=form_configs_input,
             event_bucket=event_bucket,
             event_environment=event_environment,
             source_email=source_email,

--- a/gear/form_scheduler/test/python/test_integration_event_logging.py
+++ b/gear/form_scheduler/test/python/test_integration_event_logging.py
@@ -695,3 +695,131 @@ class TestCaptureDeleteEvent:
         assert event.ptid == "adrc2002"
         assert event.visit_number is None
         assert event.module == "MLST"
+
+
+class TestQCStatusReloadBehavior:
+    """Regression tests for stale file info requiring reload.
+
+    Flywheel's SDK does not always populate the
+    full info dict when listing project files — info may be None or {}. The
+    _check_qc_status method must call file.reload() to fetch current metadata.
+    """
+
+    @pytest.fixture
+    def mock_event_capture(self) -> MockVisitEventCapture:
+        return MockVisitEventCapture()
+
+    @pytest.fixture
+    def event_accumulator(
+        self, mock_event_capture: MockVisitEventCapture
+    ) -> EventAccumulator:
+        return EventAccumulator(event_capture=mock_event_capture)
+
+    def test_qc_pass_event_logged_when_file_info_only_available_after_reload(
+        self,
+        event_accumulator: EventAccumulator,
+        mock_event_capture: MockVisitEventCapture,
+    ) -> None:
+        """Events are logged even when the QC file initially has info=None.
+
+        Simulates the Flywheel SDK returning a FileEntry from the project's
+        cached file list with info=None, which then populates correctly on
+        reload(). Ensures _check_qc_status calls reload() before reading info.
+        """
+
+        class StaleQCFile(MockFile):
+            """Mimics a FileEntry returned from project.files with no info,
+            where reload() fetches the real metadata."""
+
+            def __init__(
+                self, name: str, real_info: dict, modified: datetime
+            ):
+                # Start with empty info (as Flywheel SDK may return)
+                super().__init__(name=name, info={}, modified=modified)
+                self._real_info = real_info
+                self._modified = modified
+
+            def reload(self, *args, **kwargs):
+                # Simulate fetching full metadata on reload
+                return MockFile(
+                    name=self.name,
+                    info=self._real_info,
+                    modified=self._modified,
+                )
+
+        json_file = FileEntryFactory.create_mock_json_file_with_forms_metadata(
+            name="NACC200000_FORMS-VISIT-1F_UDS.json",
+            ptid="adrc3000",
+            visitdate="2025-01-10",
+            visitnum="1F",
+            module="UDS",
+            packet="I",
+        )
+
+        qc_metadata = QCMetadataFactory.create_pass_qc_metadata(
+            ["identifier-lookup", "form-qc-checker"]
+        )
+        real_info = qc_metadata.model_dump(by_alias=True)
+
+        qc_completion_time = datetime(2025, 1, 10, 9, 0, 0)
+        stale_qc_file = StaleQCFile(
+            name="adrc3000_2025-01-10_uds_qc-status.log",
+            real_info=real_info,
+            modified=qc_completion_time,
+        )
+
+        project = MockProjectAdaptorIntegration(
+            label="ingest-form-alpha",
+            group="dummy-center",
+            pipeline_adcid=42,
+            files=[stale_qc_file],
+        )
+
+        event_accumulator.capture_qc_event(json_file=json_file, project=project)
+
+        assert len(mock_event_capture.logged_events) == 1, (
+            "Expected pass-qc event to be logged after reload populates file info"
+        )
+        event = mock_event_capture.logged_events[0]
+        assert event.action == "pass-qc"
+        assert event.ptid == "adrc3000"
+
+    def test_no_event_when_qc_file_has_no_qc_key_after_reload(
+        self,
+        event_accumulator: EventAccumulator,
+        mock_event_capture: MockVisitEventCapture,
+    ) -> None:
+        """No event is logged when the reloaded QC file has no 'qc' key.
+
+        Prevents false-positive pass-qc events for files that exist at project
+        level but have not yet had QC metadata written (e.g., a new log file
+        with only text content and no custom info).
+        """
+        json_file = FileEntryFactory.create_mock_json_file_with_forms_metadata(
+            name="NACC200001_FORMS-VISIT-2F_UDS.json",
+            ptid="adrc3001",
+            visitdate="2025-02-20",
+            visitnum="2F",
+            module="UDS",
+            packet="I",
+        )
+
+        # QC file exists but has no 'qc' key in its info
+        qc_file = MockFile(
+            name="adrc3001_2025-02-20_uds_qc-status.log",
+            info={"some_other_key": "value"},
+            modified=datetime(2025, 2, 20, 10, 0, 0),
+        )
+
+        project = MockProjectAdaptorIntegration(
+            label="ingest-form-alpha",
+            group="dummy-center",
+            pipeline_adcid=42,
+            files=[qc_file],
+        )
+
+        event_accumulator.capture_qc_event(json_file=json_file, project=project)
+
+        assert len(mock_event_capture.logged_events) == 0, (
+            "Should not log event when QC file has no 'qc' key in info"
+        )

--- a/gear/form_scheduler/test/python/test_integration_event_logging.py
+++ b/gear/form_scheduler/test/python/test_integration_event_logging.py
@@ -700,9 +700,9 @@ class TestCaptureDeleteEvent:
 class TestQCStatusReloadBehavior:
     """Regression tests for stale file info requiring reload.
 
-    Flywheel's SDK does not always populate the
-    full info dict when listing project files — info may be None or {}. The
-    _check_qc_status method must call file.reload() to fetch current metadata.
+    Flywheel's SDK does not always populate the full info dict when
+    listing project files — info may be None or {}. The _check_qc_status
+    method must call file.reload() to fetch current metadata.
     """
 
     @pytest.fixture
@@ -722,18 +722,17 @@ class TestQCStatusReloadBehavior:
     ) -> None:
         """Events are logged even when the QC file initially has info=None.
 
-        Simulates the Flywheel SDK returning a FileEntry from the project's
-        cached file list with info=None, which then populates correctly on
-        reload(). Ensures _check_qc_status calls reload() before reading info.
+        Simulates the Flywheel SDK returning a FileEntry from the
+        project's cached file list with info=None, which then populates
+        correctly on reload(). Ensures _check_qc_status calls reload()
+        before reading info.
         """
 
         class StaleQCFile(MockFile):
             """Mimics a FileEntry returned from project.files with no info,
             where reload() fetches the real metadata."""
 
-            def __init__(
-                self, name: str, real_info: dict, modified: datetime
-            ):
+            def __init__(self, name: str, real_info: dict, modified: datetime):
                 # Start with empty info (as Flywheel SDK may return)
                 super().__init__(name=name, info={}, modified=modified)
                 self._real_info = real_info
@@ -791,9 +790,9 @@ class TestQCStatusReloadBehavior:
     ) -> None:
         """No event is logged when the reloaded QC file has no 'qc' key.
 
-        Prevents false-positive pass-qc events for files that exist at project
-        level but have not yet had QC metadata written (e.g., a new log file
-        with only text content and no custom info).
+        Prevents false-positive pass-qc events for files that exist at
+        project level but have not yet had QC metadata written (e.g., a
+        new log file with only text content and no custom info).
         """
         json_file = FileEntryFactory.create_mock_json_file_with_forms_metadata(
             name="NACC200001_FORMS-VISIT-2F_UDS.json",

--- a/gear/form_scheduler/test/python/test_property_error_resilience.py
+++ b/gear/form_scheduler/test/python/test_property_error_resilience.py
@@ -116,6 +116,7 @@ class TestErrorResilience:
         mock_qc_file.info = None  # No custom info
         mock_qc_file.read.return_value = qc_content
         mock_qc_file.modified = datetime.now()
+        mock_qc_file.reload.return_value = mock_qc_file
 
         # Create mock project
         mock_project = Mock(spec=ProjectAdaptor)
@@ -176,6 +177,7 @@ class TestErrorResilience:
             },
         }
         mock_qc_file.modified = datetime.now()
+        mock_qc_file.reload.return_value = mock_qc_file
 
         # Create mock project with valid label
         mock_project = Mock(spec=ProjectAdaptor)
@@ -273,6 +275,7 @@ class TestErrorResilience:
         }
         mock_qc_file.read.return_value = '{"file_status": "PASS"}'
         mock_qc_file.modified = datetime.now()
+        mock_qc_file.reload.return_value = mock_qc_file
 
         # Create mock project
         mock_project = Mock(spec=ProjectAdaptor)

--- a/gear/form_scheduler/test/python/test_property_error_resilience.py
+++ b/gear/form_scheduler/test/python/test_property_error_resilience.py
@@ -42,6 +42,7 @@ class TestErrorResilience:
 
         # Create mock JSON file with varying levels of metadata
         mock_json_file = Mock(spec=FileEntry)
+        mock_json_file.reload.return_value = mock_json_file
         mock_json_file.name = file_name
 
         if has_info:
@@ -99,6 +100,7 @@ class TestErrorResilience:
 
         # Create mock JSON file with valid metadata
         mock_json_file = Mock(spec=FileEntry)
+        mock_json_file.reload.return_value = mock_json_file
         mock_json_file.name = "test.json"
         mock_json_file.info = {
             "forms": {
@@ -112,11 +114,11 @@ class TestErrorResilience:
 
         # Create mock QC status file with invalid content
         mock_qc_file = Mock(spec=FileEntry)
+        mock_qc_file.reload.return_value = mock_qc_file
         mock_qc_file.name = "qc_status.json"
         mock_qc_file.info = None  # No custom info
         mock_qc_file.read.return_value = qc_content
         mock_qc_file.modified = datetime.now()
-        mock_qc_file.reload.return_value = mock_qc_file
 
         # Create mock project
         mock_project = Mock(spec=ProjectAdaptor)
@@ -151,6 +153,7 @@ class TestErrorResilience:
 
         # Create valid mock JSON file
         mock_json_file = Mock(spec=FileEntry)
+        mock_json_file.reload.return_value = mock_json_file
         mock_json_file.name = "test.json"
         mock_json_file.info = {
             "forms": {
@@ -165,6 +168,7 @@ class TestErrorResilience:
 
         # Create valid mock QC status file with PASS status
         mock_qc_file = Mock(spec=FileEntry)
+        mock_qc_file.reload.return_value = mock_qc_file
         mock_qc_file.name = "qc_status.json"
         mock_qc_file.info = {
             "qc": {"form-qc-checker": {"validation": {"state": "PASS", "data": []}}},
@@ -177,7 +181,6 @@ class TestErrorResilience:
             },
         }
         mock_qc_file.modified = datetime.now()
-        mock_qc_file.reload.return_value = mock_qc_file
 
         # Create mock project with valid label
         mock_project = Mock(spec=ProjectAdaptor)
@@ -252,6 +255,7 @@ class TestErrorResilience:
 
         # Create mock JSON file with invalid metadata that will cause validation errors
         mock_json_file = Mock(spec=FileEntry)
+        mock_json_file.reload.return_value = mock_json_file
         mock_json_file.name = "test.json"
         mock_json_file.info = {
             "forms": {
@@ -265,6 +269,7 @@ class TestErrorResilience:
 
         # Create mock QC status file
         mock_qc_file = Mock(spec=FileEntry)
+        mock_qc_file.reload.return_value = mock_qc_file
         mock_qc_file.name = "qc_status.json"
         mock_qc_file.info = {
             "visit": {
@@ -275,7 +280,6 @@ class TestErrorResilience:
         }
         mock_qc_file.read.return_value = '{"file_status": "PASS"}'
         mock_qc_file.modified = datetime.now()
-        mock_qc_file.reload.return_value = mock_qc_file
 
         # Create mock project
         mock_project = Mock(spec=ProjectAdaptor)

--- a/gear/form_scheduler/test/python/test_property_event_structure_compatibility.py
+++ b/gear/form_scheduler/test/python/test_property_event_structure_compatibility.py
@@ -85,6 +85,7 @@ class MockProjectAdaptor:
         file_entry.info = custom_info or {}
         file_entry.info["qc"] = qc_data
 
+        file_entry.reload.return_value = file_entry
         self.files[filename] = file_entry
         return file_entry
 

--- a/gear/form_scheduler/test/python/test_property_event_structure_compatibility.py
+++ b/gear/form_scheduler/test/python/test_property_event_structure_compatibility.py
@@ -70,14 +70,16 @@ class MockProjectAdaptor:
         qc_data = {
             "test-gear": GearQCModel(
                 validation=ValidationModel(
-                    state=qc_status,
+                    state=qc_status, # type: ignore
                     data=[],
+                    cleared=[],
                 )
             )
         }
 
         # Create file entry
         file_entry = Mock(spec=FileEntry)
+        file_entry.reload.return_value = file_entry
         file_entry.name = filename
         file_entry.modified = qc_completion_time or datetime.now()
 
@@ -85,7 +87,6 @@ class MockProjectAdaptor:
         file_entry.info = custom_info or {}
         file_entry.info["qc"] = qc_data
 
-        file_entry.reload.return_value = file_entry
         self.files[filename] = file_entry
         return file_entry
 
@@ -96,6 +97,7 @@ def json_file_strategy(draw) -> FileEntry:
     forms_json = draw(shared_json_strategy())
 
     file_entry = Mock(spec=FileEntry)
+    file_entry.reload.return_value = file_entry
     file_entry.name = (
         f"{forms_json['ptid']}"
         f"_{forms_json['visitdate']}_{forms_json['module'].lower()}.json"
@@ -135,6 +137,7 @@ def test_event_structure_compatibility(
 
     # Create JSON file from visit metadata
     json_file = Mock(spec=FileEntry)
+    json_file.reload.return_value = json_file
     assert visit_metadata.module, "module is required for visit metadata"
     json_file.name = (
         f"{visit_metadata.ptid}_{visit_metadata.date}_"
@@ -333,6 +336,7 @@ def test_event_structure_required_fields():
 
     # Create test JSON file with all fields
     json_file = Mock(spec=FileEntry)
+    json_file.reload.return_value = json_file
     json_file.name = "test001_2024-01-15_uds.json"
     json_file.info = {
         "forms": {
@@ -416,6 +420,7 @@ def test_event_structure_s3_storage_compatibility():
 
     # Create test JSON file
     json_file = Mock(spec=FileEntry)
+    json_file.reload.return_value = json_file
     json_file.name = "test001_2024-01-15_uds.json"
     json_file.info = {
         "forms": {

--- a/gear/form_scheduler/test/python/test_property_event_structure_compatibility.py
+++ b/gear/form_scheduler/test/python/test_property_event_structure_compatibility.py
@@ -70,7 +70,7 @@ class MockProjectAdaptor:
         qc_data = {
             "test-gear": GearQCModel(
                 validation=ValidationModel(
-                    state=qc_status, # type: ignore
+                    state=qc_status,  # type: ignore
                     data=[],
                     cleared=[],
                 )

--- a/gear/form_scheduler/test/python/test_property_event_structure_compatibility.py
+++ b/gear/form_scheduler/test/python/test_property_event_structure_compatibility.py
@@ -70,7 +70,7 @@ class MockProjectAdaptor:
         qc_data = {
             "test-gear": GearQCModel(
                 validation=ValidationModel(
-                    state=qc_status,  # type: ignore
+                    state=qc_status,
                     data=[],
                     cleared=[],
                 )

--- a/gear/form_scheduler/test/python/test_property_missing_configuration.py
+++ b/gear/form_scheduler/test/python/test_property_missing_configuration.py
@@ -161,7 +161,8 @@ class TestMissingConfigurationHandling:
                 file=json_file, pipeline_name="finalization"
             )
 
-            # EventAccumulator should be instantiated with event_capture
+            # EventAccumulator should be instantiated with event_capture and
+            # the (here unset) form module configs.
             mock_accumulator_class.assert_called_once_with(
-                event_capture=mock_event_capture
+                event_capture=mock_event_capture, form_configs=None
             )

--- a/gear/form_scheduler/test/python/test_property_qc_pass_event_creation.py
+++ b/gear/form_scheduler/test/python/test_property_qc_pass_event_creation.py
@@ -28,6 +28,7 @@ def json_file_strategy(draw):
     forms_json = draw(shared_json_strategy())
 
     file_entry = Mock(spec=FileEntry)
+    file_entry.reload.return_value = file_entry
     file_entry.name = (
         f"{forms_json['ptid']}"
         f"_{forms_json['visitdate']}"
@@ -158,6 +159,7 @@ def test_qc_pass_event_structure():
 
     # Create test JSON file
     json_file = Mock(spec=FileEntry)
+    json_file.reload.return_value = json_file
     json_file.name = "test001_2024-01-15_uds.json"
     json_file.info = {
         "forms": {
@@ -233,6 +235,7 @@ def test_multiple_json_files_mixed_qc_status():
         [QC_STATUS_PASS, "FAIL", QC_STATUS_PASS, "IN REVIEW"]
     ):
         json_file = Mock(spec=FileEntry)
+        json_file.reload.return_value = json_file
         json_file.name = f"test{i:03d}_2024-01-15_uds.json"
         json_file.info = {
             "forms": {

--- a/gear/form_scheduler/test/python/test_property_qc_status_matching.py
+++ b/gear/form_scheduler/test/python/test_property_qc_status_matching.py
@@ -23,6 +23,7 @@ def create_mock_file_entry(
 ) -> FileEntry:
     """Create a mock FileEntry with the given info."""
     file_entry = Mock(spec=FileEntry)
+    file_entry.reload.return_value = file_entry
     file_entry.name = name
     file_entry.info = info or {}
     return file_entry

--- a/gear/form_scheduler/test/python/test_property_visit_metadata_extraction.py
+++ b/gear/form_scheduler/test/python/test_property_visit_metadata_extraction.py
@@ -31,6 +31,7 @@ def create_mock_file_entry(
 ) -> FileEntry:
     """Create a mock FileEntry with the given info."""
     file_entry = Mock(spec=FileEntry)
+    file_entry.reload.return_value = file_entry
     file_entry.name = name
     file_entry.info = info or {}
     return file_entry

--- a/gear/form_scheduler/test/python/test_property_visit_metadata_validation.py
+++ b/gear/form_scheduler/test/python/test_property_visit_metadata_validation.py
@@ -29,6 +29,7 @@ def create_mock_file_entry(
 ) -> FileEntry:
     """Create a mock FileEntry with the given info."""
     file_entry = Mock(spec=FileEntry)
+    file_entry.reload.return_value = file_entry
     file_entry.name = name
     file_entry.info = info or {}
     return file_entry

--- a/gear/transactional_event_scraper/src/docker/BUILD
+++ b/gear/transactional_event_scraper/src/docker/BUILD
@@ -7,5 +7,5 @@ docker_image(
         ":manifest",
         "gear/transactional_event_scraper/src/python/transactional_event_scraper_app:bin",
     ],
-    image_tags=["1.1.0", "latest"],
+    image_tags=["1.2.0", "latest"],
 )

--- a/gear/transactional_event_scraper/src/docker/manifest.json
+++ b/gear/transactional_event_scraper/src/docker/manifest.json
@@ -2,7 +2,7 @@
   "name": "transactional-event-scraper",
   "label": "Transactional Event Scraper",
   "description": "A gear for scraping existing QC status log files to generate historical submission and pass-qc events",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": "NACC",
   "maintainer": "NACC <nacchelp@uw.edu>",
   "cite": "",
@@ -15,7 +15,7 @@
   "custom": {
     "gear-builder": {
       "category": "utility",
-      "image": "naccdata/transactional-event-scraper:1.1.0"
+      "image": "naccdata/transactional-event-scraper:1.2.0"
     },
     "flywheel": {
       "suite": "Utility",

--- a/gear/transactional_event_scraper/src/docker/manifest.json
+++ b/gear/transactional_event_scraper/src/docker/manifest.json
@@ -25,6 +25,16 @@
   "inputs": {
     "api-key": {
       "base": "api-key"
+    },
+    "form_configs_file": {
+      "description": "A JSON file with form module configurations",
+      "base": "file",
+      "optional": true,
+      "type": {
+        "enum": [
+          "source code"
+        ]
+      }
     }
   },
   "config": {

--- a/gear/transactional_event_scraper/src/python/transactional_event_scraper_app/event_scraper.py
+++ b/gear/transactional_event_scraper/src/python/transactional_event_scraper_app/event_scraper.py
@@ -29,6 +29,7 @@ UnmatchedSubmitEvents collection for efficient event matching.
 import logging
 from typing import Optional
 
+from configs.ingest_configs import FormProjectConfigs
 from event_capture.event_capture import VisitEventCapture
 from event_capture.event_generator import EventGenerator
 from event_capture.event_processor import QCEventProcessor, SubmitEventProcessor
@@ -77,6 +78,7 @@ class EventScraper:
         event_capture: Optional[VisitEventCapture] = None,
         dry_run: bool = False,
         date_filter: Optional[DateRange] = None,
+        form_configs: Optional[FormProjectConfigs] = None,
     ) -> None:
         """Initialize the EventScraper.
 
@@ -88,11 +90,14 @@ class EventScraper:
             event_capture: Optional event capture for storing events (None for dry-run)
             dry_run: Whether to perform a dry run without capturing events
             date_filter: Optional date range for filtering files
+            form_configs: optional form module configs used to resolve the
+                module-specific date field for visit extraction
         """
         self._project = project
         self._event_capture = event_capture
         self._dry_run = dry_run
         self._date_filter = date_filter
+        self._form_configs = form_configs
 
         # Shared components
         self._event_generator = EventGenerator(project)
@@ -113,6 +118,7 @@ class EventScraper:
             event_capture=event_capture,
             dry_run=dry_run,
             date_filter=date_filter,
+            form_configs=form_configs,
         )
 
     def scrape_events(self) -> None:

--- a/gear/transactional_event_scraper/src/python/transactional_event_scraper_app/run.py
+++ b/gear/transactional_event_scraper/src/python/transactional_event_scraper_app/run.py
@@ -3,6 +3,10 @@
 import logging
 from typing import Optional
 
+from configs.ingest_configs import (
+    FormProjectConfigs,
+    load_form_ingest_configurations,
+)
 from event_capture.event_capture import VisitEventCapture
 from flywheel_adaptor.flywheel_proxy import ProjectAdaptor
 from fw_gear import GearContext
@@ -12,8 +16,10 @@ from gear_execution.gear_execution import (
     GearEngine,
     GearExecutionEnvironment,
     GearExecutionError,
+    InputFileWrapper,
 )
 from inputs.parameter_store import ParameterStore
+from pydantic import ValidationError
 from s3.s3_bucket import S3BucketInterface
 
 from transactional_event_scraper_app.config import (
@@ -34,6 +40,7 @@ class TransactionalEventScraperVisitor(GearExecutionEnvironment):
         config: TransactionalEventScraperConfig,
         project: ProjectAdaptor,
         event_capture: Optional[VisitEventCapture] = None,
+        form_configs: Optional[FormProjectConfigs] = None,
     ):
         """Initialize the visitor.
 
@@ -42,11 +49,14 @@ class TransactionalEventScraperVisitor(GearExecutionEnvironment):
             config: The gear configuration
             project: The project adaptor
             event_capture: Optional event capture for storing events (None for dry-run)
+            form_configs: optional form module configs used to resolve the
+                module-specific date field for visit extraction
         """
         super().__init__(client=client)
         self.__config = config
         self.__project = project
         self.__event_capture = event_capture
+        self.__form_configs = form_configs
 
     @classmethod
     def create(
@@ -96,6 +106,23 @@ class TransactionalEventScraperVisitor(GearExecutionEnvironment):
 
         project = ProjectAdaptor(project=fw_project, proxy=proxy)
 
+        # Optional: form module configs, used to resolve the module-specific
+        # date field when extracting visit metadata.
+        form_configs_input = InputFileWrapper.create(
+            input_name="form_configs_file", context=context
+        )
+        form_configs = None
+        if form_configs_input:
+            try:
+                form_configs = load_form_ingest_configurations(
+                    form_configs_input.filepath
+                )
+            except ValidationError as error:
+                raise GearExecutionError(
+                    "Error reading form configurations file "
+                    f"{form_configs_input.filename}: {error}"
+                ) from error
+
         # Initialize visit event capture if not in dry-run mode
         event_capture = None
         if not config.dry_run:
@@ -116,6 +143,7 @@ class TransactionalEventScraperVisitor(GearExecutionEnvironment):
             config=config,
             project=project,
             event_capture=event_capture,
+            form_configs=form_configs,
         )
 
     def run(self, context: GearContext) -> None:
@@ -151,6 +179,7 @@ class TransactionalEventScraperVisitor(GearExecutionEnvironment):
             event_capture=self.__event_capture,
             dry_run=self.__config.dry_run,
             date_filter=date_filter,
+            form_configs=self.__form_configs,
         )
 
         # Run the scraper

--- a/gear/transactional_event_scraper/test/python/transactional_event_scraper_tests/test_event_scraper.py
+++ b/gear/transactional_event_scraper/test/python/transactional_event_scraper_tests/test_event_scraper.py
@@ -137,7 +137,7 @@ def test_scrape_events_three_phase_workflow(mock_project, caplog):
     # Verify all three phases are logged
     assert "Phase 1: Processing QC status logs" in caplog.text
     assert "Phase 2: Processing JSON files and matching events" in caplog.text
-    assert "Phase 3: Pushing" in caplog.text
+    assert "Phase 3" in caplog.text
 
 
 def test_scrape_events_returns_none(mock_project):
@@ -148,7 +148,7 @@ def test_scrape_events_returns_none(mock_project):
 
 
 def test_scrape_events_logs_unmatched_events(mock_project, caplog):
-    """Test that unmatched submit events are pushed in Phase 3."""
+    """Test that unmatched submit events are logged at completion."""
     import logging
 
     caplog.set_level(logging.INFO)
@@ -156,8 +156,8 @@ def test_scrape_events_logs_unmatched_events(mock_project, caplog):
     scraper = EventScraper(mock_project, dry_run=True)
     scraper.scrape_events()
 
-    # Since we only process QC logs and no JSON files, all submit events remain
-    #  unmatched and get pushed in Phase 3
+    # Since none of the JSON files carry forms.json metadata, no QC events match
+    # and all submit events remain unmatched (pushed in Phase 3).
     assert "unmatched submit events" in caplog.text.lower()
 
 
@@ -205,7 +205,7 @@ def test_scrape_events_completion_message_with_unmatched(mock_project, caplog):
     scraper = EventScraper(mock_project, dry_run=True)
     scraper.scrape_events()
 
-    # Should log Phase 3 push of unmatched events
+    # Should log that unmatched submit events are being pushed in Phase 3
     assert "unmatched submit events" in caplog.text.lower()
-    # Should log dry-run messages for each unmatched event
-    assert "[DRY RUN] Would push unenriched submit event" in caplog.text
+    # Should log each unmatched event being pushed (dry-run)
+    assert "Would push unenriched submit event" in caplog.text

--- a/gear/transactional_event_scraper/test/python/transactional_event_scraper_tests/test_visitor.py
+++ b/gear/transactional_event_scraper/test/python/transactional_event_scraper_tests/test_visitor.py
@@ -29,8 +29,12 @@ def mock_context():
     dest_container.container_type = "project"
     dest_container.id = "test-project-id"
     mock_config.get_destination_container = Mock(return_value=dest_container)
+    # The optional form_configs_file input is not provided in these tests.
+    mock_config.get_input = Mock(return_value=None)
     context.config = mock_config
-    context.manifest = {"name": "transactional-event-scraper"}
+    manifest = Mock()
+    manifest.inputs.get.return_value = {"optional": True}
+    context.manifest = manifest
     context.config_json = {"job": {"id": "test-job-id"}}
     return context
 

--- a/nacc-common/src/python/nacc_common/field_names.py
+++ b/nacc-common/src/python/nacc_common/field_names.py
@@ -9,6 +9,7 @@ class FieldNames:
     MODE = "mode"
     VISITNUM = "visitnum"
     DATE_COLUMN = "visitdate"
+    NPDATE = "npformdate"
     FORMVER = "formver"
     GUID = "guid"
     OLDADCID = "oldadcid"


### PR DESCRIPTION
- Update DataIdentificationExtractor to use the module specific date field
   - Modify form-scheduler and transactional-event-scraper to pass the form configs using optional input file `form_configs_file`
   - If config file not present falls back to using known date fields
- Merge the existing transactional event logging changes from [PR 430](https://github.com/naccdata/flywheel-gear-extensions/pull/430)