### PR TITLE
Unpin flywheel-sdk to >=22.2.2

### DIFF
--- a/mypy.lock
+++ b/mypy.lock
@@ -399,19 +399,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548",
-              "url": "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl"
+              "hash": "481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8",
+              "url": "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466",
-              "url": "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz"
+              "hash": "dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5",
+              "url": "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz"
             }
           ],
           "project_name": "typing-extensions",
           "requires_dists": [],
           "requires_python": ">=3.9",
-          "version": "4.15.0"
+          "version": "4.16.0"
         },
         {
           "artifacts": [

--- a/python-default.lock
+++ b/python-default.lock
@@ -12,7 +12,7 @@
 //     "boto3-stubs[boto3]",
 //     "boto3>=1.28.53",
 //     "botocore",
-//     "flywheel-sdk==22.0.0",
+//     "flywheel-sdk>=22.2.2",
 //     "fw-client>=0.7.0",
 //     "fw-gear>=0.3.5",
 //     "fw-utils>=3",
@@ -154,42 +154,42 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "edffb4a8f49c0a61e8f4aa4104cc2da3c362de8042fc0819216d5e5ce5d38380",
-              "url": "https://files.pythonhosted.org/packages/0a/60/e0e3baeb394e084c5136a46b8e944ba87a26bb1f67f7b3064eb035bb7e77/boto3-1.43.38-py3-none-any.whl"
+              "hash": "c34a36c9181998dd9b663095b0b0f5f5bc97f3b6846d6a63b31529462091047a",
+              "url": "https://files.pythonhosted.org/packages/85/53/ccb197ae4659300370b2538fa8a73bde1dcb4118319f0e9a865a975ea2a7/boto3-1.43.42-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a8d1e175a87a743e755237d884d7e5f4606e61e5602e9823469a1a630e379b3c",
-              "url": "https://files.pythonhosted.org/packages/eb/ee/97798453d8e9dba0c60458870b07c78ac685fc21cdddd8eb3e20190249c6/boto3-1.43.38.tar.gz"
+              "hash": "f5a7fa503fd902dbd305d52a4571971149acb2c19f02508188f283e244e121e4",
+              "url": "https://files.pythonhosted.org/packages/21/1e/4b6b2bd7ad9173e72fd5aef5ec1187847e06ff5497b66c2051b387827d56/boto3-1.43.42.tar.gz"
             }
           ],
           "project_name": "boto3",
           "requires_dists": [
-            "botocore<1.44.0,>=1.43.38",
+            "botocore<1.44.0,>=1.43.42",
             "botocore[crt]<2.0a0,>=1.21.0; extra == \"crt\"",
             "jmespath<2.0.0,>=0.7.1",
             "s3transfer<0.20.0,>=0.19.0"
           ],
           "requires_python": ">=3.10",
-          "version": "1.43.38"
+          "version": "1.43.42"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "5d9c21e2b52d0c4077ee377f686fc965395a2d02534e1e3de0c7cb9c2f0ad6d4",
-              "url": "https://files.pythonhosted.org/packages/44/ba/2c9c7153ebd3ada100f111bf7a2f16b1627ba94450a9c6edf9e6e26c5845/boto3_stubs-1.43.38-py3-none-any.whl"
+              "hash": "630683286d0fc88444c95e9ed6e29afad1bbc03c3c198cd84e14becf0c9a6523",
+              "url": "https://files.pythonhosted.org/packages/4b/83/3b88ae81aa4973614bef46632b595e3bcc36f9f82ea287ef715c218329df/boto3_stubs-1.43.42-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "55701008fa910d60aa2a593aa307d121c85a91a892cb24182bcf8ec41f29a9f5",
-              "url": "https://files.pythonhosted.org/packages/89/8d/2b249f56bc7a5e90bf1d5f23b6f089fd762f65d7ad032b32e93e69eb1242/boto3_stubs-1.43.38.tar.gz"
+              "hash": "f517678562387bc54f872006e29bc7f4472f196229f188b4298122e2ee23fcb7",
+              "url": "https://files.pythonhosted.org/packages/4b/76/c9af2a465321d657e9f5009d8f667f5856089226db25239b228ed5d6cc3f/boto3_stubs-1.43.42.tar.gz"
             }
           ],
           "project_name": "boto3-stubs",
           "requires_dists": [
             "boto3-stubs-full<1.44.0,>=1.43.0; extra == \"full\"",
-            "boto3==1.43.38; extra == \"boto3\"",
+            "boto3==1.43.42; extra == \"boto3\"",
             "botocore-stubs",
             "mypy-boto3-accessanalyzer<1.44.0,>=1.43.0; extra == \"accessanalyzer\"",
             "mypy-boto3-accessanalyzer<1.44.0,>=1.43.0; extra == \"all\"",
@@ -775,6 +775,8 @@
             "mypy-boto3-partnercentral-benefits<1.44.0,>=1.43.0; extra == \"partnercentral-benefits\"",
             "mypy-boto3-partnercentral-channel<1.44.0,>=1.43.0; extra == \"all\"",
             "mypy-boto3-partnercentral-channel<1.44.0,>=1.43.0; extra == \"partnercentral-channel\"",
+            "mypy-boto3-partnercentral-revenue-measurement<1.44.0,>=1.43.0; extra == \"all\"",
+            "mypy-boto3-partnercentral-revenue-measurement<1.44.0,>=1.43.0; extra == \"partnercentral-revenue-measurement\"",
             "mypy-boto3-partnercentral-selling<1.44.0,>=1.43.0; extra == \"all\"",
             "mypy-boto3-partnercentral-selling<1.44.0,>=1.43.0; extra == \"partnercentral-selling\"",
             "mypy-boto3-payment-cryptography-data<1.44.0,>=1.43.0; extra == \"all\"",
@@ -1050,19 +1052,19 @@
             "typing-extensions>=4.1.0; python_version < \"3.12\""
           ],
           "requires_python": ">=3.9",
