### PR TITLE
Upgrade Pants from 2.29 to 2.32

### DIFF
--- a/common/src/python/gear_execution/gear_execution.py
+++ b/common/src/python/gear_execution/gear_execution.py
@@ -214,7 +214,7 @@ class InputFileWrapper:
     @property
     def basename(self) -> str:
         """Returns the base name of the file name."""
-        (basename, extension) = os.path.splitext(self.filename)
+        (basename, _extension) = os.path.splitext(self.filename)
         return basename
 
     @property

--- a/common/test/python/preprocess_test/test_preprocessor.py
+++ b/common/test/python/preprocess_test/test_preprocessor.py
@@ -154,7 +154,7 @@ class TestFormPreprocessor:
     def test_check_optional_forms_status_none(self, np_module_configs, np_pp_context):
         """Tests the _check_optional_forms_status check when there are no
         optional forms."""
-        processor, error_writer, _ = self.__setup_processor(
+        processor, _error_writer, _ = self.__setup_processor(
             DefaultValues.NP_MODULE, np_module_configs
         )
         assert processor._check_optional_forms_status(np_pp_context)
@@ -367,7 +367,7 @@ class TestFormPreprocessor:
 
     def test_is_existing_visit(self, uds_module_configs, uds_pp_context):
         """Tests the is_existing_visit method."""
-        processor, error_writer, forms_store = self.__setup_processor(
+        processor, _error_writer, forms_store = self.__setup_processor(
             DefaultValues.UDS_MODULE, uds_module_configs
         )
 

--- a/gear/form_deletion/test/python/form_deletion_test/test_acquisition_remover.py
+++ b/gear/form_deletion/test/python/form_deletion_test/test_acquisition_remover.py
@@ -182,7 +182,7 @@ class TestCleanupAcquisitions:
         self, form_configs, uds_module_configs, deleted_items, delete_request
     ):
         """Missing acquisition file is not an error — returns True."""
-        mock_subject, mock_session, mock_acquisition = make_mock_hierarchy(
+        mock_subject, mock_session, _mock_acquisition = make_mock_hierarchy(
             acq_file=None
         )
         mock_subject.sessions.return_value = [mock_session]
@@ -204,7 +204,7 @@ class TestCleanupAcquisitions:
     ):
         """Happy path: acquisition deleted and tracked in deleted_items."""
         acq_file = make_mock_acq_file()
-        mock_subject, mock_session, mock_acquisition = make_mock_hierarchy(
+        mock_subject, _mock_session, mock_acquisition = make_mock_hierarchy(
             acq_file=acq_file, empty_session_after_delete=True
         )
 

--- a/gear/form_transformer/test/python/test_milestones_transform.py
+++ b/gear/form_transformer/test/python/test_milestones_transform.py
@@ -133,14 +133,14 @@ class TestMilestonesTransform:
 
     def test_valid_milestones_record(self):
         """Test valid milestones record."""
-        visitor, project, _ = create_mlst_visitor()
+        visitor, _project, _ = create_mlst_visitor()
         record = create_milestones_record({})
         assert visitor.visit_row(record, 0)
 
     def test_invalid_milestones_record(self):
         """Test missing required fields."""
 
-        visitor, project, _ = create_mlst_visitor()
+        visitor, _project, _ = create_mlst_visitor()
         record = create_milestones_record({})
         record.pop(FieldNames.FORMVER)
         assert not visitor.visit_row(record, 0)

--- a/gear/form_transformer/test/python/test_uds_transform.py
+++ b/gear/form_transformer/test/python/test_uds_transform.py
@@ -242,7 +242,7 @@ class TestUDSTransform:
 
     def test_already_exists(self):
         """Test that the subject already exists - this is allowed"""
-        visitor, project, form_store = create_uds_visitor()
+        visitor, _project, form_store = create_uds_visitor()
         record = create_record({})
         form_store.add_subject(
             subject_lbl=record["naccid"],
@@ -360,7 +360,7 @@ class TestUDSTransform:
 
     def test_non_numeric_visitnum(self):
         """Tests non-numeric visit numbers."""
-        visitor, project, _ = create_uds_visitor()
+        visitor, _project, _ = create_uds_visitor()
         record = create_record(
             {
                 "ptid": "new-ptid1",

--- a/gear/gather_form_data/test/python/BUILD
+++ b/gear/gather_form_data/test/python/BUILD
@@ -1,1 +1,0 @@
-python_tests(name="tests")

--- a/gear/identifier_lookup/test/python/test_property_output_format_preservation.py
+++ b/gear/identifier_lookup/test/python/test_property_output_format_preservation.py
@@ -114,8 +114,8 @@ def test_output_format_preservation_property(
     for i, (baseline_call, event_call) in enumerate(
         zip(baseline_result["qc_calls"], event_logging_result["qc_calls"], strict=False)
     ):
-        baseline_args, baseline_kwargs = baseline_call
-        event_args, event_kwargs = event_call
+        _baseline_args, baseline_kwargs = baseline_call
+        _event_args, event_kwargs = event_call
 
         # Compare status (most important QC metadata)
         assert baseline_kwargs["status"] == event_kwargs["status"], (

--- a/gear/identifier_lookup/test/python/test_property_visitor_coordination.py
+++ b/gear/identifier_lookup/test/python/test_property_visitor_coordination.py
@@ -136,7 +136,7 @@ def test_visitor_coordination_success_case():
 
     # Check that all QC log calls used PASS status (no errors in shared error writer)
     for call in mock_qc_creator.update_qc_log.call_args_list:
-        args, kwargs = call
+        _args, kwargs = call
         assert kwargs["status"] == "PASS", (
             "QC status should be PASS for successful identifier lookup"
         )
@@ -254,7 +254,7 @@ def test_visitor_coordination_failure_case():
 
     # Check that all QC log calls used FAIL status (errors in shared error writer)
     for call in mock_qc_creator.update_qc_log.call_args_list:
-        args, kwargs = call
+        _args, kwargs = call
         assert kwargs["status"] == "FAIL", (
             "QC status should be FAIL for failed identifier lookup"
         )

--- a/gear/image_identifier_lookup/test/python/image_identifier_lookup_test/test_visitor_and_main.py
+++ b/gear/image_identifier_lookup/test/python/image_identifier_lookup_test/test_visitor_and_main.py
@@ -788,7 +788,7 @@ class TestRunDataIdentificationReturn:
         )
 
         # Act
-        success, data_identification = ImageIdentifierLookup(
+        _success, data_identification = ImageIdentifierLookup(
             lookup_context=lookup_context,
             project=mock_project,
             subject=mock_subject,

--- a/gear/pipeline_event_logger/test/python/pipeline_event_logger_test/test_main.py
+++ b/gear/pipeline_event_logger/test/python/pipeline_event_logger_test/test_main.py
@@ -137,7 +137,7 @@ class TestQCMetadataReading:
             event_actions={},
         )
 
-        with pytest.raises(GearExecutionError, match="file.info is empty"):
+        with pytest.raises(GearExecutionError, match=r"file\.info is empty"):
             logger.run()
 
     def test_missing_qc_section_raises(self) -> None:
@@ -148,7 +148,7 @@ class TestQCMetadataReading:
         }
         logger = _make_logger(upstream_gear_name="gear", file_info=info)
 
-        with pytest.raises(GearExecutionError, match="file.info.qc not found"):
+        with pytest.raises(GearExecutionError, match=r"file\.info\.qc not found"):
             logger.run()
 
     def test_missing_upstream_gear_in_qc_raises(self) -> None:
@@ -157,7 +157,7 @@ class TestQCMetadataReading:
         info = _build_full_info("other-gear", status="PASS")
         logger = _make_logger(upstream_gear_name="my-gear", file_info=info)
 
-        with pytest.raises(GearExecutionError, match="not found in file.info.qc"):
+        with pytest.raises(GearExecutionError, match=r"not found in file\.info\.qc"):
             logger.run()
 
     def test_invalid_qc_structure_raises(self) -> None:
@@ -168,7 +168,7 @@ class TestQCMetadataReading:
         }
         logger = _make_logger(upstream_gear_name="gear", file_info=info)
 
-        with pytest.raises(GearExecutionError, match="file.info.qc not found"):
+        with pytest.raises(GearExecutionError, match=r"file\.info\.qc not found"):
             logger.run()
 
 
@@ -189,7 +189,7 @@ class TestDataIdentificationReading:
         logger = _make_logger(upstream_gear_name=gear, file_info=info)
 
         with pytest.raises(
-            GearExecutionError, match="file.info.data_identification not found"
+            GearExecutionError, match=r"file\.info\.data_identification not found"
         ):
             logger.run()
 
@@ -676,5 +676,5 @@ class TestDryRun:
             dry_run=True,
         )
 
-        with pytest.raises(GearExecutionError, match="file.info.qc not found"):
+        with pytest.raises(GearExecutionError, match=r"file\.info\.qc not found"):
             logger.run()

--- a/mypy.lock
+++ b/mypy.lock
@@ -140,64 +140,64 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "070aa8c26c0a74774317a72df8851facc7f0f012a5b406557ac56992d92e1ec8",
-              "url": "https://files.pythonhosted.org/packages/9e/58/9384b2f4eb1ed1d273d40948a7c5c4b2360213b402ef3be4641c06299f9c/librt-0.11.0-cp312-cp312-musllinux_1_2_x86_64.whl"
+              "hash": "1eac6cc0e23e448fb3c1446ed85ff796afb616eed5897c978d35dbec030b7c7c",
+              "url": "https://files.pythonhosted.org/packages/b3/1e/93aebb219d52c37ea578f83b0588cd7b040974e464d4e435086a48b4dc4d/librt-0.12.0-cp312-cp312-musllinux_1_2_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "bc3ce6b33c5828d9e80592011a5c584cb2ce86edbc4088405f70da47dc1d1b3b",
-              "url": "https://files.pythonhosted.org/packages/07/10/f1f23a7c595ee90ece4d35c851e5d104b1311a887ed1b4ac4c35bbd13da8/librt-0.11.0-cp312-cp312-musllinux_1_2_aarch64.whl"
+              "hash": "10a40cf74cdd97b6f8f905056db73f5d459783de2ca04c6ebd1bf47652818e7e",
+              "url": "https://files.pythonhosted.org/packages/4d/71/03c8c8cec39645fda451132ff9d6d662fc5aea42a1a188a77a4fddb35906/librt-0.12.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0d1029d7e1ae1a7e647ed6fb5df8c4ce2dffefb7a9f5fd1376a4554d96dac09f",
-              "url": "https://files.pythonhosted.org/packages/19/6e/55bdf5d5ca00c3e18430690bf2c953d8d3ffd3c337418173d33dec985dc9/librt-0.11.0-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl"
+              "hash": "9efed79d51ad1383bba0855f613cca7aa91c943e709af2413ac7f4bb9936ce08",
+              "url": "https://files.pythonhosted.org/packages/79/1e/a9afe85d5bb8b65dc27be3809ed1d69082079e1e9717fd2c66aa9939600c/librt-0.12.0-cp312-cp312-musllinux_1_2_riscv64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "075dc3ef4458a278e0195cbf6ac9d38808d9b906c5a6c7f7f79c3888276a3fb1",
-              "url": "https://files.pythonhosted.org/packages/40/08/9e7f6b5d2b5bed6ad055cdd5925f192bb403a51280f86b56554d9d0699a2/librt-0.11.0.tar.gz"
+              "hash": "0461344061d6fc3718940f5855d95647831cef6d03a6c7506897f98222784ad4",
+              "url": "https://files.pythonhosted.org/packages/7a/34/717055325d028743aa01a7691ad59a63352a26a8ff2e7eeb0c9249514150/librt-0.12.0-cp312-cp312-musllinux_1_2_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "9bc0ca6ad9381cbe8e4aa6e5726e4c80c78115a6e9723c599ed1d73e092bc49d",
-              "url": "https://files.pythonhosted.org/packages/50/db/b4a47c6f91db4ff76348a0b3dd0cc65e090a078b765a810a62ff9434c3d3/librt-0.11.0-cp312-cp312-musllinux_1_2_riscv64.whl"
+              "hash": "e6dfe89074732c9287b3c0f5a6af575c9ede380a788013876cc7b14fe0da0361",
+              "url": "https://files.pythonhosted.org/packages/95/f8/7612eeedb3395d92f7c6a84dca5f15e282d650483a4dc01aa5b9cffdfda3/librt-0.12.0-cp312-cp312-musllinux_1_2_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "40071fc5fe0ce8daa6de616702314a01e1250711682b0523d6ab8d4525910cb3",
-              "url": "https://files.pythonhosted.org/packages/7a/24/8493538fa4f62f982686398a5b8f68008138a75086abdea19ade64bf4255/librt-0.11.0-cp312-cp312-macosx_11_0_arm64.whl"
+              "hash": "d007efe9243ede81ce75990ad7aa172da1e2024144b3eff17ba46a5fff1fff3c",
+              "url": "https://files.pythonhosted.org/packages/9e/10/c02325556beb2aa158c9e549ddade8cc9a23b36cdad14756dbed730c1ff1/librt-0.12.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b87504f1690a23b9a2cca841191a04f83895d4fc2dd04df91d82b1a04ca2ad46",
-              "url": "https://files.pythonhosted.org/packages/8b/d0/07c77e067f0838949b43bd89232c29d72efebb9d2801a9750184eb706b71/librt-0.11.0-cp312-cp312-macosx_10_13_x86_64.whl"
+              "hash": "b0ace09f5bf4d982fe726015f102fb856658b41580597104e301e630ed1d8d86",
+              "url": "https://files.pythonhosted.org/packages/b9/d0/cc04b48a57c1f275387f5578847214c4a6c21bfb24c6c8c8d6ba753fe403/librt-0.12.0-cp312-cp312-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d5b0eea49f5562861ee8d757a32ef7d559c1d35be2aaaa1ec28941d74c9ffc8a",
-              "url": "https://files.pythonhosted.org/packages/b0/da/5d1876984b3746c85dbd219dbfcb73c85f54ee263fd32e5b2a632ec14571/librt-0.11.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+              "hash": "cb26faedbd09c6130e9c1b64d8000efec5076ffd18d606c6cd1cf02730e6d8b0",
+              "url": "https://files.pythonhosted.org/packages/c6/e0/dbd0f2a68a1c1a1991eb7921ff6014465d56608cdc9a9fb468a616210a37/librt-0.12.0.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "936c5995f3514a42111f20099397d8177c79b4d7e70961e396c6f5a0a3566766",
-              "url": "https://files.pythonhosted.org/packages/b6/02/5720f5697a7f54b78b3aefbe20df3a48cedcff1276618c4aa481177942ed/librt-0.11.0-cp312-cp312-musllinux_1_2_i686.whl"
+              "hash": "ad324a5e4858388a4864915b90a42efc8b374376393f14b9940f2454e791912b",
+              "url": "https://files.pythonhosted.org/packages/cb/9e/7b49ca1c30baa9c8df96024aa09a97c35a97455e36004c9b5311703c56f3/librt-0.12.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "cca6644054e78746d8d4ef238681f9c34ff8b584fe6b988ecebb8db3b15e622a",
-              "url": "https://files.pythonhosted.org/packages/c0/fe/3594ebfbaf03084ba4b120c9ba5c3183fd938a48725e9bbe6ff0a5159ad8/librt-0.11.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl"
+              "hash": "9bce19aa7c05f91c989f9da7b567f81d21d57a2e6501e2b811aa0f3f79614c1a",
+              "url": "https://files.pythonhosted.org/packages/d5/1a/5bec493821b0e85b91de4f234912b50133d1aedb875048eef27938ec3f96/librt-0.12.0-cp312-cp312-macosx_10_13_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "137e79445c896a0ea7b265f52d23954e05b64222ee1af69e2cb34219067cbb67",
-              "url": "https://files.pythonhosted.org/packages/ff/1e/f8bad050810d9171f34a1648ed910e56814c2ba61639f2bd53c6377ae24b/librt-0.11.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+              "hash": "92e61c09de95217ae02a9d17f4f66cf073253cdc51bcfdc0f15c62c9a70baa85",
+              "url": "https://files.pythonhosted.org/packages/e0/ec/a9f357f94bbcba92277d22af22cff42ef706ae5d9d6d58b69bebf3a67954/librt-0.12.0-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl"
             }
           ],
           "project_name": "librt",
           "requires_dists": [],
           "requires_python": ">=3.9",
-          "version": "0.11.0"
+          "version": "0.12.0"
         },
         {
           "artifacts": [

--- a/mypy.lock
+++ b/mypy.lock
@@ -4,7 +4,7 @@
 //
 // --- BEGIN PANTS LOCKFILE METADATA: DO NOT EDIT OR REMOVE ---
 // {
-//   "version": 4,
+//   "version": 8,
 //   "valid_for_interpreter_constraints": [
 //     "CPython==3.12.*"
 //   ],
@@ -17,7 +17,13 @@
 //   "only_binary": [],
 //   "no_binary": [],
 //   "excludes": [],
-//   "overrides": []
+//   "overrides": [],
+//   "sources": [],
+//   "lock_style": "universal",
+//   "complete_platforms": [],
+//   "uploaded_prior_to": null,
+//   "lockfile_format": "pex",
+//   "resolve": "mypy"
 // }
 // --- END PANTS LOCKFILE METADATA ---
 
@@ -428,6 +434,7 @@
           "version": "0.4.2"
         }
       ],
+      "marker": null,
       "platform_tag": null
     }
   ],
