### PR TITLE
adding code in phi-coordinator to process the checkbox added to reader form

### DIFF
--- a/docs/phi_coordinator/CHANGELOG.md
+++ b/docs/phi_coordinator/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this gear are documented in this file.
 
 ## Unreleased
 
+* Requires the deletion-acknowledgment checkbox (`ack_key`, default `delete_ack`) to be checked
+  before a `yes` answer is confirmed; a `yes` without the acknowledgment is treated as missing data
+  (reset/skip) and the file is not tagged `PHI-Confirmed`. Adds the `ack_key` config.
 * Initial version
 * Adds this CHANGELOG
 * Implements PHI review finalization: scans completed PHI reader tasks (by protocol) across accessible

--- a/docs/phi_coordinator/index.md
+++ b/docs/phi_coordinator/index.md
@@ -4,7 +4,7 @@ Finalizes the PHI review of images by reading completed reader-task form respons
 
 ## Workflow
 
-An upstream `image-pii-detector` gear scans a DICOM image for burned-in PHI, tags the acquisition file `PHI-Found`, and a gear rule creates a **reader task** so a person reviews the flagged region and answers a one-question form (*"Does the bounding box show PHI?"*, `yes`/`no`). When the reviewer submits, the task becomes `Complete`.
+An upstream `image-pii-detector` gear scans a DICOM image for burned-in PHI, tags the acquisition file `PHI-Found`, and a gear rule creates a **reader task** so a person reviews the flagged region and answers the form (*"Does the bounding box show PHI?"*, `yes`/`no`). Answering `yes` reveals a warning that the image will be deleted and a required acknowledgment checkbox (*"I understand"*) the reviewer must check to submit. When the reviewer submits, the task becomes `Complete`.
 
 PHI Coordinator runs **on a schedule from an administrative group** (no input file). On each run it finds the completed PHI reader tasks across all accessible projects and finalizes each one's tags so downstream automation (triggered by those tags, outside this gear) can proceed.
 
@@ -21,6 +21,7 @@ Gear configs are defined in [manifest.json](../../gear/phi_coordinator/src/docke
 | `dry_run` | `false` | Log intended changes without applying them. |
 | `phi_protocol_label` | `default_image_pii_detector_protocol` | Label of the reader-task protocols whose completed tasks to process. |
 | `answer_key` | `phi_radio` | Key in the form `response_data` holding the yes/no answer. |
+| `ack_key` | `delete_ack` | Key in the form `response_data` for the deletion-acknowledgment checkbox that must be checked before a `yes` answer is confirmed; empty disables the requirement. |
 | `found_tag` | `PHI-Found` | Tag marking a file with detected PHI awaiting review; removed once resolved. |
 | `confirmed_tag` | `PHI-Confirmed` | Tag added when the reviewer confirms PHI is present. |
 | `not_found_tag` | `PHI-Not-Found` | Tag added when the reviewer reports no PHI. |
@@ -33,9 +34,10 @@ For each completed PHI reader task that is not yet marked `coordinated_tag`:
 
 - Read the latest form response's `answer_key`.
 - **`yes`** → add `confirmed_tag` to the file; **`no`** → add `not_found_tag`.
+- A **`yes`** answer is only confirmed when the `ack_key` acknowledgment checkbox is checked. A `yes` with the acknowledgment unchecked (or missing) is treated like missing data — the file is **not** tagged `confirmed_tag`. The acknowledgment is not required for a `no` answer.
 - Remove `found_tag` from the file if present, and remove the opposite resolution tag if present, so the file ends with exactly one resolution tag.
 - **Only after** the file tags are updated, add `coordinated_tag` to the task so it is excluded from future runs (a failed run leaves the task unmarked and it is retried).
-- If a completed task has no usable answer and `reset_on_missing_data` is set, reset the task to `Todo` and clear its response so the reviewer redoes it (the task is not marked).
+- If a completed task has no usable answer — or confirms PHI without the acknowledgment — and `reset_on_missing_data` is set, reset the task to `Todo` and clear its response so the reviewer redoes it (the task is not marked).
 
 Tasks are discovered with a single server-side query per protocol
 (`status=Complete,protocol_id=<id>,tags!=<coordinated_tag>`), so the work set only ever contains unprocessed tasks.

--- a/gear/phi_coordinator/src/docker/BUILD
+++ b/gear/phi_coordinator/src/docker/BUILD
@@ -7,5 +7,5 @@ docker_image(
         ":manifest",
         "gear/phi_coordinator/src/python/phi_coordinator_app:bin",
     ],
-    image_tags=["0.0.3", "latest"],
+    image_tags=["0.0.4", "latest"],
 )