-          "version": "1.43.38"
+          "version": "1.43.42"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "54c1c41aff82422d2b88a8a7d782fde8ae1299a45f088d00011d85c4bc44b0cc",
-              "url": "https://files.pythonhosted.org/packages/22/b4/fdff7920b3776b37f8b42d4e6eabb141974fa88f9fb1aae5c2224bdaf635/botocore-1.43.38-py3-none-any.whl"
+              "hash": "62aa017eb5bb9791b1bc655571fa1548611e508f35e13e636d3939e1be3745f0",
+              "url": "https://files.pythonhosted.org/packages/b2/c5/ca819ae7489a233b03241d20458518b0de150bddc6b87c20192de3eaff7e/botocore-1.43.42-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "70fbd5c74f5742f5975ddcc61e6afb5174cb80577c2ccc17c6898ad3a49b51f3",
-              "url": "https://files.pythonhosted.org/packages/73/6c/815f49f0c582396b1a4c37df554ffab6bb420abd5a96d5329183a97022de/botocore-1.43.38.tar.gz"
+              "hash": "d813d5d5707db5f1c73b5d65f6b172c49f38375b23b30c593966fef56f8b5e40",
+              "url": "https://files.pythonhosted.org/packages/54/de/c264abcfb6b371d05c7c1ffbd10d666bf517b6a259390d3e49c921f2a1c5/botocore-1.43.42.tar.gz"
             }
           ],
           "project_name": "botocore",
@@ -1073,7 +1075,7 @@
             "urllib3!=2.2.0,<3,>=1.25.4"
           ],
           "requires_python": ">=3.10",
