### PR TITLE
Fix VisitEvent serialization and bump affected gears

### DIFF
--- a/common/src/python/event_capture/event_capture.py
+++ b/common/src/python/event_capture/event_capture.py
@@ -12,11 +12,11 @@ class VisitEventCapture:
 
     <transaction-log-bucket>
     ├── prod
-    │   ├── log-submit-20240115-100000-42-ingest-form-alpha-110001-2024-01-15.json
-    │   ├── log-pass-qc-20240115-102000-42-ingest-form-alpha-110001-2024-01-15.json
-    │   └── log-not-pass-qc-20240116-143000-43-ingest-dicom-beta-220002-2024-01-16.json
+    │   ├── log-submit-20240115-100000-42-ingest-form-110001-2024-01-15.json
+    │   ├── log-pass-qc-20240115-102000-42-ingest-form-110001-2024-01-15.json
+    │   └── log-not-pass-qc-20240116-143000-43-ingest-dicom-220002-2024-01-16.json
     └── dev
-        └── log-submit-20240115-100000-42-ingest-form-alpha-110001-2024-01-15.json
+        └── log-submit-20240115-100000-42-ingest-form-110001-2024-01-15.json
 
     Filename format: log-{action}-{timestamp}-{adcid}-{project}-{ptid}-{visit_date}.json
     """

--- a/common/src/python/event_capture/visit_events.py
+++ b/common/src/python/event_capture/visit_events.py
@@ -10,7 +10,7 @@ Note: processes do not support issuing an explicit QC failure event.
 """
 
 from datetime import datetime
-from typing import Any, Literal, Self
+from typing import Any, ClassVar, Literal, Self
 
 from keys.types import DatatypeNameType
 from nacc_common.data_identification import (
@@ -78,32 +78,36 @@ class VisitEvent(BaseModel):
                 f"'{type(self).__name__}' object has no attribute '{name}'"
             ) from error
 
+    # Fields from DataIdentification that are renamed in the serialized output.
+    # All other fields from data_identification are passed through as-is.
+    _RENAMED_FIELDS: ClassVar[dict[str, str]] = {
+        "adcid": "pipeline_adcid",
+        "date": "visit_date",
+        "visitnum": "visit_number",
+    }
+
     @model_serializer(mode="wrap")
     def serialize_model(
         self, handler: SerializerFunctionWrapHandler, info: SerializationInfo
     ) -> dict[str, Any]:
         data = handler(self)
 
-        # Extract and remove data_identification from serialized output
+        # Extract and remove data_identification from serialized output.
+        # DataIdentification's own serializer already flattens its nested
+        # participant/visit/data sub-objects into a single dict.
         data_identification = data.pop("data_identification")
 
-        # Map DataIdentification fields to VisitEvent field names
-        # adcid -> pipeline_adcid
-        if "adcid" in data_identification:
-            data["pipeline_adcid"] = data_identification["adcid"]
-
-        # date -> visit_date
-        if "date" in data_identification:
-            data["visit_date"] = data_identification["date"]
-
-        # visitnum -> visit_number
-        if "visitnum" in data_identification:
-            data["visit_number"] = data_identification["visitnum"]
-
-        # Pass through fields that have the same name
-        for field in ["ptid", "naccid", "module", "packet"]:
-            if field in data_identification:
-                data[field] = data_identification[field]
+        # Map renamed fields, then pass through everything else as-is.
+        # This approach is forward-compatible: new fields added to future
+        # DataIdentification data subclasses (e.g., EnrollmentIdentification)
+        # will automatically appear in the serialized VisitEvent without
+        # needing to update this serializer.
+        for field, value in data_identification.items():
+            renamed = self._RENAMED_FIELDS.get(field)
+            if renamed:
+                data[renamed] = value
+            else:
+                data[field] = value
 
         return data
 

--- a/docs/form_scheduler/CHANGELOG.md
+++ b/docs/form_scheduler/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this gear are documented in this file.
 
+## 1.4.3
+
+* Rebuilt for VisitEvent serialization fix (forward-compatible field passthrough)
+
 ## 1.4.2
 * Pins flywheel-sdk to 22.0.0 to fix deserialization crash caused by missing `Avatars` model in SDK 22.1.0+
 

--- a/docs/identifier_lookup/CHANGELOG.md
+++ b/docs/identifier_lookup/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this gear are documented in this file.
 