@@ -435,7 +442,7 @@
   "only_wheels": [],
   "overridden": [],
   "path_mappings": {},
-  "pex_version": "2.55.2",
+  "pex_version": "2.95.1",
   "pip_version": "24.2",
   "prefer_older_binary": false,
   "requirements": [

--- a/pants.toml
+++ b/pants.toml
@@ -33,9 +33,6 @@ root_patterns = [
 default_repository = "naccdata/{name}"
 env_vars = ["BUILDX_NO_DEFAULT_ATTESTATIONS=1"]
 
-[dockerfile-parser]
-use_rust_parser = true
-
 [python]
 interpreter_constraints = ["==3.12.*"]
 enable_resolves = true

--- a/pants.toml
+++ b/pants.toml
@@ -1,5 +1,5 @@
 [GLOBAL]
-pants_version = "2.29.0"
+pants_version = "2.32.0"
 backend_packages = [
     "pants.backend.build_files.fmt.ruff",
     "pants.backend.docker",

--- a/python-default.lock
+++ b/python-default.lock
@@ -4,7 +4,7 @@
 //
 // --- BEGIN PANTS LOCKFILE METADATA: DO NOT EDIT OR REMOVE ---
 // {
-//   "version": 4,
+//   "version": 8,
 //   "valid_for_interpreter_constraints": [
 //     "CPython==3.12.*"
 //   ],
@@ -18,8 +18,8 @@
 //     "fw-utils>=3",
 //     "hypothesis>=6.0.0",
 //     "moto[s3,ses,ssm]==5.1.14",
-//     "nacc_attribute_deriver@ https://github.com/naccdata/nacc-attribute-deriver/releases/download/v2.3.4/nacc_attribute_deriver-2.3.4-py3-none-any.whl",
-//     "nacc_form_validator@ https://github.com/naccdata/nacc-form-validator/releases/download/v0.6.4/nacc_form_validator-0.6.4-py3-none-any.whl",
+//     "nacc_attribute_deriver @ https://github.com/naccdata/nacc-attribute-deriver/releases/download/v2.3.4/nacc_attribute_deriver-2.3.4-py3-none-any.whl",
+//     "nacc_form_validator @ https://github.com/naccdata/nacc-form-validator/releases/download/v0.6.4/nacc_form_validator-0.6.4-py3-none-any.whl",
 //     "natsort",
 //     "pandas-stubs>=2.0.3",
 //     "pandas>=2.1.1",
@@ -33,7 +33,7 @@
 //     "pyyaml>=6.0.1",
 //     "ratelimit-types>=0.0.1",
 //     "ratelimit>=2.2.1",
-//     "redcap_api@ https://github.com/naccdata/redcap-api/releases/download/v0.3.0/redcap_api-0.3.0-py3-none-any.whl",
+//     "redcap_api @ https://github.com/naccdata/redcap-api/releases/download/v0.3.0/redcap_api-0.3.0-py3-none-any.whl",
 //     "requests-oauthlib>=2.0.0",
 //     "requests>=2.18.4",
 //     "setuptools>=68.3.0",
@@ -50,7 +50,13 @@
 //   "only_binary": [],
 //   "no_binary": [],
 //   "excludes": [],
-//   "overrides": []
+//   "overrides": [],
+//   "sources": [],
+//   "lock_style": "universal",
+//   "complete_platforms": [],
+//   "uploaded_prior_to": null,
+//   "lockfile_format": "pex",
+//   "resolve": "python-default"
 // }
 // --- END PANTS LOCKFILE METADATA ---
 
@@ -89,13 +95,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "dd9b7a2a9799ed6552fde617b2c5df02b7fdd7d88392fc48101e51bae46164d9",
-              "url": "https://files.pythonhosted.org/packages/ba/16/9826f089383c593cdfc4a6e5aca94d9e91ae1692c57af82c3b2aa5e810f7/anyio-4.14.0-py3-none-any.whl"
+              "hash": "4e5533c5b8ff0a24f5d7a176cbe6877129cd183893f66b537f8f227d10527d72",
+              "url": "https://files.pythonhosted.org/packages/b0/7b/90df4a0a816d98d6ea26f559d87836d494a2cf1fcf063be67df50a7bcc30/anyio-4.14.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b47c1f9ccf73e67021df785332508f99379c68fa7d0684e8e3492cb1d4b23f89",
-              "url": "https://files.pythonhosted.org/packages/1c/b5/001890774a9552aff22502b8da382593109ce0c95314abaebbb116567545/anyio-4.14.0.tar.gz"
+              "hash": "8d648a3544c1a700e3ff78615cd679e4c5c3f149904287e73687b2596963629e",
+              "url": "https://files.pythonhosted.org/packages/3b/72/5562aabb8dd7181e8e860622a38bea08d17842b99ecd4c91f84ac95251b0/anyio-4.14.1.tar.gz"
             }
           ],
           "project_name": "anyio",
@@ -106,7 +112,7 @@
             "typing_extensions>=4.5; python_version < \"3.13\""
           ],
           "requires_python": ">=3.10",
