### PR TITLE
Pin flywheel-sdk to 22.0.0

### DIFF
--- a/docs/center_form_export/CHANGELOG.md
+++ b/docs/center_form_export/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.0.2
+
+- Pins flywheel-sdk to 22.0.0 to fix deserialization crash caused by missing `Avatars` model in SDK 22.1.0+
+
 ## v0.0.1
 
 Initial release.

--- a/docs/form_scheduler/CHANGELOG.md
+++ b/docs/form_scheduler/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this gear are documented in this file.
 
+## 1.4.2
+* Pins flywheel-sdk to 22.0.0 to fix deserialization crash caused by missing `Avatars` model in SDK 22.1.0+
+
 ## 1.4.1
 * Fixes pass-qc event logging: reloads QC status log file before reading metadata to avoid stale/empty info from Flywheel SDK
 * Resolves module-specific date field (e.g. `npformdate` for NP) when extracting visit metadata from forms.json

--- a/docs/gather_form_data/CHANGELOG.md
+++ b/docs/gather_form_data/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this gear are documented in this file.
 
+## 0.2.1
+
+* Pins flywheel-sdk to 22.0.0 to fix deserialization crash caused by missing `Avatars` model in SDK 22.1.0+
+
 ## 0.2.0
 
 * Adds `formver_split` config option to split output CSVs by form version (one file per module/formver pair with version-specific columns)

--- a/docs/transactional_event_scraper/CHANGELOG.md
+++ b/docs/transactional_event_scraper/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this gear are documented in this file.
 
+## 1.2.1
+
+* Pins flywheel-sdk to 22.0.0 to fix deserialization crash caused by missing `Avatars` model in SDK 22.1.0+
+
 ## 1.2.0
 
 * Adds new optional input file `form_configs_file` to resolve module-specific date fields when extracting visit metadata

--- a/gear/center_form_export/src/docker/BUILD
+++ b/gear/center_form_export/src/docker/BUILD
@@ -7,5 +7,5 @@ docker_image(
         ":manifest",
         "gear/center_form_export/src/python/center_form_export_app:bin",
     ],
-    image_tags=["0.0.1", "latest"],
+    image_tags=["0.0.2", "latest"],
 )

--- a/gear/center_form_export/src/docker/manifest.json
+++ b/gear/center_form_export/src/docker/manifest.json
@@ -2,7 +2,7 @@
   "name": "center-form-export",
   "label": "Center Form Export",
   "description": "Exports form data for all subjects in a Flywheel group/project without a participant list",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "author": "NACC",
   "maintainer": "NACC <nacchelp@uw.edu>",
   "cite": "",