+## 2.4.3
+
+* Rebuilt for VisitEvent serialization fix (forward-compatible field passthrough)
+
 ## 2.4.2
 
 * Rebuilt for module configs update

--- a/docs/image_identifier_lookup/CHANGELOG.md
+++ b/docs/image_identifier_lookup/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this gear are documented in this file.
 
+## 0.2.1
+
+* Fix VisitEvent serialization: `modality` field is now included in serialized dicom events
+* Rebuilt with forward-compatible event field passthrough
+
 ## 0.2.0
 
 * Write `DataIdentification` to `file.info.data_identification` after successful processing

--- a/docs/pipeline_event_logger/CHANGELOG.md
+++ b/docs/pipeline_event_logger/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Pipeline Event Logger Changelog
 
+## 0.1.1
+
+* Fix VisitEvent serialization: `modality` field is now included in serialized dicom events
+* Rebuilt with forward-compatible event field passthrough
+
 ## 0.1.0
 
 - Initial release

--- a/docs/processes/data-identification.md
+++ b/docs/processes/data-identification.md
@@ -1,0 +1,156 @@
+# Data Identification Architecture
+
+## Overview
+
+The `DataIdentification` model (`nacc-common/src/python/nacc_common/data_identification.py`) provides a composable way to identify data artifacts across the NACC Data Platform. It uses nested sub-models to separate participant identity, visit context, and datatype-specific fields.
+
+## Class Hierarchy
+
+```
+DataIdentification
+├── participant: ParticipantIdentification (always required)
+│   ├── adcid: Optional[int]
+│   ├── ptid: str
+│   └── naccid: Optional[str]
+├── date: str (always required)
+├── visit: Optional[VisitIdentification]
+│   └── visitnum: str
+└── data: FormIdentification | ImageIdentification (always required)
+```
+
+### Current Data Subclasses
+
+- **FormIdentification** — identifies form data (module + optional packet)
+- **ImageIdentification** — identifies imaging data (modality)
+
+## Serialization Behavior
+
+`DataIdentification` has a custom `@model_serializer` that **flattens** all nested sub-models into a single dict:
+
+```python
+# Internal structure:
+DataIdentification(
+    participant=ParticipantIdentification(adcid=42, ptid="ABC", naccid="NACC001"),
+    date="2024-01-15",
+    visit=VisitIdentification(visitnum="1"),
+    data=FormIdentification(module="UDS", packet="I"),
+)
+
+# Serialized output (model_dump()):
+{
+    "adcid": 42,
+    "ptid": "ABC",
+    "naccid": "NACC001",
+    "date": "2024-01-15",
+    "visitnum": "1",
+    "module": "UDS",
+    "packet": "I",
+}
+```
+
+When `visit` is `None`, the serialized output includes `"visitnum": None`.
+
+### Serialization Modes
+
+- **Default** (`model_dump()`): Flattened dict with all fields (including None values).
+- **`exclude_none=True`**: Flattened dict omitting None fields. Used by `VisitEventCapture` for JSON output.
+- **`mode="raw"`**: Preserves the nested structure (does NOT flatten). Used by `QCStatusLogCreator` when writing visit metadata to QC log `custom_info`.
+
+## VisitEvent Serialization
+
+`VisitEvent` wraps a `DataIdentification` and applies additional renaming when serializing for the event log:
+
+| DataIdentification field | VisitEvent serialized key |
+|--------------------------|---------------------------|
+| `adcid`                  | `pipeline_adcid`          |
+| `date`                   | `visit_date`              |
+| `visitnum`               | `visit_number`            |
+| All other fields         | Passed through as-is      |
+
+The renaming is defined in `VisitEvent._RENAMED_FIELDS`. All fields from the flattened `DataIdentification` that are NOT in the rename map are forwarded directly. This means new fields added to future data subclasses will automatically appear in the serialized `VisitEvent` without updating the serializer.
+
+## Extending with a New Datatype
+
+When a new datatype needs event capture (e.g., `enrollment`, `biomarker`), follow these steps:
+
+### Step 1: Define the data subclass
+
+Add a new model in `data_identification.py`:
+
+```python
+class EnrollmentIdentification(BaseModel):
+    """Identifies enrollment-specific data."""
+
+    enrollment_type: str  # e.g., "initial", "transfer"
+
+    def apply(self, visitor: AbstractIdentificationVisitor) -> None:
+        """Apply visitor to this enrollment identification."""
+        visitor.visit_enrollment(self)  # Add to visitor ABC too
+```
+
+### Step 2: Expand the union type
+
+Update `DataIdentification.data`:
+
+```python
+data: FormIdentification | ImageIdentification | EnrollmentIdentification
+```
+
+### Step 3: Update the factory method
+
+Add a branch to `DataIdentification.from_visit_metadata`:
+
+```python
+if modality is not None:
+    data = ImageIdentification(modality=modality)
+elif enrollment_type is not None:
+    data = EnrollmentIdentification(enrollment_type=enrollment_type)
+elif module is not None:
+    data = FormIdentification(module=module, packet=packet)
+else:
+    raise ValueError("Either module, modality, or enrollment_type must be provided")
+```
+
+### Step 4: Update the VisitEvent validator
+
+Add a branch to `VisitEvent.validate_datatype_consistency`:
+
+```python
+elif self.datatype == "enrollment":
+    if not isinstance(data_obj, EnrollmentIdentification):
+        raise ValueError(
+            f"Visit event has datatype 'enrollment' but data_identification.data "
+            f"is {type(data_obj).__name__}"
+        )
+```
+
+### Step 5: Update the visitor ABC (if applicable)
+
+Add a new `visit_*` method to `AbstractIdentificationVisitor` if the new subclass participates in the visitor pattern.
+
+### What does NOT need updating
+
+- **`DataIdentification.serialize_model`** — flattening already handles arbitrary fields from any data subclass generically.
+- **`DataIdentification.__getattr__`** — attribute delegation already forwards to `self.data` regardless of type.
+- **`VisitEvent.serialize_model`** — the passthrough loop already forwards all non-renamed fields from the flattened DataIdentification. New fields will appear automatically.
+- **`VisitEvent.__getattr__`** — delegates to `data_identification.__getattr__`, which delegates to `self.data`.
+
+### Checklist
+
+| Step | File | Required? |
+|------|------|-----------|
+| Define subclass | `data_identification.py` | Yes |
+| Expand union type | `data_identification.py` | Yes |
+| Update factory method | `data_identification.py` | Yes, if using `from_visit_metadata` |
+| Update VisitEvent validator | `visit_events.py` | Yes |
+| Update visitor ABC | `data_identification.py` | Only if using visitor pattern |
+| Update VisitEvent serializer | `visit_events.py` | No (automatic) |
+| Update VisitEvent `__getattr__` | `visit_events.py` | No (automatic) |
+| Update documentation | `docs/processes/` | Yes |
+
+## Design Rationale
+
+- **Composition over inheritance**: `DataIdentification` composes sub-models rather than using a deep class hierarchy. This keeps each concept (participant, visit, data-type-specifics) isolated and testable.
+- **Flat serialization**: The custom serializer produces a flat dict that matches the legacy schema expected by downstream consumers (S3 event logs, Parquet tables).
+- **Forward-compatible VisitEvent serializer**: By iterating over all fields rather than maintaining an explicit allowlist, new data subclass fields are surfaced automatically.
+- **Validator as guardrail**: `validate_datatype_consistency` ensures you can't accidentally create mismatched events (e.g., a "form" event with `ImageIdentification` data). Each new datatype requires an explicit validator branch, making the addition a conscious design decision.