-          "version": "4.14.0"
+          "version": "4.14.1"
         },
         {
           "artifacts": [
@@ -148,42 +154,42 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "69c5521ad864f33d4d53b0e18a3927697f4558210693b1cb4dd97da959d1f7b9",
-              "url": "https://files.pythonhosted.org/packages/13/66/67b54f12fc0c5b2dc6fd0c04ea4cf1e7fc4a9843de680a22070d1fd77901/boto3-1.43.31-py3-none-any.whl"
+              "hash": "42942dde254673abcbc9e6e60017c88341a4f49d99d24e1f2e290fb38138c26f",
+              "url": "https://files.pythonhosted.org/packages/9f/f1/274303f52483ecf199eae6f8d9b6f5951670397ee4d72c06cfd4eb644612/boto3-1.43.36-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8165b79c02955affbe4b4e9aa7c560684d0d4d86b4b9de66a37b45eb79fc4b69",
-              "url": "https://files.pythonhosted.org/packages/a5/8a/1d33e395da9319b162046ff7d7e75550756425c2a236d8682b4a1bbdec1c/boto3-1.43.31.tar.gz"
+              "hash": "587d7ee92a12e440ad12b0e7f11f3358f0c4d65b19f64726efc94aaf194aff28",
+              "url": "https://files.pythonhosted.org/packages/ff/9f/897287e955db0f50b12fd69ef45956e4fd2c7ddb48c736872f7ea2314443/boto3-1.43.36.tar.gz"
             }
           ],
           "project_name": "boto3",
           "requires_dists": [
-            "botocore<1.44.0,>=1.43.31",
+            "botocore<1.44.0,>=1.43.36",
             "botocore[crt]<2.0a0,>=1.21.0; extra == \"crt\"",
             "jmespath<2.0.0,>=0.7.1",
             "s3transfer<0.20.0,>=0.19.0"
           ],
           "requires_python": ">=3.10",