@@ -15,7 +15,7 @@
   "custom": {
     "gear-builder": {
       "category": "utility",
-      "image": "naccdata/center-form-export:0.0.1"
+      "image": "naccdata/center-form-export:0.0.2"
     },
     "flywheel": {
       "suite": "Utility",

--- a/gear/form_scheduler/src/docker/BUILD
+++ b/gear/form_scheduler/src/docker/BUILD
@@ -4,5 +4,5 @@ docker_image(
     name="form-scheduler",
     source="Dockerfile",
     dependencies=[":manifest", "gear/form_scheduler/src/python/form_scheduler_app:bin"],
-    image_tags=["1.4.1", "latest"],
+    image_tags=["1.4.2", "latest"],
 )

--- a/gear/form_scheduler/src/docker/manifest.json
+++ b/gear/form_scheduler/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "form-scheduler",
     "label": "Form Scheduler",
     "description": "Queues project files for the submission pipeline",
-    "version": "1.4.1",
+    "version": "1.4.2",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/form-scheduler:1.4.1"
+            "image": "naccdata/form-scheduler:1.4.2"
         },
         "flywheel": {
             "suite": "NACC Admin Gears",

--- a/gear/gather_form_data/src/docker/BUILD
+++ b/gear/gather_form_data/src/docker/BUILD
@@ -7,5 +7,5 @@ docker_image(
         ":manifest",
         "gear/gather_form_data/src/python/gather_form_data_app:bin",
     ],
-    image_tags=["0.2.0", "latest"],
+    image_tags=["0.2.1", "latest"],
 )

--- a/gear/gather_form_data/src/docker/manifest.json
+++ b/gear/gather_form_data/src/docker/manifest.json
@@ -2,7 +2,7 @@
   "name": "gather-form-data",
   "label": "Gather Form Data",
   "description": "Gathers form data across centers",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": "NACC",
   "maintainer": "NACC <nacchelp@uw.edu>",
   "cite": "",
@@ -15,7 +15,7 @@
   "custom": {
     "gear-builder": {
       "category": "utility",
-      "image": "naccdata/gather-form-data:0.2.0"
+      "image": "naccdata/gather-form-data:0.2.1"
     },
     "flywheel": {
       "suite": "Utility",

--- a/gear/transactional_event_scraper/src/docker/BUILD
+++ b/gear/transactional_event_scraper/src/docker/BUILD
@@ -7,5 +7,5 @@ docker_image(
         ":manifest",
         "gear/transactional_event_scraper/src/python/transactional_event_scraper_app:bin",
     ],
-    image_tags=["1.2.0", "latest"],
+    image_tags=["1.2.1", "latest"],
 )

--- a/gear/transactional_event_scraper/src/docker/manifest.json
+++ b/gear/transactional_event_scraper/src/docker/manifest.json
@@ -2,7 +2,7 @@
   "name": "transactional-event-scraper",
   "label": "Transactional Event Scraper",
   "description": "A gear for scraping existing QC status log files to generate historical submission and pass-qc events",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "author": "NACC",
   "maintainer": "NACC <nacchelp@uw.edu>",
   "cite": "",
@@ -15,7 +15,7 @@
   "custom": {
     "gear-builder": {
       "category": "utility",
-      "image": "naccdata/transactional-event-scraper:1.2.0"
+      "image": "naccdata/transactional-event-scraper:1.2.1"
     },
     "flywheel": {
       "suite": "Utility",

--- a/mypy.lock
+++ b/mypy.lock
@@ -62,79 +62,79 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "239a4c354e8d676e9d94631d1d4a64edc6b266f86ff3a5a80aedd344f342c01d",
-              "url": "https://files.pythonhosted.org/packages/8b/38/d8d90042747d05aa08d4efcf1c99035a5f670a6bf4c214d31644392afbca/ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_x86_64.whl"
+              "hash": "4ed29121da8b3fdc291002801a1de0f76248fa07dce89157a5f277842cf6126e",
+              "url": "https://files.pythonhosted.org/packages/95/93/5524a3dc6c3f593de3228ed9cbef73afa047625b7000ec21b7f58e6eb4d4/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "cae65289fc456fde04af979a2be09302ef5d8ab92ef23e596d6746dc267ada27",
-              "url": "https://files.pythonhosted.org/packages/0c/ce/b59e02a82d9c4244d64cde502e0b00e83e38816abe19155ceb5437402c7f/ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_i686.whl"
+              "hash": "cdc4e6f930b9090c2f92c9036ad12ffb8e6e44d4a5ba06f1458a05d60f203f7b",
+              "url": "https://files.pythonhosted.org/packages/0e/4b/3676ca2191f39bafb75f93f99b2f429ec464586158fece2165f3572805dc/ast_serialize-0.6.0-cp39-abi3-manylinux_2_31_riscv64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "bf683d6363edf2b39eed6b6d4fe22d34b6203867a67e27134d9e2a2680c4bc4a",
-              "url": "https://files.pythonhosted.org/packages/26/0a/bd3d18a582f273d6c843d16bb9e22e9e16365ff7991e92f18f798e9f1224/ast_serialize-0.5.0-cp39-abi3-macosx_11_0_arm64.whl"
+              "hash": "c7b8b8f0c42f752ea00b2b7d7c090b3f80d9c1c5c75cadf16423790a0cc74081",
+              "url": "https://files.pythonhosted.org/packages/4d/21/087957bba486242afc52f49b2d9e21c9dad00289356cf9efe67084015a9d/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e42d729ef2be96a14efbad355093284739e3670ece3e534f82cc8832790911d9",
-              "url": "https://files.pythonhosted.org/packages/35/b2/a620e206b5aeb7efbf2710336df57d457cffbb3991076bbcc1147ef9abd4/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+              "hash": "093cb8bb91b720d8523580498d031791bb1bbaa048599c3d21085d380e11a596",
+              "url": "https://files.pythonhosted.org/packages/52/19/ac8348ae8711c9b5ae834634f635780cab62a0f5e6f988882e048b89c2ae/ast_serialize-0.6.0-cp39-abi3-macosx_10_12_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "9cc22cf0c9be65e71cf88fda130af60d61eb4a79370ad4cfe7900d48a4aa2211",
-              "url": "https://files.pythonhosted.org/packages/40/ae/1f919100f8620887af58fcc381c61a1f218cdf89c6e155f87b213e61010a/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "aadd3ffcf4858c9726bf3515f7b199c7eadbe504f96028e4a87172c0da65a8fe",
+              "url": "https://files.pythonhosted.org/packages/58/ad/0d70a3a2d6e01968d985415259e8ec7ad3f777903f9b1c1f3c8c44642c60/ast_serialize-0.6.0.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "27d51654fc240a1e87e742d353d98eb45b75f62f129086b3596ab53df2ac2a43",
-              "url": "https://files.pythonhosted.org/packages/6d/4f/0de1bbe06f6edef9fde4ed12ca8e7b3ec7e6e2bd4e672c5af487f7957665/ast_serialize-0.5.0-cp39-abi3-manylinux_2_31_riscv64.whl"
+              "hash": "4d6ef91590258ada18909b9caea344dac4de2013906b035473cd674a43f4b790",
+              "url": "https://files.pythonhosted.org/packages/64/64/62fb99d6faf199b4c3e5b08a07136e9a0d7664bb249c6de3670e5b63e9b6/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2782c36237c46dd1674542f2109740ea5ea485a169bf1431939ada0434e17934",
-              "url": "https://files.pythonhosted.org/packages/75/61/e00872439cfdddcc3c1b6cdaa6e5d904ba8e26a18807c67c4e14409d0ca8/ast_serialize-0.5.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl"
+              "hash": "305802f2ce2a7c4e87835078ea85c58b586ddda8095b92fe2ead9364ae19c80a",
+              "url": "https://files.pythonhosted.org/packages/6f/02/613a7534a41d0122f37d1e0c64aa8ac78bfb831f8c92f6db057a311abb3c/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1943db345233cc7194a470f13afa9c59772c0b123dea0c9414c4d4ca54369759",
-              "url": "https://files.pythonhosted.org/packages/76/8e/699a5b955f7926956c95e9e1d74132acad73c2fe7a426f94da89123c20aa/ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_aarch64.whl"
+              "hash": "cd5b91b9e6f2356ace3a556963b0cd783b395fbbb0bb17b4defc283415466e77",
+              "url": "https://files.pythonhosted.org/packages/82/04/78128bbb170071c2c72a210a181f1c00e11cc1cec60a8beef747b07f9201/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5880091bfe6f4f986f22866375c2e884843e7a0b6343ae41aeea659613d879b6",
-              "url": "https://files.pythonhosted.org/packages/81/9d/09e27731bd5864a9ce04e3244074e674bb8936bf62b45e0357248717adac/ast_serialize-0.5.0.tar.gz"
+              "hash": "c901adbd750029b9ac4ad3d6aa56853e0ad4875119fbf52b7b8298afc223828b",
+              "url": "https://files.pythonhosted.org/packages/a8/5a/e046f3899e2acba4677d7427b76431443a1aa1a0e583dfb05b55b69d55cf/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_armv7l.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "df1c00022cbbcb064bfaa505aa9c9295362443ce5dacb459d1331d3da353f887",
-              "url": "https://files.pythonhosted.org/packages/a9/ae/d5b7626874478997adc7a29ab28accf21e596fb590c944290401dfd0b29e/ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_armv7l.whl"
+              "hash": "c4af9a1386166e40ed01464991806f89038a2d89782576c7774876fa77034e32",
+              "url": "https://files.pythonhosted.org/packages/b1/f2/13736d920ab3d49bbee80ef1a277dd7b7aaf3b3545efd9d2a8114fe05525/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b54f60c1d78767a53b67eaa663f0dfac3afe606aa07f1301572f588b73d64809",
-              "url": "https://files.pythonhosted.org/packages/b2/71/4d1d479aa56d0101c40e17720c3d6ac2af7269ea0487a80b18e7bfd1a5b7/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "e61580a69faf47e3689795367ed211f2a10fd741478cc0f36a0f128793360aad",
+              "url": "https://files.pythonhosted.org/packages/c1/f6/ec7ec652c51db77c2f61d8573338e13e4704303265ccc658cb4031d9f354/ast_serialize-0.6.0-cp39-abi3-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f66173891548c9f2726bf27957b41cabce12fa679dc6da505ddbde4d4b3b31cf",
-              "url": "https://files.pythonhosted.org/packages/c6/ca/6376559dcce707cdbc1d0d9a13c8d3baaaa501e949ce0ebdc4230cd881aa/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+              "hash": "dcbed41e9386059fc0261d602445ede0976c2ecec2939688bcbcb9ed0b6f28b7",
+              "url": "https://files.pythonhosted.org/packages/ca/87/b4d6c38e0ccd5e85dc54cecdf933a152c60b28fe5d993a6d8a72fa6d5896/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0668aa9459cfa8c9c49ddd2163ebcf43088ba045ef7492af6fe22e0098303101",
-              "url": "https://files.pythonhosted.org/packages/e0/9e/dc2530acb3a60dc6e46d65abf27d1d9f86721694757906a148d90a6860de/ast_serialize-0.5.0-cp39-abi3-macosx_10_12_x86_64.whl"
+              "hash": "3ae22a366b752ab4496191525b78b097b5b72d531752e3c1dd7e383a8f2c8a1a",
+              "url": "https://files.pythonhosted.org/packages/cc/c7/e42aaca7bb2d22a7c06d5a8c7930086c5a334e93d716e6fa5e6647a4515f/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b725026bafa801dbd7310eb13a75f0a2e370e7e51b2cb225f9d21fcfadf919ee",
-              "url": "https://files.pythonhosted.org/packages/fa/e0/4ad5c04c24a40481b2935ce9a0ccdb6023dc8b667167d06ae530cc3512f2/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+              "hash": "897ac47b5637be41c0c07061c8a912fafa967ef1dc73fa115e4bfa70882a093b",
+              "url": "https://files.pythonhosted.org/packages/f3/58/494ef8c4b4acb2f4a265ac934caf45f792a08fe27d6b853de35ad991941a/ast_serialize-0.6.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl"
             }
           ],
           "project_name": "ast-serialize",
           "requires_dists": [],
           "requires_python": ">=3.7",
-          "version": "0.5.0"
+          "version": "0.6.0"
         },
         {
           "artifacts": [

--- a/python-default.lock
+++ b/python-default.lock
@@ -12,7 +12,7 @@
 //     "boto3-stubs[boto3]",
 //     "boto3>=1.28.53",
 //     "botocore",
-//     "flywheel-sdk>=20.0.0",
+//     "flywheel-sdk==22.0.0",
 //     "fw-client>=0.7.0",
 //     "fw-gear>=0.3.5",
 //     "fw-utils>=3",
@@ -154,42 +154,42 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "f409f931e836f2f24e168e8f93901010cb8055c7f2ddcfcfbd72b25f8c4e306c",
-              "url": "https://files.pythonhosted.org/packages/e2/48/c740abb7ba90d89ef63cf766c8e07d72e6422b3cf68aa4dccf0a83efed93/boto3-1.43.37-py3-none-any.whl"
+              "hash": "edffb4a8f49c0a61e8f4aa4104cc2da3c362de8042fc0819216d5e5ce5d38380",
+              "url": "https://files.pythonhosted.org/packages/0a/60/e0e3baeb394e084c5136a46b8e944ba87a26bb1f67f7b3064eb035bb7e77/boto3-1.43.38-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "cf7e75963229b337d1b0e37c46de6f3c2c2290d186157729c8e7afb12909bfc0",
-              "url": "https://files.pythonhosted.org/packages/fa/8b/281ca08c796322a36a639b76c714dc4c4323cab4563a492e6a923aa5f15d/boto3-1.43.37.tar.gz"
+              "hash": "a8d1e175a87a743e755237d884d7e5f4606e61e5602e9823469a1a630e379b3c",
+              "url": "https://files.pythonhosted.org/packages/eb/ee/97798453d8e9dba0c60458870b07c78ac685fc21cdddd8eb3e20190249c6/boto3-1.43.38.tar.gz"
             }
           ],
           "project_name": "boto3",
           "requires_dists": [
-            "botocore<1.44.0,>=1.43.37",
+            "botocore<1.44.0,>=1.43.38",
             "botocore[crt]<2.0a0,>=1.21.0; extra == \"crt\"",
             "jmespath<2.0.0,>=0.7.1",
             "s3transfer<0.20.0,>=0.19.0"
           ],
           "requires_python": ">=3.10",
-          "version": "1.43.37"
+          "version": "1.43.38"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "cb6884fe31cf4e2f7ac8c7bbbe66674de42a54b3df02f446987ebf901e937b04",
-              "url": "https://files.pythonhosted.org/packages/89/94/88a55e6c5d8235f8aea03ab8413481112ba01895009a49916ee293bfd76f/boto3_stubs-1.43.37-py3-none-any.whl"
+              "hash": "5d9c21e2b52d0c4077ee377f686fc965395a2d02534e1e3de0c7cb9c2f0ad6d4",
+              "url": "https://files.pythonhosted.org/packages/44/ba/2c9c7153ebd3ada100f111bf7a2f16b1627ba94450a9c6edf9e6e26c5845/boto3_stubs-1.43.38-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "16be6e8b37a05b69fef222cac66049c27621afeeb3969bc8eee04c71d67faed5",
-              "url": "https://files.pythonhosted.org/packages/f4/0e/9dd53e707f46e699578b28e0cfbed2cad5eb2d6d1678d3c4a9c9500fdf49/boto3_stubs-1.43.37.tar.gz"
+              "hash": "55701008fa910d60aa2a593aa307d121c85a91a892cb24182bcf8ec41f29a9f5",
+              "url": "https://files.pythonhosted.org/packages/89/8d/2b249f56bc7a5e90bf1d5f23b6f089fd762f65d7ad032b32e93e69eb1242/boto3_stubs-1.43.38.tar.gz"
             }
           ],
           "project_name": "boto3-stubs",
           "requires_dists": [
             "boto3-stubs-full<1.44.0,>=1.43.0; extra == \"full\"",
-            "boto3==1.43.37; extra == \"boto3\"",
+            "boto3==1.43.38; extra == \"boto3\"",
             "botocore-stubs",
             "mypy-boto3-accessanalyzer<1.44.0,>=1.43.0; extra == \"accessanalyzer\"",
             "mypy-boto3-accessanalyzer<1.44.0,>=1.43.0; extra == \"all\"",
@@ -578,10 +578,6 @@
             "mypy-boto3-iot<1.44.0,>=1.43.0; extra == \"iot\"",
             "mypy-boto3-iotdeviceadvisor<1.44.0,>=1.43.0; extra == \"all\"",
             "mypy-boto3-iotdeviceadvisor<1.44.0,>=1.43.0; extra == \"iotdeviceadvisor\"",
-            "mypy-boto3-iotevents-data<1.44.0,>=1.43.0; extra == \"all\"",
-            "mypy-boto3-iotevents-data<1.44.0,>=1.43.0; extra == \"iotevents-data\"",
-            "mypy-boto3-iotevents<1.44.0,>=1.43.0; extra == \"all\"",
-            "mypy-boto3-iotevents<1.44.0,>=1.43.0; extra == \"iotevents\"",
             "mypy-boto3-iotfleetwise<1.44.0,>=1.43.0; extra == \"all\"",
             "mypy-boto3-iotfleetwise<1.44.0,>=1.43.0; extra == \"iotfleetwise\"",
             "mypy-boto3-iotsecuretunneling<1.44.0,>=1.43.0; extra == \"all\"",
@@ -773,8 +769,6 @@
             "mypy-boto3-osis<1.44.0,>=1.43.0; extra == \"osis\"",
             "mypy-boto3-outposts<1.44.0,>=1.43.0; extra == \"all\"",
             "mypy-boto3-outposts<1.44.0,>=1.43.0; extra == \"outposts\"",
-            "mypy-boto3-panorama<1.44.0,>=1.43.0; extra == \"all\"",
-            "mypy-boto3-panorama<1.44.0,>=1.43.0; extra == \"panorama\"",
             "mypy-boto3-partnercentral-account<1.44.0,>=1.43.0; extra == \"all\"",
             "mypy-boto3-partnercentral-account<1.44.0,>=1.43.0; extra == \"partnercentral-account\"",
             "mypy-boto3-partnercentral-benefits<1.44.0,>=1.43.0; extra == \"all\"",
@@ -947,8 +941,6 @@
             "mypy-boto3-signin<1.44.0,>=1.43.0; extra == \"signin\"",
             "mypy-boto3-simpledbv2<1.44.0,>=1.43.0; extra == \"all\"",
             "mypy-boto3-simpledbv2<1.44.0,>=1.43.0; extra == \"simpledbv2\"",
-            "mypy-boto3-simspaceweaver<1.44.0,>=1.43.0; extra == \"all\"",
-            "mypy-boto3-simspaceweaver<1.44.0,>=1.43.0; extra == \"simspaceweaver\"",
             "mypy-boto3-snow-device-management<1.44.0,>=1.43.0; extra == \"all\"",
             "mypy-boto3-snow-device-management<1.44.0,>=1.43.0; extra == \"snow-device-management\"",
             "mypy-boto3-snowball<1.44.0,>=1.43.0; extra == \"all\"",
@@ -990,6 +982,8 @@
             "mypy-boto3-support-app<1.44.0,>=1.43.0; extra == \"support-app\"",
             "mypy-boto3-support<1.44.0,>=1.43.0; extra == \"all\"",
             "mypy-boto3-support<1.44.0,>=1.43.0; extra == \"support\"",
+            "mypy-boto3-supportauthz<1.44.0,>=1.43.0; extra == \"all\"",
+            "mypy-boto3-supportauthz<1.44.0,>=1.43.0; extra == \"supportauthz\"",
             "mypy-boto3-sustainability<1.44.0,>=1.43.0; extra == \"all\"",
             "mypy-boto3-sustainability<1.44.0,>=1.43.0; extra == \"sustainability\"",
             "mypy-boto3-swf<1.44.0,>=1.43.0; extra == \"all\"",
@@ -1056,19 +1050,19 @@
             "typing-extensions>=4.1.0; python_version < \"3.12\""
           ],
           "requires_python": ">=3.9",