-          "version": "1.43.38"
+          "version": "1.43.42"
         },
         {
           "artifacts": [
@@ -1138,144 +1140,129 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187",
-              "url": "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl"
+              "hash": "379de10ce1ba048b1448599d1b37b24caee16309d1ac98d3982fc997f768700b",
+              "url": "https://files.pythonhosted.org/packages/79/99/0d0fd37f055224085f42bbb2c022d002e17dde4a97972822327b07d84101/cffi-2.1.0-cp312-cp312-musllinux_1_2_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94",
-              "url": "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl"
+              "hash": "b6422532152adf4e59b110cb2808cee7a033800952f5c036b4af047ee43199e7",
+              "url": "https://files.pythonhosted.org/packages/1b/dc/5620cf930688be01f2d673804291de757a934c90b946dbdc3d84130c2ea4/cffi-2.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037",
-              "url": "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl"
+              "hash": "df2b82571a1b30f58a87bf4e5a9e78d2b1eff6c6ce8fd3aa3757221f93f0863f",
+              "url": "https://files.pythonhosted.org/packages/1e/85/990925db5df586ec90beb97529c853497e7f85ba0234830447faf41c3057/cffi-2.1.0-cp312-cp312-macosx_10_15_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba",
-              "url": "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
+              "hash": "78474632761faa0fb96f30b1c928c84ebcf68713cbb80d15bab09dfe61640fde",
+              "url": "https://files.pythonhosted.org/packages/4b/92/e7bb136ad6b5352603732cf907ef862ca103f20f2031c1735a46300c20c9/cffi-2.1.0-cp312-cp312-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e",
-              "url": "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl"
+              "hash": "46b1c8db8f6122420f32d02fffb924c2fe9bc772d228c7c711748fff56aabb2b",
+              "url": "https://files.pythonhosted.org/packages/4b/a4/77b53abbf7a1e0beb9637edbef2a94d15f9c822f591e85d439ffd91519a6/cffi-2.1.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062",
-              "url": "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
+              "hash": "efc1cdd798b1aaf39b4610bba7aad28c9bea9b910f25c784ccf9ec1fa719d1f9",
+              "url": "https://files.pythonhosted.org/packages/57/5f/ff100cae70ebe9d8df1c01a00e510e45d9adb5c1fdda84791b199141de97/cffi-2.1.0.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c",
-              "url": "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl"
+              "hash": "d9fafc5aa2e2a39aaf7f8cc0c1f044a9b07fca12e558dca53a3cc5c654ad67a7",
+              "url": "https://files.pythonhosted.org/packages/58/0c/f528df19cc94b675087324d4760d9e6d5bfae97d6217aa4fac43de4f5fcc/cffi-2.1.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d",
-              "url": "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl"
+              "hash": "1e9f50d192a3e525b15a75ab5114e442d83d657b7ec29182a991bc9a88fd3a66",
+              "url": "https://files.pythonhosted.org/packages/62/f2/c9522a81c32132799a1972c39f5c5f8b4c8b9f00488a23feaa6c06f07741/cffi-2.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529",
-              "url": "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz"
+              "hash": "98fff996e983a36d3aa2eca83af40c5821202e7e6f32d13ae94e3d2286f10cfe",
+              "url": "https://files.pythonhosted.org/packages/6e/28/bd53988b9833e8f8ad539d26f4c07a6b3f6bcb1e9e02e7ca038250b3428d/cffi-2.1.0-cp312-cp312-musllinux_1_2_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe",
-              "url": "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl"
+              "hash": "5972433ad71a9e46516584ef60a0fda12d9dc459938d1539c3ddecf9bdc1368d",
+              "url": "https://files.pythonhosted.org/packages/c3/c0/d1ec30ffb370f748f2fb54425972bfef9871e0132e82fb589c46b6676049/cffi-2.1.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl"
             }
           ],
           "project_name": "cffi",
           "requires_dists": [
             "pycparser; implementation_name != \"PyPy\""
           ],