-          "version": "1.43.31"
+          "version": "1.43.36"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "f710d553c54ce5c2819f0396aec4159e3b629595d98032762935a00931ed962c",
-              "url": "https://files.pythonhosted.org/packages/f4/d9/ccc0e71543c086af006d5e0ec51ffd3472331200b18a0bd31e2fe5e3ab08/boto3_stubs-1.43.31-py3-none-any.whl"
+              "hash": "e89e48f937710919ef2d36623a8a98c3768568ca6fb9726f7b2369f681ec5745",
+              "url": "https://files.pythonhosted.org/packages/34/54/a2ed6e00bdb37315dcdc336e68a2047e73d7664df836a84d8ba723fd5ac7/boto3_stubs-1.43.36-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "fdbdad627a94d303332764cad4ae26b35d8c4963af26ebaa38350e580d954f15",
-              "url": "https://files.pythonhosted.org/packages/69/24/e56728c8e06f18df066f22950ee3a3227691bd656fbc6cb4e35152ad94d5/boto3_stubs-1.43.31.tar.gz"
+              "hash": "35bdcef0f3e5b6bb1f1f6e61ab813fdde0d739508512450b6ea12509b516cdcb",
+              "url": "https://files.pythonhosted.org/packages/c0/64/bbc5e1a6a8e770e8380d1480d714926a70873d0f022c4b733ac80242703e/boto3_stubs-1.43.36.tar.gz"
             }
           ],
           "project_name": "boto3-stubs",
           "requires_dists": [
             "boto3-stubs-full<1.44.0,>=1.43.0; extra == \"full\"",
-            "boto3==1.43.31; extra == \"boto3\"",
+            "boto3==1.43.36; extra == \"boto3\"",
             "botocore-stubs",
             "mypy-boto3-accessanalyzer<1.44.0,>=1.43.0; extra == \"accessanalyzer\"",
             "mypy-boto3-accessanalyzer<1.44.0,>=1.43.0; extra == \"all\"",
@@ -626,6 +632,10 @@
             "mypy-boto3-kms<1.44.0,>=1.43.0; extra == \"kms\"",
             "mypy-boto3-lakeformation<1.44.0,>=1.43.0; extra == \"all\"",
             "mypy-boto3-lakeformation<1.44.0,>=1.43.0; extra == \"lakeformation\"",
+            "mypy-boto3-lambda-core<1.44.0,>=1.43.0; extra == \"all\"",
+            "mypy-boto3-lambda-core<1.44.0,>=1.43.0; extra == \"lambda-core\"",
+            "mypy-boto3-lambda-microvms<1.44.0,>=1.43.0; extra == \"all\"",
+            "mypy-boto3-lambda-microvms<1.44.0,>=1.43.0; extra == \"lambda-microvms\"",
             "mypy-boto3-lambda<1.44.0,>=1.43.0; extra == \"all\"",
             "mypy-boto3-lambda<1.44.0,>=1.43.0; extra == \"essential\"",
             "mypy-boto3-lambda<1.44.0,>=1.43.0; extra == \"lambda\"",
@@ -1046,19 +1056,19 @@
             "typing-extensions>=4.1.0; python_version < \"3.12\""
           ],
           "requires_python": ">=3.9",