--- a/docs/processes/event-capture.md
+++ b/docs/processes/event-capture.md
@@ -363,18 +363,20 @@ Event object logged to S3:
 
 ```python
 class VisitEvent(BaseModel):
-    action: str                    # "submit" or "pass-qc"
+    action: str                    # "submit", "pass-qc", "not-pass-qc", or "delete"
     study: str                     # Study identifier (extracted from project label)
     pipeline_adcid: int            # ADCID for event routing
     project_label: str             # Project name (e.g., "ingest-form", "ingest-form-dvcid")
     center_label: str              # Center name
     gear_name: str                 # "identifier-lookup" or "form-scheduler"
     ptid: str                      # Participant ID
+    naccid: Optional[str]          # NACC-assigned participant ID (optional)
     visit_date: date               # Visit date
     visit_number: str              # Visit number (optional for some modules)
-    datatype: str                  # "form"
-    module: str                    # "UDS", "FTLD", "LBD", etc.
-    packet: Optional[str]          # Packet type (optional)
+    datatype: str                  # "form" or "dicom"
+    module: Optional[str]          # "UDS", "FTLD", "LBD", etc. (form events only)
+    packet: Optional[str]          # Packet type (form events only, optional)
+    modality: Optional[str]        # Imaging modality, e.g. "MR" (dicom events only)
     timestamp: datetime            # When action occurred
 ```
 