-          "requires_python": ">=3.9",
-          "version": "2.0.0"
+          "requires_python": ">=3.10",
+          "version": "2.1.0"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d",
-              "url": "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl"
+              "hash": "68e5f26a1ad57ded6d1cfb85331d1c1a195314756471d97758c48498bb4dcdf5",
+              "url": "https://files.pythonhosted.org/packages/98/2b/f97f1c193fb855c345d678f5077d6926034db0722df74c8f057020e05a25/charset_normalizer-3.4.9-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46",
-              "url": "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl"
+              "hash": "5e226f6218febc71f6c1fc2fafb91c226f75bdc1d8fb12d66823716e891608fd",
+              "url": "https://files.pythonhosted.org/packages/01/c4/4fa4c8b3097a11f3c5f09a35b72ed6855fb1d332469504962ab7bafcc702/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15",
-              "url": "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl"
+              "hash": "60f44ade2cf573dad7a277e6f8ca9a51a21dda572b13bd7d8539bb3cd5dbedde",
+              "url": "https://files.pythonhosted.org/packages/33/9a/895095b83e7907abd6d3d99aad3a38ad0d9686cc186cb0c94c24320fe63e/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b",
-              "url": "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl"
+              "hash": "9104ed0bd76a429d46f9ec0dbc9b08ad1d2dcdf2b00a5a0daa1c145329b35b44",
+              "url": "https://files.pythonhosted.org/packages/4b/4c/5361f9aa7f2cb58d94f2ab831b3d493f69efb1d239654b4744e3c09527cb/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116",
-              "url": "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+              "hash": "7b86a2b16095d250c6f58b3d9b2eee6f4147754344f3dab0922f7c9bf7d226c9",
+              "url": "https://files.pythonhosted.org/packages/50/78/ce342ca4ff30b2eb49fe6d9578df85974f90c67d294113e94efdd9664cbd/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7",
-              "url": "https://files.pythonhosted.org/packages/59/7a/071feed8124111a32b316b33ae4de83d36923039ef8cf48120266844285b/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl"
+              "hash": "45b0cc4e3556cd875e09102988d1ab8356c998b596c9fced84547c8138b487a0",
+              "url": "https://files.pythonhosted.org/packages/70/4a/ecbd131485c07fcdfad54e28946d513e3da22ef3b4bd854dcafae54ec739/charset_normalizer-3.4.9-cp312-cp312-macosx_10_13_universal2.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1",
-              "url": "https://files.pythonhosted.org/packages/6f/c0/7b1f943f7e87cc3db9626ba17807d042c38645f0a1d4415c7a14afb5591f/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl"
+              "hash": "03d07803992c6c7bbc976327f34b18b6160327fc81cb82c9d504720ac0be3b62",
+              "url": "https://files.pythonhosted.org/packages/83/dc/9b29fa4412b318bf3bfea985c35d67eb55e04b59a7c3f2237168b0e0be6f/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49",
-              "url": "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl"
+              "hash": "90c44bc373b7687f6948b693cceaea1348ae0975d7474746559494468e3c1d84",
+              "url": "https://files.pythonhosted.org/packages/87/3a/ad914516df7e358a81aae018caa5e0470ba827fa6d763b1d2e87d920a5f6/charset_normalizer-3.4.9-cp312-cp312-manylinux_2_31_armv7l.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb",
-              "url": "https://files.pythonhosted.org/packages/b1/f1/6d2b0b261b6c4ceef0fcb0d17a01cc5bc53586c2d4796fa04b5c540bc13d/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl"
+              "hash": "a1786910334ed46ab1dd73222f2cd1e05c2c3bb39f6dddb4f8b36fc382058a39",
+              "url": "https://files.pythonhosted.org/packages/a1/34/ef5c05f412f42520d7709b7d3784d19640839eb7366ded1755511585429f/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_armv7l.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d",
-              "url": "https://files.pythonhosted.org/packages/c1/4c/a5fb52d528a8ca41f7598cb619409ece30a169fbdf9cdce592e53b46c3a6/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl"
+              "hash": "673611bbd43f0810bec0b0f028ddeaaa501190339cac411f347ac76917c3ae7b",
+              "url": "https://files.pythonhosted.org/packages/bd/2a/23f34ec9d04624958e137efdc394888716353190e75f25dd22c7a2c7a8aa/charset_normalizer-3.4.9.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5",
-              "url": "https://files.pythonhosted.org/packages/d5/ff/531a1cad5ca855d1c1a8b69cb71abfd6d85c0291580146fda7c82857caa1/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl"
+              "hash": "9cdef90ae47919cae358d8ab15797a800ed41da7aba5d72419fb510729e2ed4b",
+              "url": "https://files.pythonhosted.org/packages/d7/74/3c12f9755717dfe5c5c87da63f35d765fa0c00382ec26bf23f7fae34f2ba/charset_normalizer-3.4.9-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a",
-              "url": "https://files.pythonhosted.org/packages/dc/67/675a46eb016118a2fbde5a277a5d15f4f69d5f3f5f338e5ee2f8948fcf43/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5",
-              "url": "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2",
-              "url": "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464",
-              "url": "https://files.pythonhosted.org/packages/fd/35/f7dba3994312d7ba508e041eaac39a36b120f32d4c8662b8814dab876431/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl"
+              "hash": "9b2aff1c7b3884512b9512c3eaadd9bab39fb45042ffaaa1dd08ff2b9f8109d9",
+              "url": "https://files.pythonhosted.org/packages/ec/96/5d9364e3342d69f3a045e1777bc47c85c383e6e9466d561b33fdb419d1f9/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
             }
           ],
           "project_name": "charset-normalizer",
           "requires_dists": [],
           "requires_python": ">=3.7",