-          "version": "1.43.31"
+          "version": "1.43.36"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "4c51c63f39515fc1a2b8e3e2c29e452009c988ba55ad489251658fdd3aedad6e",
-              "url": "https://files.pythonhosted.org/packages/d2/1e/da5fdcb8438008d3c53a0c6de6a40cb10bdb7e02a6e034aef79bc2b66800/botocore-1.43.31-py3-none-any.whl"
+              "hash": "3c65fdc39ed01d8dfde1e961b34038aed03c459f8ddf80717a12ac006475e49d",
+              "url": "https://files.pythonhosted.org/packages/5c/19/934f81592527a3f7f9b943c893e334c721a4644948642bc33885d584e9ec/botocore-1.43.36-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "c249625faaa353c5b4004043706a394a4f3bcd3643e242f6b01fff6dc70e988b",
-              "url": "https://files.pythonhosted.org/packages/a4/17/225ae5e7253441ae3beadf26aa12c2f9ce292f386a4877a2ed0bb17d6014/botocore-1.43.31.tar.gz"
+              "hash": "4cae47d1b2d426316b85a0087d9e69e048f13bc003b5177d74639fe9dfd28205",
+              "url": "https://files.pythonhosted.org/packages/7c/37/da9e7f6ca73ac73afd7f0bb7f238aa5daba35c081e98d7f48a7c399599c0/botocore-1.43.36.tar.gz"
             }
           ],
           "project_name": "botocore",
@@ -1069,7 +1079,7 @@
             "urllib3!=2.2.0,<3,>=1.25.4"
           ],
           "requires_python": ">=3.10",
-          "version": "1.43.31"
+          "version": "1.43.36"
         },
         {
           "artifacts": [
@@ -1116,19 +1126,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897",
-              "url": "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl"
+              "hash": "2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db",
+              "url": "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d",
-              "url": "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz"
+              "hash": "024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432",
+              "url": "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz"
             }
           ],
           "project_name": "certifi",
           "requires_dists": [],
           "requires_python": ">=3.7",
-          "version": "2026.5.20"
+          "version": "2026.6.17"
         },
         {
           "artifacts": [
@@ -1553,13 +1563,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "5218779da5d6e3c2013ac706121abfb3815d450e0613495c0de50264dce58242",
-              "url": "https://files.pythonhosted.org/packages/7c/72/4fdf2306143a92a471fad9f3655aa542d43aa9188a7c9534e82c9aecf837/httpcore2-2.4.0-py3-none-any.whl"
+              "hash": "5ce35188de461d31e8d000bfb8ef8bf22c6c16587a211e5571deaa5e9bdf842a",
+              "url": "https://files.pythonhosted.org/packages/c9/a1/7564199d1a8728fe737b0a72e5b3f8d92dfe085a74ddf7cdd83bce5f206d/httpcore2-2.5.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "3093a8ab8980d9f910b9cb4351df9186a0ad2350a6284a9107ac9a362a584422",
-              "url": "https://files.pythonhosted.org/packages/7b/9b/2b1d1833a58236d1f6ee755e027a3917da0db59cc9708554cefc440ee8b6/httpcore2-2.4.0.tar.gz"
+              "hash": "88aa170137c17328d5ac44234f9fd10706466d5fb347f3edac4d39b91137b09d",
+              "url": "https://files.pythonhosted.org/packages/47/06/5c12df521b5322fb1114a83d46911b2fbcb8855ddb3a635f11c01a214af5/httpcore2-2.5.0.tar.gz"
             }
           ],
           "project_name": "httpcore2",
@@ -1572,19 +1582,19 @@
             "truststore>=0.10"
           ],
           "requires_python": ">=3.10",