@@ -474,22 +476,22 @@ Events are written to S3 in a flat structure organized by environment.
 ```text
 s3://event-bucket/
 ├── prod/
-│   ├── log-submit-{YYYYMMDD-HHMMSS}-{adcid}-{project}-{ptid}-{visitnum}.json
-│   └── log-pass-qc-{YYYYMMDD-HHMMSS}-{adcid}-{project}-{ptid}-{visitnum}.json
+│   ├── log-submit-{YYYYMMDD-HHMMSS}-{adcid}-{project}-{ptid}-{visit_date}.json
+│   └── log-pass-qc-{YYYYMMDD-HHMMSS}-{adcid}-{project}-{ptid}-{visit_date}.json
 └── dev/
     └── ...
 ```
 
-**Filename Format**: `log-{action}-{timestamp}-{adcid}-{project}-{ptid}-{visitnum}.json`
+**Filename Format**: `log-{action}-{timestamp}-{adcid}-{project}-{ptid}-{visit_date}.json`
 
 Where:
 
-- **action**: Event type (`submit`, `pass-qc`)
+- **action**: Event type (`submit`, `pass-qc`, `not-pass-qc`, `delete`)
 - **timestamp**: Event timestamp in format `YYYYMMDD-HHMMSS` (when action occurred)
 - **adcid**: Pipeline ADCID
 - **project**: Project label (sanitized)
 - **ptid**: Participant ID
-- **visitnum**: Visit number (if present)
+- **visit_date**: Visit date (YYYY-MM-DD)
 
 ### Example
 
@@ -499,26 +501,28 @@ For a visit with:
 - pipeline_adcid: `42`
 - project_label: `ingest-form` (ADRC study)
 - ptid: `110001`
-- visit_number: `01`
+- visit_date: `2024-01-15`
 - submit timestamp: `2024-01-15T10:00:00Z`
 - pass-qc timestamp: `2024-01-15T10:20:00Z`
 
 Events are written to:
 
 ```text
-s3://event-bucket/prod/log-submit-20240115-100000-42-ingest-form-110001-01.json
-s3://event-bucket/prod/log-pass-qc-20240115-102000-42-ingest-form-110001-01.json
+s3://event-bucket/prod/log-submit-20240115-100000-42-ingest-form-110001-2024-01-15.json
+s3://event-bucket/prod/log-pass-qc-20240115-102000-42-ingest-form-110001-2024-01-15.json
 ```
 
 For a DVCID study visit:
 
 ```text
-s3://event-bucket/prod/log-submit-20240115-100000-44-ingest-form-dvcid-110003-01.json
+s3://event-bucket/prod/log-submit-20240115-100000-44-ingest-form-dvcid-110003-2024-01-15.json
 ```
 
 ### Event File Format
 
-Each event file contains a JSON object with the complete VisitEvent data:
+Each event file contains a JSON object with the complete VisitEvent data.
+
+**Form event example:**
 
 ```json
 {
@@ -529,6 +533,7 @@ Each event file contains a JSON object with the complete VisitEvent data:
   "center_label": "alpha",
   "gear_name": "identifier-lookup",
   "ptid": "110001",
+  "naccid": "NACC000001",
   "visit_date": "2024-01-15",
   "visit_number": "01",
   "datatype": "form",
@@ -537,6 +542,28 @@ Each event file contains a JSON object with the complete VisitEvent data:
   "timestamp": "2024-01-15T10:00:00Z"
 }
 ```