--- a/gear/phi_coordinator/src/docker/manifest.json
+++ b/gear/phi_coordinator/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "phi-coordinator",
     "label": "PHI Coordinator",
     "description": "Finalizes PHI review tags by reading completed reader-task form responses.",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/phi-coordinator:0.0.3"
+            "image": "naccdata/phi-coordinator:0.0.4"
         },
         "flywheel": {
             "suite": "NACC Data Gears",
@@ -42,6 +42,11 @@
             "description": "Key in the form response_data holding the yes/no answer",
             "type": "string",
             "default": "phi_radio"
+        },
+        "ack_key": {
+            "description": "Key in the form response_data for the deletion-acknowledgment checkbox that must be checked before a 'yes' answer is confirmed; empty disables the requirement",
+            "type": "string",
+            "default": "delete_ack"
         },
         "found_tag": {
             "description": "Tag marking a file with detected PHI awaiting review; removed once resolved",

--- a/gear/phi_coordinator/src/python/phi_coordinator_app/main.py
+++ b/gear/phi_coordinator/src/python/phi_coordinator_app/main.py
@@ -20,6 +20,7 @@ def run(
     reader_tasks: ReaderTaskClient,
     phi_protocol_label: str,
     answer_key: str,
+    ack_key: str,
     found_tag: str,
     confirmed_tag: str,
     not_found_tag: str,
@@ -34,6 +35,8 @@ def run(
         reader_tasks: client for reader tasks and form responses
         phi_protocol_label: label identifying the PHI reader-task protocols
         answer_key: key in the form response_data holding the yes/no answer
+        ack_key: key in the form response_data for the deletion-acknowledgment
+            checkbox that must be checked before a 'yes' answer is confirmed
         found_tag: tag marking unresolved PHI detection (removed once resolved)
         confirmed_tag: tag added when the reviewer confirms PHI
         not_found_tag: tag added when the reviewer reports no PHI
@@ -61,6 +64,7 @@ def run(
         proxy=proxy,
         reader_tasks=reader_tasks,
         answer_key=answer_key,
+        ack_key=ack_key,
         found_tag=found_tag,
         confirmed_tag=confirmed_tag,
         not_found_tag=not_found_tag,

--- a/gear/phi_coordinator/src/python/phi_coordinator_app/processor.py
+++ b/gear/phi_coordinator/src/python/phi_coordinator_app/processor.py
@@ -40,6 +40,7 @@ class PHITaskProcessor:
         proxy: FlywheelProxy,
         reader_tasks: ReaderTaskClient,
         answer_key: str,
+        ack_key: str,
         found_tag: str,
         confirmed_tag: str,
         not_found_tag: str,
@@ -53,6 +54,9 @@ class PHITaskProcessor:
             proxy: Flywheel proxy used to fetch and tag files
             reader_tasks: client for reader-task and form-response calls
             answer_key: response_data key holding the yes/no answer
+            ack_key: response_data key for the deletion-acknowledgment
+                checkbox that must be checked before a 'yes' is confirmed;
+                empty disables the requirement
             found_tag: tag for PHI awaiting review; removed once resolved
             confirmed_tag: tag added when the reviewer confirms PHI
             not_found_tag: tag added when the reviewer reports no PHI
@@ -63,6 +67,7 @@ class PHITaskProcessor:
         self.__proxy = proxy
         self.__reader_tasks = reader_tasks
         self.__answer_key = answer_key
+        self.__ack_key = ack_key
         self.__found_tag = found_tag
         self.__confirmed_tag = confirmed_tag
         self.__not_found_tag = not_found_tag
@@ -87,9 +92,25 @@ class PHITaskProcessor:
             return Outcome.SKIPPED
 
         if answer not in ("yes", "no"):
-            return self.__handle_missing(task, latest)
+            return self.__reset_or_skip(
+                task,
+                latest,
+                reason=(f"is Complete but has no usable '{self.__answer_key}' answer"),
+            )
 
         confirmed = answer == "yes"
+        # Confirming PHI deletes the image downstream, so the reviewer must
+        # check the acknowledgment before we apply the confirmed tag.
+        if confirmed and self.__ack_key and not self.__acknowledged(latest):
+            return self.__reset_or_skip(
+                task,
+                latest,
+                reason=(
+                    f"confirms PHI but the '{self.__ack_key}' "
+                    "acknowledgment is unchecked"
+                ),
+            )
+
         desired = self.__confirmed_tag if confirmed else self.__not_found_tag
         opposite = self.__not_found_tag if confirmed else self.__confirmed_tag
 
@@ -116,6 +137,25 @@ class PHITaskProcessor:
             return value.strip().lower()
         return None
 
+    def __acknowledged(self, response: FormResponseModel | None) -> bool:
+        """Returns whether the deletion-acknowledgment checkbox is checked."""
+        if response is None:
+            return False
+        return self.__is_checked(response.response_data.get(self.__ack_key))
+
+    @staticmethod
+    def __is_checked(value: object) -> bool:
+        """Interprets a form checkbox value as checked (True) or not.
+
+        Flywheel form responses serialize a checked box as the boolean True;
+        common string encodings are accepted defensively.
+        """
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            return value.strip().lower() in ("true", "yes", "on", "1")
+        return False
+
     @staticmethod
     def __file_id(task: ReaderTaskModel) -> str | None:
         """Returns the id of the file the task reviewed, or None."""
@@ -125,28 +165,41 @@ class PHITaskProcessor:
             return task.parents.file
         return None
 
-    def __handle_missing(
-        self, task: ReaderTaskModel, response: FormResponseModel | None
+    def __reset_or_skip(
+        self,
+        task: ReaderTaskModel,
+        response: FormResponseModel | None,
+        *,
+        reason: str,
     ) -> Outcome:
-        """Resets the task to Todo and clears its response, or skips it."""
+        """Resets the task to Todo and clears its response, or skips it.
+
+        Used when a completed task cannot be applied as submitted: it has no
+        usable answer, or it confirms PHI without the required acknowledgment.
+
+        Args:
+            task: the completed task that cannot be applied
+            response: the task's latest response, cleared when resetting
+            reason: short phrase describing why, included in the log message
+        Returns:
+            SKIPPED when resets are disabled, otherwise RESET
+        """
         if not self.__reset_on_missing_data:
-            log.warning(
-                "Task %s is Complete but has no usable '%s' answer; skipping",
-                task.task_id,
-                self.__answer_key,
-            )
+            log.warning("Task %s %s; skipping", task.task_id, reason)
             return Outcome.SKIPPED
 
         if self.__dry_run:
             log.info(
-                "Dry run: would reset task %s to Todo and clear its response",
+                "Dry run: would reset task %s to Todo and clear its response (%s)",
                 task.task_id,
+                reason,
             )
             return Outcome.RESET
 
         log.info(
-            "Task %s has no usable answer; resetting to Todo and clearing response",
+            "Task %s %s; resetting to Todo and clearing response",
             task.task_id,
+            reason,
         )
         self.__reader_tasks.set_task_status(task.id, _TODO_STATUS)
         if response is not None:

--- a/gear/phi_coordinator/src/python/phi_coordinator_app/processor.py
+++ b/gear/phi_coordinator/src/python/phi_coordinator_app/processor.py
@@ -147,8 +147,8 @@ class PHITaskProcessor:
     def __is_checked(value: object) -> bool:
         """Interprets a form checkbox value as checked (True) or not.
 
-        Flywheel form responses serialize a checked box as the boolean True;
-        common string encodings are accepted defensively.
+        Flywheel form responses serialize a checked box as the boolean
+        True; common string encodings are accepted defensively.
         """
         if isinstance(value, bool):
             return value

--- a/gear/phi_coordinator/src/python/phi_coordinator_app/run.py
+++ b/gear/phi_coordinator/src/python/phi_coordinator_app/run.py
@@ -134,7 +134,6 @@ class PHICoordinatorVisitor(GearExecutionEnvironment):
 
 def main():
     """Main method for PHI Coordinator."""
-
     GearEngine().run(gear_type=PHICoordinatorVisitor)
 
 

--- a/gear/phi_coordinator/src/python/phi_coordinator_app/run.py
+++ b/gear/phi_coordinator/src/python/phi_coordinator_app/run.py
@@ -34,6 +34,7 @@ class PHICoordinatorVisitor(GearExecutionEnvironment):
         fw_client: FWClient,
         phi_protocol_label: str,
         answer_key: str,
+        ack_key: str,
         found_tag: str,
         confirmed_tag: str,
         not_found_tag: str,
@@ -47,6 +48,7 @@ class PHICoordinatorVisitor(GearExecutionEnvironment):
             fw_client: FWClient for the reader-task endpoints the SDK lacks
             phi_protocol_label: label of PHI reader-task protocols to process
             answer_key: response_data key holding the yes/no answer
+            ack_key: response_data key for the deletion-acknowledgment checkbox
             found_tag: tag for PHI awaiting review; removed once resolved
             confirmed_tag: tag added when the reviewer confirms PHI
             not_found_tag: tag added when the reviewer reports no PHI
@@ -57,6 +59,7 @@ class PHICoordinatorVisitor(GearExecutionEnvironment):
         self.__fw_client = fw_client
         self.__phi_protocol_label = phi_protocol_label
         self.__answer_key = answer_key
+        self.__ack_key = ack_key
         self.__found_tag = found_tag
         self.__confirmed_tag = confirmed_tag
         self.__not_found_tag = not_found_tag
@@ -97,6 +100,7 @@ class PHICoordinatorVisitor(GearExecutionEnvironment):
                 "phi_protocol_label", "default_image_pii_detector_protocol"
             ),
             answer_key=opts.get("answer_key", "phi_radio"),
+            ack_key=opts.get("ack_key", "delete_ack"),
             found_tag=opts.get("found_tag", "PHI-Found"),
             confirmed_tag=opts.get("confirmed_tag", "PHI-Confirmed"),
             not_found_tag=opts.get("not_found_tag", "PHI-Not-Found"),
@@ -113,6 +117,7 @@ class PHICoordinatorVisitor(GearExecutionEnvironment):
             reader_tasks=reader_tasks,
             phi_protocol_label=self.__phi_protocol_label,
             answer_key=self.__answer_key,
+            ack_key=self.__ack_key,
             found_tag=self.__found_tag,
             confirmed_tag=self.__confirmed_tag,
             not_found_tag=self.__not_found_tag,

--- a/gear/phi_coordinator/test/python/phi_coordinator_test/test_main.py
+++ b/gear/phi_coordinator/test/python/phi_coordinator_test/test_main.py
@@ -15,6 +15,7 @@ def _run(proxy: Mock, reader_tasks: Mock, dry_run: bool = False) -> bool:
         reader_tasks=reader_tasks,
         phi_protocol_label="default_image_pii_detector_protocol",
         answer_key="phi_radio",
+        ack_key="delete_ack",
         found_tag="PHI-Found",
         confirmed_tag="PHI-Confirmed",
         not_found_tag="PHI-Not-Found",

--- a/gear/phi_coordinator/test/python/phi_coordinator_test/test_processor.py
+++ b/gear/phi_coordinator/test/python/phi_coordinator_test/test_processor.py
@@ -45,6 +45,11 @@ def make_response(data: dict, revision: int = 1) -> FormResponseModel:
     )
 
 
+# A 'yes' answer is only confirmed when the acknowledgment checkbox is checked.
+YES = {"phi_radio": "yes", "delete_ack": True}
+NO = {"phi_radio": "no"}
+
+
 def make_file(tags: list[str]) -> Mock:
     file = Mock(spec=FileEntry)
     file.name = "image.dicom.zip"
@@ -53,12 +58,18 @@ def make_file(tags: list[str]) -> Mock:
 
 
 def make_processor(
-    proxy: Mock, reader_tasks: Mock, *, reset: bool = True, dry_run: bool = False
+    proxy: Mock,
+    reader_tasks: Mock,
+    *,
+    reset: bool = True,
+    dry_run: bool = False,
+    ack_key: str = "delete_ack",
 ) -> PHITaskProcessor:
     return PHITaskProcessor(
         proxy=proxy,
         reader_tasks=reader_tasks,
         answer_key="phi_radio",
+        ack_key=ack_key,
         found_tag=FOUND,
         confirmed_tag=CONFIRMED,
         not_found_tag=NOT_FOUND,
@@ -81,7 +92,7 @@ def reader_tasks() -> Mock:
 def test_yes_confirms_and_marks_task_last(proxy: Mock, reader_tasks: Mock) -> None:
     file = make_file([FOUND])
     proxy.get_file.return_value = file
-    reader_tasks.get_responses.return_value = [make_response({"phi_radio": "yes"})]
+    reader_tasks.get_responses.return_value = [make_response(YES)]
 
     manager = Mock()
     manager.attach_mock(file, "file")
@@ -102,7 +113,7 @@ def test_yes_confirms_and_marks_task_last(proxy: Mock, reader_tasks: Mock) -> No
 def test_no_adds_not_found(proxy: Mock, reader_tasks: Mock) -> None:
     file = make_file([FOUND])
     proxy.get_file.return_value = file
-    reader_tasks.get_responses.return_value = [make_response({"phi_radio": "no"})]
+    reader_tasks.get_responses.return_value = [make_response(NO)]
 
     outcome = make_processor(proxy, reader_tasks).resolve(make_task([FOUND]))
 
@@ -114,7 +125,7 @@ def test_no_adds_not_found(proxy: Mock, reader_tasks: Mock) -> None:
 def test_opposite_resolution_tag_removed(proxy: Mock, reader_tasks: Mock) -> None:
     file = make_file([FOUND, NOT_FOUND])
     proxy.get_file.return_value = file
-    reader_tasks.get_responses.return_value = [make_response({"phi_radio": "yes"})]
+    reader_tasks.get_responses.return_value = [make_response(YES)]
 
     make_processor(proxy, reader_tasks).resolve(make_task([FOUND]))
 
@@ -127,7 +138,7 @@ def test_already_resolved_makes_no_file_writes_but_marks(
 ) -> None:
     file = make_file([CONFIRMED])
     proxy.get_file.return_value = file
-    reader_tasks.get_responses.return_value = [make_response({"phi_radio": "yes"})]
+    reader_tasks.get_responses.return_value = [make_response(YES)]
 
     outcome = make_processor(proxy, reader_tasks).resolve(make_task())
 
@@ -141,8 +152,8 @@ def test_uses_latest_response_by_revision(proxy: Mock, reader_tasks: Mock) -> No
     file = make_file([FOUND])
     proxy.get_file.return_value = file
     reader_tasks.get_responses.return_value = [
-        make_response({"phi_radio": "no"}, revision=1),
-        make_response({"phi_radio": "yes"}, revision=3),
+        make_response(NO, revision=1),
+        make_response(YES, revision=3),
     ]
 
     outcome = make_processor(proxy, reader_tasks).resolve(make_task([FOUND]))
@@ -189,7 +200,7 @@ def test_no_file_id_is_skipped(proxy: Mock, reader_tasks: Mock) -> None:
 def test_dry_run_makes_no_mutations(proxy: Mock, reader_tasks: Mock) -> None:
     file = make_file([FOUND])
     proxy.get_file.return_value = file
-    reader_tasks.get_responses.return_value = [make_response({"phi_radio": "yes"})]
+    reader_tasks.get_responses.return_value = [make_response(YES)]
 
     processor = make_processor(proxy, reader_tasks, dry_run=True)
     outcome = processor.resolve(make_task([FOUND]))
@@ -204,9 +215,78 @@ def test_file_tag_failure_prevents_marker(proxy: Mock, reader_tasks: Mock) -> No
     file = make_file([FOUND])
     file.add_tag.side_effect = RuntimeError("api boom")
     proxy.get_file.return_value = file
-    reader_tasks.get_responses.return_value = [make_response({"phi_radio": "yes"})]
+    reader_tasks.get_responses.return_value = [make_response(YES)]
 
     with pytest.raises(RuntimeError):
         make_processor(proxy, reader_tasks).resolve(make_task([FOUND]))
 
     reader_tasks.add_task_tag.assert_not_called()
+
+
+def test_yes_without_ack_resets_and_clears(proxy: Mock, reader_tasks: Mock) -> None:
+    reader_tasks.get_responses.return_value = [make_response({"phi_radio": "yes"})]
+
+    processor = make_processor(proxy, reader_tasks, reset=True)
+    outcome = processor.resolve(make_task([FOUND]))
+
+    assert outcome is Outcome.RESET
+    # The file is never fetched or tagged when the acknowledgment is missing.
+    proxy.get_file.assert_not_called()
+    reader_tasks.set_task_status.assert_called_once_with("t1", "Todo")
+    reader_tasks.clear_response.assert_called_once_with("r1")
+    reader_tasks.add_task_tag.assert_not_called()
+
+
+def test_yes_with_unchecked_ack_resets(proxy: Mock, reader_tasks: Mock) -> None:
+    reader_tasks.get_responses.return_value = [
+        make_response({"phi_radio": "yes", "delete_ack": False})
+    ]
+
+    outcome = make_processor(proxy, reader_tasks, reset=True).resolve(
+        make_task([FOUND])
+    )
+
+    assert outcome is Outcome.RESET
+    proxy.get_file.assert_not_called()
+    reader_tasks.clear_response.assert_called_once_with("r1")
+
+
+def test_yes_without_ack_skips_when_reset_disabled(
+    proxy: Mock, reader_tasks: Mock
+) -> None:
+    reader_tasks.get_responses.return_value = [make_response({"phi_radio": "yes"})]
+
+    outcome = make_processor(proxy, reader_tasks, reset=False).resolve(
+        make_task([FOUND])
+    )
+
+    assert outcome is Outcome.SKIPPED
+    proxy.get_file.assert_not_called()
+    reader_tasks.set_task_status.assert_not_called()
+    reader_tasks.add_task_tag.assert_not_called()
+
+
+def test_ack_accepts_string_true(proxy: Mock, reader_tasks: Mock) -> None:
+    file = make_file([FOUND])
+    proxy.get_file.return_value = file
+    reader_tasks.get_responses.return_value = [
+        make_response({"phi_radio": "yes", "delete_ack": "true"})
+    ]
+
+    outcome = make_processor(proxy, reader_tasks).resolve(make_task([FOUND]))
+
+    assert outcome is Outcome.CONFIRMED
+    file.add_tag.assert_called_once_with(CONFIRMED)
+
+
+def test_empty_ack_key_disables_requirement(proxy: Mock, reader_tasks: Mock) -> None:
+    file = make_file([FOUND])
+    proxy.get_file.return_value = file
+    reader_tasks.get_responses.return_value = [make_response({"phi_radio": "yes"})]
+
+    outcome = make_processor(proxy, reader_tasks, ack_key="").resolve(
+        make_task([FOUND])
+    )
+
+    assert outcome is Outcome.CONFIRMED
+    file.add_tag.assert_called_once_with(CONFIRMED)


### PR DESCRIPTION
adding code to process the added checkbox in the reader form that acknowledges a yes answer means the file will be deleted.