-          "version": "3.4.7"
+          "version": "3.4.9"
         },
         {
           "artifacts": [
@@ -1436,8 +1423,8 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "77ffe2550546c57a70edcb4514f7e4c7bfbc722d1b9ea9342f8d7a1d67e64ee0",
-              "url": "https://files.pythonhosted.org/packages/a7/e9/550f4435d95cba3d5a07b83faf2ac5dbe6db8522f4817991362dc5bf9e03/flywheel_sdk-22.0.0-py3-none-any.whl"
+              "hash": "c181de058e57cdab22840d20c9bc5554d2511ed45371bf51f5d2d9575cbd84b6",
+              "url": "https://files.pythonhosted.org/packages/eb/61/40a51087d1f9ffdc7ac37c9dcc32081bd6d7e91778f92866d16f1467ed75/flywheel_sdk-22.2.2-py3-none-any.whl"
             }
           ],
           "project_name": "flywheel-sdk",
@@ -1453,7 +1440,7 @@
             "urllib3<3.0,>=2.5"
           ],
           "requires_python": ">=3.10",
-          "version": "22.0.0"
+          "version": "22.2.2"
         },
         {
           "artifacts": [
@@ -1614,13 +1601,33 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "9f634bdb1f9e9b8ab6ba09431cf2deedb750c96978125a6fb3c5a0f6c6db4131",
-              "url": "https://files.pythonhosted.org/packages/01/f8/c151e196d4f397ed9436a071e52666c70a2f021138dea828b0a461e245db/hypothesis-6.155.7-py3-none-any.whl"
+              "hash": "32cbdbbdf9bd4416270e0849db90791bf43128c616f44af498140ed8c6b13ef1",
+              "url": "https://files.pythonhosted.org/packages/47/41/c0272ca96dff030d7e4119c35feac4cd388395f4317739273a11f1f57378/hypothesis-6.156.2-cp312-cp312-musllinux_1_2_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d8d6091753d0669db3c90c5e5b346cb37c72f3dd9378c8413acb1fd5da63f7ea",
-              "url": "https://files.pythonhosted.org/packages/f2/55/983b6bc1b6b343a5ff6020388f9d0680ab477be59a731517e6c4a0387100/hypothesis-6.155.7.tar.gz"
+              "hash": "089abb5f72c980c7d3a8fd6986c08743cbb9105fab826a8a3d4e34dcf4b3c446",
+              "url": "https://files.pythonhosted.org/packages/2a/04/cba9692e3ba6802a7f881ee1000634bc327c50999eff31c848a89572b94e/hypothesis-6.156.2-cp312-cp312-macosx_10_12_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "94fddaef961465db10201e385366366d7a394073a3e5915d402c38e184a30490",
+              "url": "https://files.pythonhosted.org/packages/45/9d/96d39aa32fc5a53a0598bafae9fdd7150e0d1679b37ca820df85ddecd166/hypothesis-6.156.2-cp312-cp312-musllinux_1_2_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "94e027517e435d0bda48557ef736552cf14a06af76961375e48a3c2c48afb502",
+              "url": "https://files.pythonhosted.org/packages/be/a6/023e521d053b9b99d70f6c493d626f4f1b51a87d9a6f6cdb286b0c8532f5/hypothesis-6.156.2-cp312-cp312-macosx_11_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "74f49b87e367d9ac844350b617eab9846126d45c57d3062d5515545e5d3854cf",
+              "url": "https://files.pythonhosted.org/packages/cd/d9/1822df320ce0ea4cbfa1cbeb888f88d5dbd3b8ecfcb1fd7236cd2cbcbf64/hypothesis-6.156.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "f8f3ab2c0b70231c73fe3bc686f3ecf827882a132dbd44758fdfe562b92b725a",
+              "url": "https://files.pythonhosted.org/packages/dd/1a/33682e317f96ff04d101782ba174d2eb9c70b709b51cb4c22de4a1cc48d0/hypothesis-6.156.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             }
           ],
           "project_name": "hypothesis",
@@ -1630,13 +1637,13 @@
             "black>=20.8b0; extra == \"ghostwriter\"",
             "click>=7.0; extra == \"all\"",
             "click>=7.0; extra == \"cli\"",
-            "crosshair-tool>=0.0.106; extra == \"all\"",
-            "crosshair-tool>=0.0.106; extra == \"crosshair\"",
+            "crosshair-tool>=0.0.107; extra == \"all\"",
+            "crosshair-tool>=0.0.107; extra == \"crosshair\"",
             "django>=5.2; extra == \"all\"",
             "django>=5.2; extra == \"django\"",
             "dpcontracts>=0.4; extra == \"all\"",
             "dpcontracts>=0.4; extra == \"dpcontracts\"",
-            "exceptiongroup>=1.0.0; python_version < \"3.11\"",
+            "exceptiongroup>=1.0.0; python_full_version < \"3.11\"",
             "hypothesis-crosshair>=0.0.28; extra == \"all\"",
             "hypothesis-crosshair>=0.0.28; extra == \"crosshair\"",
             "lark>=0.10.1; extra == \"all\"",
@@ -1658,13 +1665,13 @@
             "rich>=9.0.0; extra == \"all\"",
             "rich>=9.0.0; extra == \"cli\"",
             "sortedcontainers<3.0.0,>=2.1.0",
-            "tzdata>=2026.2; (sys_platform == \"win32\" or sys_platform == \"emscripten\") and extra == \"all\"",
-            "tzdata>=2026.2; (sys_platform == \"win32\" or sys_platform == \"emscripten\") and extra == \"zoneinfo\"",
+            "tzdata>=2026.2; (sys_platform == \"emscripten\" and extra == \"all\") or (sys_platform == \"win32\" and extra == \"all\")",
+            "tzdata>=2026.2; (sys_platform == \"emscripten\" and extra == \"zoneinfo\") or (sys_platform == \"win32\" and extra == \"zoneinfo\")",
             "watchdog>=4.0.0; extra == \"all\"",
             "watchdog>=4.0.0; extra == \"watchdog\""
           ],
           "requires_python": ">=3.10",
