### PR TITLE
Check for legacy submissions with same visit date

### DIFF
--- a/common/src/python/keys/keys.py
+++ b/common/src/python/keys/keys.py
@@ -122,6 +122,7 @@ class SysErrorCodes:
     NP_UDS_DAGE_MISMATCH = "preprocess-030"
     UDS_NOT_EXIST = "preprocess-031"
     MULTIPLE_SUBMISSIONS = "preprocess-032"
+    DUPLICATE_LEGACY_VISIT = "preprocess-033"
 
     # other errors for preprocessing issues that don't fall
     # in above categories

--- a/common/src/python/outputs/errors.py
+++ b/common/src/python/outputs/errors.py
@@ -135,6 +135,10 @@ preprocess_errors = {
         "Multiple submissions not allowed for {0} module, "
         "delete the existing submissions for this participant with dates {1} and retry"
     ),
+    SysErrorCodes.DUPLICATE_LEGACY_VISIT: (
+        "Duplicate record with the same visit date exists in the legacy submissions "
+        "for this participant/module"
+    ),
 }
 
 

--- a/common/src/python/preprocess/preprocessor.py
+++ b/common/src/python/preprocess/preprocessor.py
@@ -536,6 +536,38 @@ class FormPreprocessor:
 
         return True
 
+    def __check_duplicate_legacy_record(self, pp_context: PreprocessingContext) -> bool:
+        """Check for a legacy record with the same visit date.
+
+        Args:
+            pp_context: preprocessing context
+
+        Returns:
+            bool: False, if a conflicting record found
+        """
+        assert pp_context.subject_lbl, "pp_context.subject_lbl required"
+
+        subject_lbl = pp_context.subject_lbl
+        input_record = pp_context.input_record
+        date_field = self.__module_configs.date_field
+
+        date_matches = self.__forms_store.query_form_data(
+            subject_lbl=subject_lbl,
+            module=self.__module,
+            legacy=True,
+            search_col=date_field,
+            search_val=input_record[date_field],
+            search_op="=",
+        )
+
+        if date_matches:
+            self.__error_handler.write_date_error(
+                pp_context=pp_context, error_code=SysErrorCodes.DUPLICATE_LEGACY_VISIT
+            )
+            return False
+
+        return True
+
     def _check_udsv4_initial_visit(self, pp_context: PreprocessingContext) -> bool:
         """Validate UDSv4 I4 packet requirements.
 
@@ -652,9 +684,13 @@ class FormPreprocessor:
         Returns:
             bool: False if conflict found
         """
-        return self.__check_visitdate_visitnum(
-            pp_context
-        ) and self.__check_visitnum_visitdate(pp_context)
+
+        if FieldNames.VISITNUM in self.__module_configs.required_fields:
+            return self.__check_visitdate_visitnum(
+                pp_context
+            ) and self.__check_visitnum_visitdate(pp_context)
+
+        return self.__check_duplicate_legacy_record(pp_context)
 
     def _check_supplement_module(self, pp_context: PreprocessingContext) -> bool:
         """Check whether a matching supplement module found.

--- a/gear/form_transformer/data/form-data-module-configs.json
+++ b/gear/form_transformer/data/form-data-module-configs.json
@@ -277,6 +277,7 @@
                 "duplicate-record",
                 "version",
                 "packet",
+                "visit-conflict",
                 "clinical-forms"
             ],
             "longitudinal": false
@@ -406,6 +407,7 @@
             "preprocess_checks": [
                 "duplicate-record",
                 "version",
+                "visit-conflict",
                 "supplement-module"
             ],
             "longitudinal": false


### PR DESCRIPTION
Add a new pre-processing check to prevent legacy milestone forms being resubmitted to ingest form projects