-          "version": "2.4.0"
+          "version": "2.5.0"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "425acd99297829599decf6701386dd84db3542597d36d3e2e4def930ecd57fd9",
-              "url": "https://files.pythonhosted.org/packages/29/45/82bc57c3d9c3314f663b67cc057f1c017a6450685dde513f4f8db5cf431f/httpx2-2.4.0-py3-none-any.whl"
+              "hash": "3d2d4d9cf4b61f1a1f46a95947cfdb47e80cb56a2f91c6256ac8f58e4891df41",
+              "url": "https://files.pythonhosted.org/packages/31/22/859d8252dad9bc9adee34b52e62cde621ece07b042ccb2ab4da1be46695f/httpx2-2.5.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "32e0734b61eb0824b3f56a9e98d6d92d381a3ef12c0045aa917ee63df6c411ef",
-              "url": "https://files.pythonhosted.org/packages/fc/60/b43ced4ccf26e95b396dbf67051d3e5042b645917d4da0469dd82a3bdd4f/httpx2-2.4.0.tar.gz"
+              "hash": "e2df9cb4611021527ff8a675b1c320b610a2ec397acc8d6fe6e91df2d9b33c29",
+              "url": "https://files.pythonhosted.org/packages/d0/e2/b5dedc0cf35aa65de5f541ccd30d2bc1fd7f1d43c9ab09f8ed9a7342317b/httpx2-2.5.0.tar.gz"
             }
           ],
           "project_name": "httpx2",
@@ -1594,7 +1604,7 @@
             "brotlicffi; platform_python_implementation != \"CPython\" and extra == \"brotli\"",
             "click==8.*; extra == \"cli\"",
             "h2<5,>=3; extra == \"http2\"",
-            "httpcore2==2.4.0",
+            "httpcore2==2.5.0",
             "idna>=3.18",
             "pygments==2.*; extra == \"cli\"",
             "rich<16,>=10; extra == \"cli\"",
@@ -1604,19 +1614,19 @@
             "zstandard>=0.18.0; python_version <= \"3.13\" and extra == \"zstd\""
           ],
           "requires_python": ">=3.10",
-          "version": "2.4.0"
+          "version": "2.5.0"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "ede5a3d142d9c5c9f70cb3075541905b228d6c3a682bcec3d4fe0722e9eda127",
-              "url": "https://files.pythonhosted.org/packages/a2/23/ce3a543935a01e478349e82f6c1440776f92d4cb346662c4d81574878fed/hypothesis-6.155.3-py3-none-any.whl"
+              "hash": "9f634bdb1f9e9b8ab6ba09431cf2deedb750c96978125a6fb3c5a0f6c6db4131",
+              "url": "https://files.pythonhosted.org/packages/01/f8/c151e196d4f397ed9436a071e52666c70a2f021138dea828b0a461e245db/hypothesis-6.155.7-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1e34b17ae9873515384312cb7640abd773eb096c7eef8c0d9c614fa2c306e9bb",
-              "url": "https://files.pythonhosted.org/packages/36/77/13ec9b6390bce44f5badab39837dd6789bbfe6342a2ac611a71537a7756f/hypothesis-6.155.3.tar.gz"
+              "hash": "d8d6091753d0669db3c90c5e5b346cb37c72f3dd9378c8413acb1fd5da63f7ea",
+              "url": "https://files.pythonhosted.org/packages/f2/55/983b6bc1b6b343a5ff6020388f9d0680ab477be59a731517e6c4a0387100/hypothesis-6.155.7.tar.gz"
             }
           ],
           "project_name": "hypothesis",
@@ -1660,7 +1670,7 @@
             "watchdog>=4.0.0; extra == \"watchdog\""
           ],
           "requires_python": ">=3.10",
