### PR TITLE
Reconfigure pants power mcp

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,14 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "version": "2.17.0",
+      "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:25b9f05705ffba7dbe503230ac76081419306f8c8bc88e0ce78c4ecd99a0c78c",
+      "integrity": "sha256:25b9f05705ffba7dbe503230ac76081419306f8c8bc88e0ce78c4ecd99a0c78c"
+    },
+    "ghcr.io/devcontainers/features/go:1": {
+      "version": "1.3.4",
+      "resolved": "ghcr.io/devcontainers/features/go@sha256:d85e921f91b41340055bb12b325d9d551170ed04b3b832e33530bf42f167c032",
+      "integrity": "sha256:d85e921f91b41340055bb12b325d9d551170ed04b3b832e33530bf42f167c032"
+    }
+  }
+}

--- a/.kiro/settings/mcp.json
+++ b/.kiro/settings/mcp.json
@@ -1,33 +1,30 @@
 {
-  "mcpServers": {},
-  "powers": {
-    "mcpServers": {
-      "power-kiro-pants-power-pants-devcontainer-power": {
-        "command": "uvx",
-        "args": [
-          "--from",
-          "git+https://github.com/naccdata/kiro-pants-power",
-          "pants-devcontainer-power"
-        ],
-        "env": {
-          "WORKSPACE_FOLDER": "${workspaceFolder}"
-        },
-        "autoApprove": [
-          "pants_fix",
-          "pants_lint",
-          "pants_check",
-          "pants_test",
-          "pants_package",
-          "pants_tailor",
-          "pants_workflow",
-          "full_quality_check",
-          "pants_clear_cache",
-          "container_start",
-          "container_stop",
-          "container_rebuild",
-          "container_exec"
-        ]
-      }
+  "mcpServers": {
+    "kiro-pants-power": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "git+https://github.com/naccdata/kiro-pants-power",
+        "pants-devcontainer-power"
+      ],
+      "env": {
+        "WORKSPACE_FOLDER": "."
+      },
+      "autoApprove": [
+        "pants_fix",
+        "pants_lint",
+        "pants_check",
+        "pants_test",
+        "pants_package",
+        "pants_tailor",
+        "pants_workflow",
+        "full_quality_check",
+        "pants_clear_cache",
+        "container_start",
+        "container_stop",
+        "container_rebuild",
+        "container_exec"
+      ]
     }
   }
 }


### PR DESCRIPTION
Fixes an issue where Kiro was mangling the workspace path in the kiro-pants-power MCP configuration.
Adds the devcontainer-lock.json file created by the DevContainer command.