-          "version": "1.43.37"
+          "version": "1.43.38"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "8b7e8408aa7eca7dca9ae9824fb7677daf64d40ed675366ed7b9248470d08757",
-              "url": "https://files.pythonhosted.org/packages/bf/64/49313b38d675f4004fb736d2a4293b72504eac5380fc21b6e4a8660824ad/botocore-1.43.37-py3-none-any.whl"
+              "hash": "54c1c41aff82422d2b88a8a7d782fde8ae1299a45f088d00011d85c4bc44b0cc",
+              "url": "https://files.pythonhosted.org/packages/22/b4/fdff7920b3776b37f8b42d4e6eabb141974fa88f9fb1aae5c2224bdaf635/botocore-1.43.38-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "46a7982815579cfe8c7851036b1f51237e35e7937456341df55bc5c36a316145",
-              "url": "https://files.pythonhosted.org/packages/c4/a8/3409b5df7e6a562be82e409ba5a976e7ac3df8d5567552c23d44b367a40b/botocore-1.43.37.tar.gz"
+              "hash": "70fbd5c74f5742f5975ddcc61e6afb5174cb80577c2ccc17c6898ad3a49b51f3",
+              "url": "https://files.pythonhosted.org/packages/73/6c/815f49f0c582396b1a4c37df554ffab6bb420abd5a96d5329183a97022de/botocore-1.43.38.tar.gz"
             }
           ],
           "project_name": "botocore",