-          "version": "6.155.7"
+          "version": "6.156.2"
         },
         {
           "artifacts": [
@@ -2028,54 +2035,54 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "b8c3daaf99de52415d20b42f8e8155c78642cb04207d02f9d317a0dcf1b3fb54",
-              "url": "https://files.pythonhosted.org/packages/06/34/43efdcb319988648580f93c11f1ae82cf7e2faa74925e98e454ae3aa95f8/numpy-2.5.0-cp312-cp312-musllinux_1_2_x86_64.whl"
+              "hash": "e824c2acf8862052246be5a44c15da1777940c60d010dd2aab897824d9c430f9",
+              "url": "https://files.pythonhosted.org/packages/83/d0/a39b2fbcde9cb17a1dac678f254b33a6336298af9df338824c685425d5e8/numpy-2.5.1-cp312-cp312-musllinux_1_2_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7174ce8265fc7f7417d171c9ea8fe905220748893ea67a2a7abe726ec331c4b0",
-              "url": "https://files.pythonhosted.org/packages/3a/2f/c354ec86d1f3f5c19649463b0d39652e160736e5b0a4cd18dff0576715c4/numpy-2.5.0-cp312-cp312-musllinux_1_2_aarch64.whl"
+              "hash": "a48a113e6afea91f5608793bafa7ef2ad481fefbda87ec5069f483de61cb9fa3",
+              "url": "https://files.pythonhosted.org/packages/22/fd/89965aa4ac08c74998539fcbf24fa3540f3e15237fbeb6bcf9c908f4aade/numpy-2.5.1.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "ece55976ced6bca95a03ae2839e2e5ccffe8eb6a3e7022415645eb154a81e4e6",
-              "url": "https://files.pythonhosted.org/packages/55/b2/285f48640a181947b4587a3766d21ec1eaa7fea833d4b49957e09da467a2/numpy-2.5.0-cp312-cp312-macosx_11_0_arm64.whl"
+              "hash": "f7119ebff1a9829e9f431a4f9d28e703023bb6b9fe7c8f724467dbfc27c94ab3",
+              "url": "https://files.pythonhosted.org/packages/24/7d/ad3e59015135f5261c95fd4cafeff159c955febd83a99a1d9250c4233815/numpy-2.5.1-cp312-cp312-musllinux_1_2_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a1a4874217b36d5ac8fc876f52e39df56f8182c88463e9e2dceabf7ca8b7efb8",
-              "url": "https://files.pythonhosted.org/packages/82/49/2ec21730bc63ccfda829323f7040a8ed4715b3852ce658689cf74ee96a8c/numpy-2.5.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl"
+              "hash": "78798bd5b9ad744056af8efa90e3b9ddaa53272a0848a483084a1cc0a13b2dc0",
+              "url": "https://files.pythonhosted.org/packages/42/77/fdf34a71dd30f54979b18603bee915e0aaf825b07afe79acd60b04b691e2/numpy-2.5.1-cp312-cp312-macosx_14_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "bf80333980bf37f523341ddd72c783f39d6829ec7736b9eb99086388a2d52cc2",
-              "url": "https://files.pythonhosted.org/packages/b9/83/03fc7300c7c6b6c84c487b1dc80d322817b95fbd1f4dd57a85e23b7198de/numpy-2.5.0-cp312-cp312-macosx_14_0_x86_64.whl"
+              "hash": "2c889b56fe48b1018f764b0eec8df59ab654e9148aa91faa12596043500de277",
+              "url": "https://files.pythonhosted.org/packages/62/7b/14687aa674250e5e546f616f486b0d56d3631cd5b2415739141ce40bdcea/numpy-2.5.1-cp312-cp312-macosx_10_13_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "aaa760137137e8d3c920d27927748215b56014f92667dc9b6c27dfc61249255a",
-              "url": "https://files.pythonhosted.org/packages/bb/6b/f4a3d0637692c49da8ef99d72d52526f92e0a8d6ac4f0ca9f31441b9d9ea/numpy-2.5.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
+              "hash": "61ac47e772e6b8ea489e1d2f441a34c5c3ac17327e7ce294cbdf535795ad4e75",
+              "url": "https://files.pythonhosted.org/packages/a9/4b/a2b32dd94ee9ffbeecb28152240042a3949db33b1c834d44090b80e1b3b8/numpy-2.5.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "c83b664b0e6eee9594fa920cf0639d8af796606d3fad6cc70180c87e4b97c7be",
-              "url": "https://files.pythonhosted.org/packages/dd/67/b032db1eb03ca30d16eda3b0c22aaa615338b9263c2fd559d0f29451aca4/numpy-2.5.0-cp312-cp312-macosx_14_0_arm64.whl"
+              "hash": "59fda5e192b570217ec2580c96f00e9a7e12ef6866a900eb089b62c1a32545ca",
+              "url": "https://files.pythonhosted.org/packages/b8/a9/6e73d68500f80773f65f0654ea932019d6694329a0eb0ed0533de38df376/numpy-2.5.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5a129578019311b6e56bdd714250f19b518f7dceeeb8d1af5490f4942d3f891c",
-              "url": "https://files.pythonhosted.org/packages/e7/05/3d27272d30698dc0ecb7fdfaa41ad70303b444f81722bb99bce1d818638a/numpy-2.5.0.tar.gz"
+              "hash": "2ae0ca40bcb22d6ba59c1dfd5446f49940b0f2d821fde133f10dda11f816b84e",
+              "url": "https://files.pythonhosted.org/packages/ce/e2/eb7efa015b4cce41e2517bf182a7fce0d7d5b9d9ed76a29bfa0f4fe4505c/numpy-2.5.1-cp312-cp312-macosx_14_0_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "489780423903667933b4ed6197b6ec3b75ea5dd17d1d8f0f38d798feb6921561",
-              "url": "https://files.pythonhosted.org/packages/fa/0a/11486d02add7b1384dff7374d124b1cfbb0ee864dcc9f6a2c0380638cf84/numpy-2.5.0-cp312-cp312-macosx_10_13_x86_64.whl"
+              "hash": "ab451b59c5643c570974c43aef780703ef1d3b4965d2be07afd530615a9358d1",
+              "url": "https://files.pythonhosted.org/packages/e1/19/cc5bb2a3f2913d27d6dbb2c78d25921fabaedc6741d4a5a615a11f3c5bf3/numpy-2.5.1-cp312-cp312-macosx_11_0_arm64.whl"
             }
           ],
           "project_name": "numpy",
           "requires_dists": [],
           "requires_python": ">=3.12",