+
+**DICOM event example:**
+
+```json
+{
+  "action": "submit",
+  "study": "adrc",
+  "pipeline_adcid": 42,
+  "project_label": "ingest-dicom",
+  "center_label": "alpha",
+  "gear_name": "image-identifier-lookup",
+  "ptid": "110001",
+  "naccid": "NACC000001",
+  "visit_date": "2024-03-10",
+  "visit_number": "2",
+  "datatype": "dicom",
+  "modality": "MR",
+  "timestamp": "2024-03-10T14:30:00Z"
+}
+```
+
+Note: Fields with `null` values are excluded from the JSON output (`exclude_none=True`).
 
 ### Design Rationale
 

--- a/docs/transactional_event_scraper/CHANGELOG.md
+++ b/docs/transactional_event_scraper/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this gear are documented in this file.
 
+## 1.2.2
+
+* Rebuilt for VisitEvent serialization fix (forward-compatible field passthrough)
+
 ## 1.2.1
 
 * Pins flywheel-sdk to 22.0.0 to fix deserialization crash caused by missing `Avatars` model in SDK 22.1.0+

--- a/gear/form_scheduler/src/docker/BUILD
+++ b/gear/form_scheduler/src/docker/BUILD
@@ -4,5 +4,5 @@ docker_image(
     name="form-scheduler",
     source="Dockerfile",
     dependencies=[":manifest", "gear/form_scheduler/src/python/form_scheduler_app:bin"],
-    image_tags=["1.4.2", "latest"],
+    image_tags=["1.4.3", "latest"],
 )

--- a/gear/form_scheduler/src/docker/manifest.json
+++ b/gear/form_scheduler/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "form-scheduler",
     "label": "Form Scheduler",
     "description": "Queues project files for the submission pipeline",