-          "version": "6.155.3"
+          "version": "6.155.7"
         },
         {
           "artifacts": [
@@ -2024,54 +2034,54 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "e5805d5a22fd19c8ccff10a9561f9df94436b0545619ea579db2d3c35294bce2",
-              "url": "https://files.pythonhosted.org/packages/ef/fc/85b7c4eff9b4966ade25c2273cf7e7012e92366c032058653934b37de044/numpy-2.4.6-cp312-cp312-musllinux_1_2_x86_64.whl"
+              "hash": "b8c3daaf99de52415d20b42f8e8155c78642cb04207d02f9d317a0dcf1b3fb54",
+              "url": "https://files.pythonhosted.org/packages/06/34/43efdcb319988648580f93c11f1ae82cf7e2faa74925e98e454ae3aa95f8/numpy-2.5.0-cp312-cp312-musllinux_1_2_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "001fbb8e08d942dd57599e781f2472269ee7f2755fae407b4f67b2f0b17da3f1",
-              "url": "https://files.pythonhosted.org/packages/95/2a/3d7b5ac8aac24feaf9ad7ed58f45b0bbc06d37e4338ae84c9f2298b570f9/numpy-2.4.6-cp312-cp312-macosx_10_13_x86_64.whl"
+              "hash": "7174ce8265fc7f7417d171c9ea8fe905220748893ea67a2a7abe726ec331c4b0",
+              "url": "https://files.pythonhosted.org/packages/3a/2f/c354ec86d1f3f5c19649463b0d39652e160736e5b0a4cd18dff0576715c4/numpy-2.5.0-cp312-cp312-musllinux_1_2_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "90f9849678c75fe7afa2d348ac842c168b0a4d3d61919687216dfc547976d853",
-              "url": "https://files.pythonhosted.org/packages/99/60/14115e6364fa676c5397c2ad3004e527e9aa487abf5d0706ec81bbd08529/numpy-2.4.6-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
+              "hash": "ece55976ced6bca95a03ae2839e2e5ccffe8eb6a3e7022415645eb154a81e4e6",
+              "url": "https://files.pythonhosted.org/packages/55/b2/285f48640a181947b4587a3766d21ec1eaa7fea833d4b49957e09da467a2/numpy-2.5.0-cp312-cp312-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "3213d622a0283a39a93d188f3cf72b26862df52fbb4ca3697f51705016523d41",
-              "url": "https://files.pythonhosted.org/packages/ad/fe/c0a6b7b2ca128a8fb228575147073b660656734b8ebe4d76c8fd748dcc79/numpy-2.4.6-cp312-cp312-macosx_14_0_arm64.whl"
+              "hash": "a1a4874217b36d5ac8fc876f52e39df56f8182c88463e9e2dceabf7ca8b7efb8",
+              "url": "https://files.pythonhosted.org/packages/82/49/2ec21730bc63ccfda829323f7040a8ed4715b3852ce658689cf74ee96a8c/numpy-2.5.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "c1a2af6c6ef86344a6b0db6b97834208bf598db514f2b155042439b62605601a",
-              "url": "https://files.pythonhosted.org/packages/ae/c5/693cbe59e57db94d2231fa519ca3978dc9e19da5a8f088588f5c6e947ff2/numpy-2.4.6-cp312-cp312-musllinux_1_2_aarch64.whl"
+              "hash": "bf80333980bf37f523341ddd72c783f39d6829ec7736b9eb99086388a2d52cc2",
+              "url": "https://files.pythonhosted.org/packages/b9/83/03fc7300c7c6b6c84c487b1dc80d322817b95fbd1f4dd57a85e23b7198de/numpy-2.5.0-cp312-cp312-macosx_14_0_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5f9fb9157b4ce2971008323afe46053787b526ef624fea915b261468a8421a0f",
-              "url": "https://files.pythonhosted.org/packages/c9/c6/50a46a6205feba2343f1d6d17438107c5dc491ed1c736e6ea68689fd906b/numpy-2.4.6-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl"
+              "hash": "aaa760137137e8d3c920d27927748215b56014f92667dc9b6c27dfc61249255a",
+              "url": "https://files.pythonhosted.org/packages/bb/6b/f4a3d0637692c49da8ef99d72d52526f92e0a8d6ac4f0ca9f31441b9d9ea/numpy-2.5.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda",
-              "url": "https://files.pythonhosted.org/packages/d0/ad/fed0499ce6a338d2a03ebae59cd15093910c8875328855781952abf6c2fe/numpy-2.4.6.tar.gz"
+              "hash": "c83b664b0e6eee9594fa920cf0639d8af796606d3fad6cc70180c87e4b97c7be",
+              "url": "https://files.pythonhosted.org/packages/dd/67/b032db1eb03ca30d16eda3b0c22aaa615338b9263c2fd559d0f29451aca4/numpy-2.5.0-cp312-cp312-macosx_14_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ebfb099f8dcf083deef3ac1ca4c1503f387cf76296fcb3816b66f5ecb5f54fdb",
-              "url": "https://files.pythonhosted.org/packages/ea/12/92c4c131527599e8288d6918e888d88726f84d805d784b771f32408aeaef/numpy-2.4.6-cp312-cp312-macosx_11_0_arm64.whl"
+              "hash": "5a129578019311b6e56bdd714250f19b518f7dceeeb8d1af5490f4942d3f891c",
+              "url": "https://files.pythonhosted.org/packages/e7/05/3d27272d30698dc0ecb7fdfaa41ad70303b444f81722bb99bce1d818638a/numpy-2.5.0.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "357cc07a6d7b0b182ff02249616a03742827ebb1277546b5c7cd7f7620a45698",
-              "url": "https://files.pythonhosted.org/packages/f3/d4/9770d14ba719432bb90a421bfd443872ed0f70f7264b64bec12ea363d5fd/numpy-2.4.6-cp312-cp312-macosx_14_0_x86_64.whl"
+              "hash": "489780423903667933b4ed6197b6ec3b75ea5dd17d1d8f0f38d798feb6921561",
+              "url": "https://files.pythonhosted.org/packages/fa/0a/11486d02add7b1384dff7374d124b1cfbb0ee864dcc9f6a2c0380638cf84/numpy-2.5.0-cp312-cp312-macosx_10_13_x86_64.whl"
             }
           ],
           "project_name": "numpy",
           "requires_dists": [],
-          "requires_python": ">=3.11",
-          "version": "2.4.6"
+          "requires_python": ">=3.12",
+          "version": "2.5.0"
         },
         {
           "artifacts": [
@@ -3276,13 +3286,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "024d11221ff83453eae1f608f09b145b9779e1345d08c15404ce8ff7917cf629",
-              "url": "https://files.pythonhosted.org/packages/1d/70/5771c9ecbdb7cc0c3f3bbded7e0fa7911ee8e872ce5b5dc48ce7dce21a11/tzlocal-5.4-py3-none-any.whl"
+              "hash": "24ce97bb58e2a973f7640ec2553ab4e6f6d5a0d0d1aa9dc43bca21d89e1feb82",
+              "url": "https://files.pythonhosted.org/packages/42/28/fc144409c71569e928585f8f3c629d80d1ca3ef40175e9222f01588f98c9/tzlocal-5.4.3-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "41e1293f80d4b5ff38dff222601a8fbd06b4fdcaf25e224704047ad26a39af54",
-              "url": "https://files.pythonhosted.org/packages/d8/52/ee2e6d7031687c5bad28363148cb72f2bbf38201d2e220671bd9fb830bc2/tzlocal-5.4.tar.gz"
+              "hash": "3a8c9bc18cf47e1dcde252ea0e6a72a6cde320a400b6ac6db1f1f8cccd553c00",
+              "url": "https://files.pythonhosted.org/packages/48/55/15e2340963d2bfedcc6042da3911438fd336f8ae96b65bdbe3a29766da0c/tzlocal-5.4.3.tar.gz"
             }
           ],
           "project_name": "tzlocal",
@@ -3297,7 +3307,7 @@
             "zest.releaser; extra == \"devenv\""
           ],
           "requires_python": ">=3.10",
-          "version": "5.4"
+          "version": "5.4.3"
         },
         {
           "artifacts": [
@@ -3366,6 +3376,7 @@
           "version": "1.0.4"
         }
       ],
+      "marker": null,
       "platform_tag": null
     }
   ],
@@ -3373,7 +3384,7 @@
   "only_wheels": [],
   "overridden": [],
   "path_mappings": {},