-          "version": "2.5.0"
+          "version": "2.5.1"
         },
         {
           "artifacts": [
@@ -2826,13 +2833,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "8aacc4586eb08fb2208ef64a9eb4258d9b0c6e6f4260845f2f018ab847495345",
-              "url": "https://files.pythonhosted.org/packages/3a/31/6a620b4427d546b9e7cca8b3b8c5f0559d9cef2bb9eedcda7f73c1473c19/responses-0.26.1-py3-none-any.whl"
+              "hash": "6fdfeabd58e5ec473b98dfe02e6d46d3173bd8dd573eff2ccccf1a05a5135364",
+              "url": "https://files.pythonhosted.org/packages/7c/28/693e1d9ebf72baa062ded80d837a035b86ce75eda5a269379e9e2b1008a8/responses-0.26.2-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2eb3218553cc8f79b57d257bac23af5e1bf381f5b9390b1767816f0843e01dc2",
-              "url": "https://files.pythonhosted.org/packages/c2/58/1fb6de3503428196df78638f991ec8095274f1ee9723e272ee4d9ff0092b/responses-0.26.1.tar.gz"
+              "hash": "9c9259b46a8349197edebf43cfa68a87e1a2802ef503ff8b2fecbabc0b45afd8",
+              "url": "https://files.pythonhosted.org/packages/f0/1a/4af3e6d659394b809838490b144e4ab8d7ed3b9fecc7ca78f5d2f79b1a3d/responses-0.26.2.tar.gz"
             }
           ],
           "project_name": "responses",