-    "version": "1.4.2",
+    "version": "1.4.3",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "utility",
-            "image": "naccdata/form-scheduler:1.4.2"
+            "image": "naccdata/form-scheduler:1.4.3"
         },
         "flywheel": {
             "suite": "NACC Admin Gears",

--- a/gear/identifier_lookup/src/docker/BUILD
+++ b/gear/identifier_lookup/src/docker/BUILD
@@ -4,5 +4,5 @@ docker_image(
     name="identifier-lookup",
     source="Dockerfile",
     dependencies=[":manifest", "gear/identifier_lookup/src/python/identifier_app:bin"],
-    image_tags=["2.4.2", "latest"],
+    image_tags=["2.4.3", "latest"],
 )

--- a/gear/identifier_lookup/src/docker/manifest.json
+++ b/gear/identifier_lookup/src/docker/manifest.json
@@ -2,7 +2,7 @@
   "name": "identifier-lookup",
   "label": "Identifier Lookup",
   "description": "Gear to look up participant identifiers for incoming data and capture visit events when QC logging is enabled",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "author": "NACC",
   "maintainer": "NACC <nacchelp@uw.edu>",
   "cite": "",
@@ -15,7 +15,7 @@
   "custom": {
     "gear-builder": {
       "category": "utility",
-      "image": "naccdata/identifier-lookup:2.4.2"
+      "image": "naccdata/identifier-lookup:2.4.3"
     },
     "flywheel": {
       "suite": "NACC Data Gears",

--- a/gear/image_identifier_lookup/src/docker/BUILD
+++ b/gear/image_identifier_lookup/src/docker/BUILD
@@ -7,5 +7,5 @@ docker_image(
         ":manifest",
         "gear/image_identifier_lookup/src/python/image_identifier_lookup_app:bin",
     ],
-    image_tags=["0.2.0", "latest"],
+    image_tags=["0.2.1", "latest"],
 )

--- a/gear/image_identifier_lookup/src/docker/manifest.json
+++ b/gear/image_identifier_lookup/src/docker/manifest.json
@@ -2,7 +2,7 @@
   "name": "image-identifier-lookup",
   "label": "Image Identifier Lookup",
   "description": "Performs NACCID lookups for DICOM images uploaded to the NACC Data Platform",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": "NACC",
   "maintainer": "NACC <nacchelp@uw.edu>",
   "cite": "",
@@ -15,7 +15,7 @@
   "custom": {
     "gear-builder": {
       "category": "utility",
-      "image": "naccdata/image-identifier-lookup:0.2.0"
+      "image": "naccdata/image-identifier-lookup:0.2.1"
     },
     "flywheel": {
       "suite": "NACC Data Gears",

--- a/gear/pipeline_event_logger/src/docker/BUILD
+++ b/gear/pipeline_event_logger/src/docker/BUILD
@@ -7,5 +7,5 @@ docker_image(
         ":manifest",
         "gear/pipeline_event_logger/src/python/pipeline_event_logger_app:bin",
     ],
-    image_tags=["0.1.0", "latest"],
+    image_tags=["0.1.1", "latest"],
 )

--- a/gear/pipeline_event_logger/src/docker/manifest.json
+++ b/gear/pipeline_event_logger/src/docker/manifest.json
@@ -2,7 +2,7 @@
   "name": "pipeline-event-logger",
   "label": "Pipeline Event Logger",
   "description": "Reads QC results from upstream gears and propagates them to NACC QC status logs and S3 event capture",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": "NACC",
   "maintainer": "NACC <nacchelp@uw.edu>",
   "cite": "",
@@ -15,7 +15,7 @@
   "custom": {
     "gear-builder": {
       "category": "utility",
-      "image": "naccdata/pipeline-event-logger:0.1.0"
+      "image": "naccdata/pipeline-event-logger:0.1.1"
     },
     "flywheel": {
       "suite": "NACC Data Gears",

--- a/gear/transactional_event_scraper/src/docker/BUILD
+++ b/gear/transactional_event_scraper/src/docker/BUILD
@@ -7,5 +7,5 @@ docker_image(
         ":manifest",
         "gear/transactional_event_scraper/src/python/transactional_event_scraper_app:bin",
     ],
-    image_tags=["1.2.1", "latest"],
+    image_tags=["1.2.2", "latest"],
 )

--- a/gear/transactional_event_scraper/src/docker/manifest.json
+++ b/gear/transactional_event_scraper/src/docker/manifest.json
@@ -2,7 +2,7 @@
   "name": "transactional-event-scraper",
   "label": "Transactional Event Scraper",
   "description": "A gear for scraping existing QC status log files to generate historical submission and pass-qc events",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "author": "NACC",
   "maintainer": "NACC <nacchelp@uw.edu>",
   "cite": "",
@@ -15,7 +15,7 @@
   "custom": {
     "gear-builder": {
       "category": "utility",
-      "image": "naccdata/transactional-event-scraper:1.2.1"
+      "image": "naccdata/transactional-event-scraper:1.2.2"
     },
     "flywheel": {
       "suite": "Utility",

--- a/nacc-common/src/python/nacc_common/data_identification.py
+++ b/nacc-common/src/python/nacc_common/data_identification.py
@@ -1,3 +1,13 @@
+"""Data identification models for the NACC Data Platform.
+
+Provides composable models to identify data artifacts: participants, visits,
+and datatype-specific metadata (forms, images). The DataIdentification class
+uses a flattening serializer for backward compatibility with legacy schemas.
+
+For architecture details and extensibility guide, see:
+    docs/processes/data-identification.md
+"""
+
 from abc import ABC, abstractmethod
 from typing import Any, Optional
 


### PR DESCRIPTION
## Summary

Fixes VisitEvent serialization to include all DataIdentification fields (notably `modality` for dicom events which was previously dropped silently). Makes the serializer forward-compatible so future DataIdentification subclasses won't require serializer updates.

## Changes

### Code
- **visit_events.py**: Replace explicit field allowlist with generic loop over all `data_identification` fields. Renamed fields are handled via `_RENAMED_FIELDS` class variable; everything else passes through automatically.
- **event_capture.py**: Fix docstring to match actual filename format.
- **data_identification.py**: Add module docstring.

### Documentation
- **docs/processes/event-capture.md**: Fix filename format (`visit_date` not `visitnum`), add `naccid`/`modality` to schema, add dicom JSON example, update action types.
- **docs/processes/data-identification.md** (new): Architecture overview and extensibility guide for adding new datatypes.

### Version Bumps
| Gear | Version |
|------|---------|
| identifier-lookup | 2.4.2 → 2.4.3 |
| image-identifier-lookup | 0.2.0 → 0.2.1 |
| form-scheduler | 1.4.2 → 1.4.3 |
| pipeline-event-logger | 0.1.0 → 0.1.1 |
| transactional-event-scraper | 1.2.1 → 1.2.2 |

## Testing

- All existing tests pass (event_capture, nacc-common test suites)
- Type checking passes
- Lint passes
- The change is backward-compatible: form events produce identical output; dicom events gain the previously-missing `modality` field.