@@ -1079,7 +1073,7 @@
             "urllib3!=2.2.0,<3,>=1.25.4"
           ],
           "requires_python": ">=3.10",
-          "version": "1.43.37"
+          "version": "1.43.38"
         },
         {
           "artifacts": [
@@ -1442,8 +1436,8 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "733d7cf9b831ab9edb2a3fbd643d7d40ebce9824a476da3a4c0918b33d007937",
-              "url": "https://files.pythonhosted.org/packages/4f/3c/be30bd8c797f887e1a004829e21b7addd4e9c21c843711cd0ebe8adfa644/flywheel_sdk-22.1.0-py3-none-any.whl"
+              "hash": "77ffe2550546c57a70edcb4514f7e4c7bfbc722d1b9ea9342f8d7a1d67e64ee0",
+              "url": "https://files.pythonhosted.org/packages/a7/e9/550f4435d95cba3d5a07b83faf2ac5dbe6db8522f4817991362dc5bf9e03/flywheel_sdk-22.0.0-py3-none-any.whl"
             }
           ],
           "project_name": "flywheel-sdk",
@@ -1459,7 +1453,7 @@
             "urllib3<3.0,>=2.5"
           ],
           "requires_python": ">=3.10",
-          "version": "22.1.0"
+          "version": "22.0.0"
         },
         {
           "artifacts": [
@@ -3391,7 +3385,7 @@
     "boto3-stubs[boto3]",
     "boto3>=1.28.53",
     "botocore",
-    "flywheel-sdk>=20.0.0",
+    "flywheel-sdk==22.0.0",
     "fw-client>=0.7.0",
     "fw-gear>=0.3.5",
     "fw-utils>=3",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 boto3>=1.28.53
 boto3-stubs[boto3]
 botocore
-flywheel-sdk>=20.0.0 
+flywheel-sdk==22.0.0 
 fw-client>=0.7.0
 fw-gear>=0.3.5
 fw-utils>=3


### PR DESCRIPTION
Pins the flywheel-sdk version to 22.0.0 to avoid an error from a missing definition in newer versions