@@ -2853,7 +2860,7 @@
             "urllib3<3.0,>=1.25.10"
           ],
           "requires_python": ">=3.8",
-          "version": "0.26.1"
+          "version": "0.26.2"
         },
         {
           "artifacts": [
@@ -2953,13 +2960,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb",
-              "url": "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl"
+              "hash": "29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3",
+              "url": "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9",
-              "url": "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz"
+              "hash": "025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef",
+              "url": "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz"
             }
           ],
           "project_name": "setuptools",
@@ -2989,11 +2996,11 @@
             "pyproject-hooks!=1.1; extra == \"doc\"",
             "pyproject-hooks!=1.1; extra == \"test\"",
             "pytest!=8.1.*,>=6; extra == \"test\"",
-            "pytest-checkdocs>=2.4; extra == \"check\"",
+            "pytest-checkdocs>=2.14; extra == \"check\"",
             "pytest-cov; extra == \"cover\"",
-            "pytest-enabler>=2.2; extra == \"enabler\"",
+            "pytest-enabler>=3.4; extra == \"enabler\"",
             "pytest-home>=0.5; extra == \"test\"",
-            "pytest-mypy; extra == \"type\"",
+            "pytest-mypy>=1.0.1; platform_python_implementation != \"PyPy\" and extra == \"type\"",
             "pytest-perf; sys_platform != \"cygwin\" and extra == \"test\"",
             "pytest-ruff>=0.2.1; sys_platform != \"cygwin\" and extra == \"check\"",
             "pytest-subprocess; extra == \"test\"",
@@ -3015,8 +3022,8 @@
             "wheel>=0.43.0; extra == \"core\"",
             "wheel>=0.44.0; extra == \"test\""
           ],
-          "requires_python": ">=3.9",
-          "version": "82.0.1"
+          "requires_python": ">=3.10",
+          "version": "83.0.0"
         },
         {
           "artifacts": [
@@ -3224,19 +3231,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548",
-              "url": "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl"
+              "hash": "481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8",
+              "url": "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466",
-              "url": "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz"
+              "hash": "dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5",
+              "url": "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz"
             }
           ],
           "project_name": "typing-extensions",
           "requires_dists": [],
           "requires_python": ">=3.9",
-          "version": "4.15.0"
+          "version": "4.16.0"
         },
         {
           "artifacts": [
@@ -3385,7 +3392,7 @@
     "boto3-stubs[boto3]",
     "boto3>=1.28.53",
     "botocore",
-    "flywheel-sdk==22.0.0",
+    "flywheel-sdk>=22.2.2",
     "fw-client>=0.7.0",
     "fw-gear>=0.3.5",
     "fw-utils>=3",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 boto3>=1.28.53
 boto3-stubs[boto3]
 botocore
-flywheel-sdk==22.0.0 
+flywheel-sdk>=22.2.2
 fw-client>=0.7.0
 fw-gear>=0.3.5
 fw-utils>=3


### PR DESCRIPTION
## Summary

Upgrades from the pinned `flywheel-sdk==22.0.0` workaround to `>=22.2.2`, which contains the official fix for the missing `Avatars` model bug.

## What changed

- `requirements.txt`: `flywheel-sdk==22.0.0` → `flywheel-sdk>=22.2.2`
- Regenerated `python-default.lock` and `mypy.lock`

## Verification

The 22.2.2 wheel resolves the Avatars issue by changing the `User.avatar` field from the `Avatars` class type to a plain `str` (URL). The `Avatars` model class and its import are removed entirely.

- `pants check ::` — passes
- `pants test ::` — all 1,523 tests pass
- No references to `Avatars` or `.avatars` exist in our codebase

## Context

Closes the workaround introduced in #453 (pin to 22.0.0).