-  "pex_version": "2.55.2",
+  "pex_version": "2.95.1",
   "pip_version": "24.2",
   "prefer_older_binary": false,
   "requirements": [
@@ -3386,8 +3397,8 @@
     "fw-utils>=3",
     "hypothesis>=6.0.0",
     "moto[s3,ses,ssm]==5.1.14",
-    "nacc_attribute_deriver@ https://github.com/naccdata/nacc-attribute-deriver/releases/download/v2.3.4/nacc_attribute_deriver-2.3.4-py3-none-any.whl",
-    "nacc_form_validator@ https://github.com/naccdata/nacc-form-validator/releases/download/v0.6.4/nacc_form_validator-0.6.4-py3-none-any.whl",
+    "nacc_attribute_deriver @ https://github.com/naccdata/nacc-attribute-deriver/releases/download/v2.3.4/nacc_attribute_deriver-2.3.4-py3-none-any.whl",
+    "nacc_form_validator @ https://github.com/naccdata/nacc-form-validator/releases/download/v0.6.4/nacc_form_validator-0.6.4-py3-none-any.whl",
     "natsort",
     "pandas-stubs>=2.0.3",
     "pandas>=2.1.1",
@@ -3401,7 +3412,7 @@
     "pyyaml>=6.0.1",
     "ratelimit-types>=0.0.1",
     "ratelimit>=2.2.1",
-    "redcap_api@ https://github.com/naccdata/redcap-api/releases/download/v0.3.0/redcap_api-0.3.0-py3-none-any.whl",
+    "redcap_api @ https://github.com/naccdata/redcap-api/releases/download/v0.3.0/redcap_api-0.3.0-py3-none-any.whl",
     "requests-oauthlib>=2.0.0",
     "requests>=2.18.4",
     "setuptools>=68.3.0",

--- a/python-default.lock
+++ b/python-default.lock
@@ -4,7 +4,7 @@
 //
 // --- BEGIN PANTS LOCKFILE METADATA: DO NOT EDIT OR REMOVE ---
 // {
-//   "version": 4,
+//   "version": 8,
 //   "valid_for_interpreter_constraints": [
 //     "CPython==3.12.*"
 //   ],
@@ -18,8 +18,8 @@
 //     "fw-utils>=3",
 //     "hypothesis>=6.0.0",
 //     "moto[s3,ses,ssm]==5.1.14",
-//     "nacc_attribute_deriver@ https://github.com/naccdata/nacc-attribute-deriver/releases/download/v2.3.4/nacc_attribute_deriver-2.3.4-py3-none-any.whl",
-//     "nacc_form_validator@ https://github.com/naccdata/nacc-form-validator/releases/download/v0.6.4/nacc_form_validator-0.6.4-py3-none-any.whl",
+//     "nacc_attribute_deriver @ https://github.com/naccdata/nacc-attribute-deriver/releases/download/v2.3.4/nacc_attribute_deriver-2.3.4-py3-none-any.whl",
+//     "nacc_form_validator @ https://github.com/naccdata/nacc-form-validator/releases/download/v0.6.4/nacc_form_validator-0.6.4-py3-none-any.whl",
 //     "natsort",
 //     "pandas-stubs>=2.0.3",
 //     "pandas>=2.1.1",
@@ -33,7 +33,7 @@
 //     "pyyaml>=6.0.1",
 //     "ratelimit-types>=0.0.1",
 //     "ratelimit>=2.2.1",
-//     "redcap_api@ https://github.com/naccdata/redcap-api/releases/download/v0.3.0/redcap_api-0.3.0-py3-none-any.whl",
+//     "redcap_api @ https://github.com/naccdata/redcap-api/releases/download/v0.3.0/redcap_api-0.3.0-py3-none-any.whl",
 //     "requests-oauthlib>=2.0.0",
 //     "requests>=2.18.4",
 //     "setuptools>=68.3.0",
@@ -50,7 +50,13 @@
 //   "only_binary": [],
 //   "no_binary": [],
 //   "excludes": [],
-//   "overrides": []
+//   "overrides": [],
+//   "sources": [],
+//   "lock_style": "universal",
+//   "complete_platforms": [],
+//   "uploaded_prior_to": null,
+//   "lockfile_format": "pex",
+//   "resolve": "python-default"
 // }
 // --- END PANTS LOCKFILE METADATA ---
 
@@ -3370,6 +3376,7 @@
           "version": "1.0.4"
         }
       ],
+      "marker": null,
       "platform_tag": null
     }
   ],
@@ -3377,7 +3384,7 @@
   "only_wheels": [],
   "overridden": [],
   "path_mappings": {},
-  "pex_version": "2.55.2",
+  "pex_version": "2.95.1",
   "pip_version": "24.2",
   "prefer_older_binary": false,
   "requirements": [
@@ -3390,8 +3397,8 @@
     "fw-utils>=3",
     "hypothesis>=6.0.0",
     "moto[s3,ses,ssm]==5.1.14",
-    "nacc_attribute_deriver@ https://github.com/naccdata/nacc-attribute-deriver/releases/download/v2.3.4/nacc_attribute_deriver-2.3.4-py3-none-any.whl",
-    "nacc_form_validator@ https://github.com/naccdata/nacc-form-validator/releases/download/v0.6.4/nacc_form_validator-0.6.4-py3-none-any.whl",
+    "nacc_attribute_deriver @ https://github.com/naccdata/nacc-attribute-deriver/releases/download/v2.3.4/nacc_attribute_deriver-2.3.4-py3-none-any.whl",
+    "nacc_form_validator @ https://github.com/naccdata/nacc-form-validator/releases/download/v0.6.4/nacc_form_validator-0.6.4-py3-none-any.whl",
     "natsort",
     "pandas-stubs>=2.0.3",
     "pandas>=2.1.1",
@@ -3405,7 +3412,7 @@
     "pyyaml>=6.0.1",
     "ratelimit-types>=0.0.1",
     "ratelimit>=2.2.1",
-    "redcap_api@ https://github.com/naccdata/redcap-api/releases/download/v0.3.0/redcap_api-0.3.0-py3-none-any.whl",
+    "redcap_api @ https://github.com/naccdata/redcap-api/releases/download/v0.3.0/redcap_api-0.3.0-py3-none-any.whl",
     "requests-oauthlib>=2.0.0",
     "requests>=2.18.4",
     "setuptools>=68.3.0",


### PR DESCRIPTION
## Summary

Upgrades the Pants build system from 2.29.0 to 2.32.0. This was previously blocked by Intel Mac support requirements — now that the team is fully on Apple Silicon, we can move to current stable.

## Changes

- Bump `pants_version` to 2.32.0
- Fix 20 new ruff lint errors (RUF059 unused unpacked vars, RUF043 unescaped regex metacharacters)
- Remove redundant `[dockerfile-parser] use_rust_parser = true` (now default)
- Regenerate lockfiles for the new Pants version

## What was tested

Progressed through 2.30, 2.31 and 2.32.
- Ran all commands on Pantsbuild.org upgrade guide
- `pants lint ::`, `pants check ::` and `pants test ::` pass clean
- spot tested `pants package` w/o failure
- Lockfiles regenerated successfully