### PR TITLE
Refactor form transformations

### DIFF
--- a/common/src/python/transform/transformer.py
+++ b/common/src/python/transform/transformer.py
@@ -2,9 +2,9 @@
 
 import logging
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Optional, Set, Union
+from typing import Any, Dict, List, Literal, Optional, Set
 
-from configs.ingest_configs import FormReleaseDates
+from configs.ingest_configs import ModuleConfigs
 from keys.keys import SysErrorCodes
 from nacc_common.data_identification import (
     DataIdentification,
@@ -37,8 +37,8 @@ class VersionMap(BaseModel):
         return self.default
 
 
-class FieldFilter(BaseModel, ABC):
-    """Base class for filters that drop fields from an input record."""
+class Transformation(BaseModel, ABC):
+    """Base class for transformations applied to an input record."""
 
     nofill: bool = True
 
@@ -48,26 +48,35 @@ class FieldFilter(BaseModel, ABC):
         input_record: Dict[str, Any],
         error_writer: ErrorWriter,
         line_num: int,
-        date_field: str,
-        release_dates: Optional[FormReleaseDates] = None,
+        module_configs: ModuleConfigs,
     ) -> Optional[Dict[str, Any]]:
-        """Filters the input record by dropping fields.
+        """Applies this transformation to the input record.
 
         Args:
-          input_record: the record to filter
+          input_record: the record to transform
           error_writer: error metadata writer
           line_num: line number in the input CSV
-          date_field: date field name for the module
-          release_dates: per-packet form release date configs for the module
+          module_configs: form ingest configs for the module
 
         Returns:
-          the input_record without the dropped fields, or None on error
+          the transformed input_record, or None on error
         """
 
 
-class VersionMapFilter(FieldFilter):
+class FieldTransformation(Transformation, ABC):
+    """Base class for transformations that drop individual fields from an input
+    record."""
+
+
+class FormTransformation(Transformation, ABC):
+    """Base class for transformations that remove an entire form from an input
+    record."""
+
+
+class VersionMapTransformation(FieldTransformation):
     """Defines a map of form field names for different versions of the form."""
 
+    transform_type: Literal["version_map"] = "version_map"
     version_map: VersionMap
     fields: Dict[str, List[str]] = {}
 
@@ -87,8 +96,7 @@ class VersionMapFilter(FieldFilter):
         input_record: Dict[str, Any],
         error_writer: ErrorWriter,
         line_num: int,
-        date_field: str,
-        release_dates: Optional[FormReleaseDates] = None,
+        module_configs: ModuleConfigs,
     ) -> Optional[Dict[str, Any]]:
         """Filters the input record by dropping the key-value pairs for fields
         unique to the version.
@@ -97,12 +105,12 @@ class VersionMapFilter(FieldFilter):
           input_record: the record to filter
           error_writer: error metadata writer
           line_num: line number in the input CSV
-          date_field: date field name for the module
-          release_dates: unused; accepted for interface compatibility
+          module_configs: form ingest configs for the module
 
         Returns:
           the input_record without the keys for the excluded fields or None
         """
+        date_field = module_configs.date_field
         version_name = self.version_map.apply(input_record)
         drop_fields = self.__unique_fields(version_name)
         if not drop_fields:
@@ -139,7 +147,7 @@ class VersionMapFilter(FieldFilter):
         return transformed
 
 
-class ReleaseDateFilter(FieldFilter):
+class ReleaseDateTransformation(FormTransformation):
     """Drops fields for a form not yet released for the visit and not
     submitted: when visit date < the form's release date and the mode field
     value is not one of retain_modes, the data fields, header fields, and the
@@ -153,6 +161,7 @@ class ReleaseDateFilter(FieldFilter):
     the record rejected (header fields are exempt from this check).
     """
 
+    transform_type: Literal["release_date"] = "release_date"
     form_name: str
     retain_modes: List[str] = ["1"]
     header_fields: List[str] = []
@@ -163,8 +172,7 @@ class ReleaseDateFilter(FieldFilter):
         input_record: Dict[str, Any],
         error_writer: ErrorWriter,
         line_num: int,
-        date_field: str,
-        release_dates: Optional[FormReleaseDates] = None,
+        module_configs: ModuleConfigs,
     ) -> Optional[Dict[str, Any]]:
         """Drops the form fields when the visit predates the form release date
         and the form was not submitted.
@@ -173,14 +181,15 @@ class ReleaseDateFilter(FieldFilter):
           input_record: the record to filter
           error_writer: error metadata writer
           line_num: line number in the input CSV
-          date_field: date field name for the module
-          release_dates: per-packet form release date configs for the module
+          module_configs: form ingest configs for the module
 
         Returns:
           the record without the dropped fields, the record unchanged if the
           drop condition is not met, or None if data fields are incorrectly
           filled
         """
+        date_field = module_configs.date_field
+        release_dates = module_configs.release_dates
         if not release_dates:
             # no release config; treat the form as already released
             return input_record
@@ -227,51 +236,37 @@ class ReleaseDateFilter(FieldFilter):
         }
 
 
-FieldFilterType = Union[VersionMapFilter, ReleaseDateFilter]
+# Single member per category for now; the transform_type Literal tag makes
+# extension trivial. To add a second type in a category, switch to a
+# discriminated union, e.g.:
+#   FieldTransformationType = Annotated[
+#       Union[VersionMapTransformation, NewFieldTransformation],
+#       Field(discriminator="transform_type")]
+FieldTransformationType = VersionMapTransformation
+FormTransformationType = ReleaseDateTransformation
 
 
-class FieldTransformations(RootModel):
-    """Root model for the form field schema."""
+class ModuleTransformations(BaseModel):
+    """Groups the transformations for a module by category."""
 
-    root: Dict[ModuleName, List[FieldFilterType]] = {}
+    field_transformations: List[FieldTransformationType] = []
+    form_transformations: List[FormTransformationType] = []
 
-    def __getitem__(self, key: ModuleName) -> List[FieldFilterType]:
-        """Returns the FormField schema for the module.
+
+class TransformationSchema(RootModel):
+    """Root model for the per-module transformation schema."""
+
+    root: Dict[ModuleName, ModuleTransformations] = {}
+
+    def get(self, key: ModuleName) -> Optional[ModuleTransformations]:
+        """Returns the transformations for the module, or None if not defined.
 
         Args:
           key: the module name
         Returns:
-          the FormFields object for the module
+          the ModuleTransformations for the module, or None
         """
-        return self.root[key]
-
-    def get(
-        self,
-        key: ModuleName,
-        default: List[FieldFilterType] = [],  # noqa: B006
-    ) -> List[FieldFilterType]:
-        return self.root.get(key, default)
-
-    def __setitem__(self, key: ModuleName, value: List[FieldFilterType]) -> None:
-        """Sets the form field schema for a module.
-
-        Args:
-          key: the module name
-          value: the form fields object
-        """
-        self.root[key] = value
-
-    def add(self, key: ModuleName, value: FieldFilterType) -> None:
-        """Adds the filter to the filters for the module name.
-
-        Args:
-          key: the module name
-          value: the field filter
-        """
-        if key not in self.root:
-            self.root[key] = []
-
-        self.root[key].append(value)
+        return self.root.get(key)
 
 
 class BaseRecordTransformer(ABC):
@@ -373,24 +368,22 @@ class DateTransformer(BaseRecordTransformer):
 
 
 class FilterTransformer(BaseRecordTransformer):
-    """Defines a transform that applies a field filter to a record."""
+    """Defines a transform that applies a single transformation to a record."""
 
     def __init__(
         self,
-        field_filter: FieldFilter,
+        transformation: Transformation,
         error_writer: ErrorWriter,
-        date_field: Optional[str] = None,
-        release_dates: Optional[FormReleaseDates] = None,
+        module_configs: ModuleConfigs,
     ) -> None:
-        self._transform = field_filter
+        self._transform = transformation
         self._error_writer = error_writer
-        self._date_field = date_field if date_field else FieldNames.DATE_COLUMN
-        self._release_dates = release_dates
+        self._module_configs = module_configs
 
     def transform(
         self, input_record: Dict[str, Any], line_num: int
     ) -> Optional[Dict[str, Any]]:
-        """Applies the FieldFilter to the input record.
+        """Applies the transformation to the input record.
 
         Args:
           input_record: the input record
@@ -403,21 +396,19 @@ class FilterTransformer(BaseRecordTransformer):
             input_record=input_record,
             error_writer=self._error_writer,
             line_num=line_num,
-            date_field=self._date_field,
-            release_dates=self._release_dates,
+            module_configs=self._module_configs,
         )
 
 
 class TransformerFactory:
-    def __init__(self, transformations: FieldTransformations) -> None:
+    def __init__(self, transformations: TransformationSchema) -> None:
         self.__transformations = transformations
 
     def create(
         self,
         module: Optional[str],
-        date_field: Optional[str],
         error_writer: ErrorWriter,
-        release_dates: Optional[FormReleaseDates] = None,
+        module_configs: ModuleConfigs,
     ) -> RecordTransformer:
         """Creates a transformer for the module using the transformations in
         this object.
@@ -427,22 +418,25 @@ class TransformerFactory:
 
         Args:
           module: the module name
-          date_field: date field name for the module
           error_writer: error metadata writer
-          release_dates: per-packet form release date configs for the module
+          module_configs: form ingest configs for the module
 
         Returns:
           the record transformer
         """
         transformer_list: List[BaseRecordTransformer] = []
-        transformer_list.append(DateTransformer(error_writer, date_field=date_field))
+        transformer_list.append(
+            DateTransformer(error_writer, date_field=module_configs.date_field)
+        )
         if module:
-            filter_list = self.__transformations.get(module)
-            for field_filter in filter_list:
-                transformer_list.append(
-                    FilterTransformer(
-                        field_filter, error_writer, date_field, release_dates
+            module_transforms = self.__transformations.get(module)
+            if module_transforms:
+                for transformation in (
+                    *module_transforms.field_transformations,
+                    *module_transforms.form_transformations,
+                ):
+                    transformer_list.append(
+                        FilterTransformer(transformation, error_writer, module_configs)
                     )
-                )
 
         return RecordTransformer(transformer_list)

--- a/common/test/python/transform/test_transformer.py
+++ b/common/test/python/transform/test_transformer.py
@@ -65,7 +65,8 @@ class TestVersionMapTransformation:
         error_writer = ListErrorWriter(container_id="dummy", fw_path="dummy/dummy")
         record = field_filter.apply(input_record, error_writer, 1, uds_ingest_configs())
         assert record
-        assert [k for k in record if k in input_record and k not in ["b1", "b2"]]
+        assert "b1" not in record and "b2" not in record
+        assert set(record.keys()) == {"dummy", "common1", "common2", "a1", "a2"}
 
     def test_drop_fields_nofill_true(self):
         field_filter = VersionMapTransformation(

--- a/common/test/python/transform/test_transformer.py
+++ b/common/test/python/transform/test_transformer.py
@@ -4,12 +4,13 @@ from configs.ingest_configs import FormReleaseDates
 from keys.keys import SysErrorCodes
 from nacc_common.field_names import FieldNames
 from outputs.error_writer import ListErrorWriter
+from test_mocks.mock_configs import uds_ingest_configs
 from transform.transformer import (
     DateTransformer,
-    FieldTransformations,
-    ReleaseDateFilter,
+    ReleaseDateTransformation,
+    TransformationSchema,
     VersionMap,
-    VersionMapFilter,
+    VersionMapTransformation,
 )
 
 
@@ -29,9 +30,9 @@ class TestVersionMap:
     # TODO: should not having the fieldname as a key be an error?
 
 
-class TestFieldFilter:
+class TestVersionMapTransformation:
     def test_empty_fields(self):
-        field_filter = VersionMapFilter(
+        field_filter = VersionMapTransformation(
             version_map=VersionMap(
                 fieldname="dummy", value_map={"alpha-raw": "beta"}, default="alpha"
             ),
@@ -41,12 +42,12 @@ class TestFieldFilter:
             "dummy": "alpha-raw",
         }
         error_writer = ListErrorWriter(container_id="dummy", fw_path="dummy/dummy")
-        record = field_filter.apply(input_record, error_writer, 1, "visitdate")
+        record = field_filter.apply(input_record, error_writer, 1, uds_ingest_configs())
 
         assert record == input_record
 
     def test_drop_fields(self):
-        field_filter = VersionMapFilter(
+        field_filter = VersionMapTransformation(
             version_map=VersionMap(
                 fieldname="dummy", value_map={"alpha-raw": "beta"}, default="alpha"
             ),
@@ -62,12 +63,12 @@ class TestFieldFilter:
             "b2": "",
         }
         error_writer = ListErrorWriter(container_id="dummy", fw_path="dummy/dummy")
-        record = field_filter.apply(input_record, error_writer, 1, "visitdate")
+        record = field_filter.apply(input_record, error_writer, 1, uds_ingest_configs())
         assert record
         assert [k for k in record if k in input_record and k not in ["b1", "b2"]]
 
     def test_drop_fields_nofill_true(self):
-        field_filter = VersionMapFilter(
+        field_filter = VersionMapTransformation(
             version_map=VersionMap(
                 fieldname="dummy", value_map={"alpha-raw": "beta"}, default="alpha"
             ),
@@ -82,12 +83,12 @@ class TestFieldFilter:
             "b1": "b1-val",
         }
         error_writer = ListErrorWriter(container_id="dummy", fw_path="dummy/dummy")
-        record = field_filter.apply(input_record, error_writer, 1, "visitdate")
+        record = field_filter.apply(input_record, error_writer, 1, uds_ingest_configs())
 
         assert not record
 
     def test_diff_fields_nofill_false(self):
-        field_filter = VersionMapFilter(
+        field_filter = VersionMapTransformation(
             version_map=VersionMap(
                 fieldname="dummy", value_map={"alpha-raw": "beta"}, default="alpha"
             ),
@@ -102,7 +103,7 @@ class TestFieldFilter:
             "b1": "b1-val",
         }
         error_writer = ListErrorWriter(container_id="dummy", fw_path="dummy/dummy")
-        record = field_filter.apply(input_record, error_writer, 1, "visitdate")
+        record = field_filter.apply(input_record, error_writer, 1, uds_ingest_configs())
 
         assert record
         assert [k for k in record if k in input_record and k != "b1"]
@@ -133,12 +134,12 @@ class TestDateTransformer:
         assert not record
 
 
-class TestReleaseDateFilter:
+class TestReleaseDateTransformation:
     RELEASE_DATES = FormReleaseDates({"I": {"d1c": "2026-05-01"}})
 
     @staticmethod
-    def __filter() -> ReleaseDateFilter:
-        return ReleaseDateFilter(
+    def __filter() -> ReleaseDateTransformation:
+        return ReleaseDateTransformation(
             form_name="d1c",
             fields=["d1c1", "d1c2"],
             header_fields=["frmdated1c"],
@@ -150,12 +151,14 @@ class TestReleaseDateFilter:
         return ListErrorWriter(container_id="dummy", fw_path="dummy/dummy")
 
     def __apply(self, release_filter, input_record, error_writer=None):
+        module_configs = uds_ingest_configs().model_copy(
+            update={"release_dates": self.RELEASE_DATES}
+        )
         return release_filter.apply(
             input_record,
             error_writer or self.__error_writer(),
             1,
-            "visitdate",
-            self.RELEASE_DATES,
+            module_configs,
         )
 
     def test_before_release_not_submitted_empty(self):
@@ -222,7 +225,7 @@ class TestReleaseDateFilter:
 
         fields dropped, no error.
         """
-        release_filter = ReleaseDateFilter(
+        release_filter = ReleaseDateTransformation(
             form_name="d1c",
             fields=["d1c1", "d1c2"],
             nofill=False,
@@ -333,39 +336,60 @@ class TestReleaseDateFilter:
             "moded1c": "0",
             "d1c1": "some-value",
         }
+        module_configs = uds_ingest_configs().model_copy(
+            update={
+                "release_dates": FormReleaseDates({"I": {"otherform": "2026-05-01"}})
+            }
+        )
         record = release_filter.apply(
             input_record,
             self.__error_writer(),
             1,
-            "visitdate",
-            FormReleaseDates({"I": {"otherform": "2026-05-01"}}),
+            module_configs,
         )
         assert record == input_record
 
 
-class TestFieldTransformations:
-    def test_mixed_filter_union(self):
-        """A module list containing both filter types parses to the correct
-        concrete subclasses."""
+class TestTransformationSchema:
+    def test_grouped_transformations(self):
+        """A module with both categories parses to the correct concrete
+        transformation subclasses in each category list."""
         schema = {
-            "UDS": [
-                {
-                    "version_map": {
-                        "fieldname": "packet",
-                        "value_map": {"F": "IVP"},
-                        "default": "FVP",
-                    },
-                    "fields": {"FVP": ["newinf"], "IVP": ["birthmo"]},
-                },
-                {
-                    "form_name": "d1c",
-                    "fields": ["d1c1"],
-                    "header_fields": ["frmdated1c"],
-                },
-            ]
+            "UDS": {
+                "field_transformations": [
+                    {
+                        "transform_type": "version_map",
+                        "version_map": {
+                            "fieldname": "packet",
+                            "value_map": {"F": "IVP"},
+                            "default": "FVP",
+                        },
+                        "fields": {"FVP": ["newinf"], "IVP": ["birthmo"]},
+                    }
+                ],
+                "form_transformations": [
+                    {
+                        "transform_type": "release_date",
+                        "form_name": "d1c",
+                        "fields": ["d1c1"],
+                        "header_fields": ["frmdated1c"],
+                    }
+                ],
+            }
         }
-        transformations = FieldTransformations.model_validate_json(json.dumps(schema))
-        filters = transformations.get("UDS")
-        assert len(filters) == 2
-        assert isinstance(filters[0], VersionMapFilter)
-        assert isinstance(filters[1], ReleaseDateFilter)
+        transformations = TransformationSchema.model_validate_json(json.dumps(schema))
+        module_transforms = transformations.get("UDS")
+        assert module_transforms
+        assert len(module_transforms.field_transformations) == 1
+        assert len(module_transforms.form_transformations) == 1
+        assert isinstance(
+            module_transforms.field_transformations[0], VersionMapTransformation
+        )
+        assert isinstance(
+            module_transforms.form_transformations[0], ReleaseDateTransformation
+        )
+
+    def test_unknown_module_returns_none(self):
+        """get() returns None for a module with no transformations."""
+        transformations = TransformationSchema()
+        assert transformations.get("UDS") is None

--- a/docs/form_transformer/index.md
+++ b/docs/form_transformer/index.md
@@ -16,17 +16,45 @@ After processing, the gear updates the input CSV file with the following metadat
 
 2. **File Tag**: The gear name (e.g., `"form-transformer"`) is added as a simple tag to the input file, indicating the file has been processed by this gear.
 
-Current transformations filter columns based on the versions of forms.
-Data from the NACC REDCap projects will contain rows for all versions of forms, and the transformations filter out the columns specific to the versions not used.
+## Transformations
 
-The transformation file should contain a JSON object with module names as the key values.
-Each module is associated with a list of field filters, which determine the fields to be filtered for the module version.
+The transformation file contains a JSON object with module names as the keys.
+Each module maps to an object that groups its transformations into two
+categories:
 
-Each field filter is used to determine the fields to be filtered based on the module version.
-It consists of an object indicating how to determine the version of the module to exclude.
+- **`field_transformations`** — transformations that drop individual columns
+  from a record (e.g. filtering out fields for the form versions not in use).
+- **`form_transformations`** — transformations that remove an entire form from
+  a record (e.g. dropping a form that has not yet been released for a visit).
+
+Every transformation object carries a `transform_type` tag identifying its
+type, which allows new transformation types to be added under either category
+in the future.
 
 ```json
-{ 
+{
+    "UDS": {
+        "field_transformations": [ /* ... */ ],
+        "form_transformations": [ /* ... */ ]
+    }
+}
+```
+
+If `nofill` is set to `true` on a transformation, the fields it would drop must
+be empty; otherwise the record is rejected with an error.
+
+### Field transformations
+
+#### `version_map`
+
+Data from the NACC REDCap projects contains rows with columns for all versions
+of a form. A `version_map` transformation filters out the columns specific to
+the versions not used.
+
+It includes an object indicating how to determine the version of the module:
+
+```json
+{
     "fieldname": "indicator-field",
     "value_map": { "indicator-value": "version1" },
     "default": "version2"
@@ -35,43 +63,77 @@ It consists of an object indicating how to determine the version of the module t
 
 This information is used to determine which fields to exclude:
 
-    - if the value of the `indicator-field` is `indicator-value`, exclude fields for `version1`
-    - otherwise, exclude fields for `version2`
+- if the value of the `indicator-field` is `indicator-value`, exclude fields for `version1`
+- otherwise, exclude fields for `version2`
 
-A field filter also includes the full lists of fields for each version of the module.
-If `nofill` set to `true` exclude fields must be empty
+The transformation also includes the full lists of fields for each version of
+the module under `fields`.
 
-This (partial) example shows field filters for the C2 forms of UDS and the version of the LBD module.
+### Form transformations
+
+#### `release_date`
+
+A `release_date` transformation removes an entire form from a record when the
+form has not yet been released for that visit and was not submitted. When the
+visit date is before the form's release date and the mode field value is not
+one of `retain_modes`, the form's data fields, `header_fields`, and mode field
+(derived as `mode` + `form_name`) are all removed.
+
+The release date is looked up by `form_name` from the module's release date
+configuration; a form with no configured release date is treated as already
+released. When `nofill` is `true`, if any data field is non-empty the record is
+rejected (header fields are exempt from this check).
+
+### Example
+
+This (partial) example shows a `version_map` field transformation and a
+`release_date` form transformation for UDS, and a `version_map` for LBD.
 
 ```json
 {
-    "UDS": [
-        {
-            "version_map": { 
-                "fieldname": "rmmodec2c2t",
-                "value_map": { "1": "C2" },
-                "default": "C2T"
-            },
-            "fields": {
-                "C2": [],
-                "C2T": []
-            },
-            "nofill": true
-        }
-    ],
-    "LBD": [
-        {
-            "version_map": {
-                "fieldname": "formver",
-                "value_map": { "3.1": "v3.0" },
-                "default": "v3.1"
-            },
-            "fields": {
-                "v3.0": [],
-                "v3.1": []
-            },
-            "nofill": true
-        }
-    ]
+    "UDS": {
+        "field_transformations": [
+            {
+                "transform_type": "version_map",
+                "version_map": {
+                    "fieldname": "rmmodec2c2t",
+                    "value_map": { "1": "C2" },
+                    "default": "C2T"
+                },
+                "fields": {
+                    "C2": [],
+                    "C2T": []
+                },
+                "nofill": true
+            }
+        ],
+        "form_transformations": [
+            {
+                "transform_type": "release_date",
+                "form_name": "d1c",
+                "retain_modes": ["1"],
+                "header_fields": ["frmdated1c", "initialsd1c", "langd1c", "d1cnot"],
+                "fields": [],
+                "nofill": true
+            }
+        ]
+    },
+    "LBD": {
+        "field_transformations": [
+            {
+                "transform_type": "version_map",
+                "version_map": {
+                    "fieldname": "formver",
+                    "value_map": { "3.1": "v3.0" },
+                    "default": "v3.1"
+                },
+                "fields": {
+                    "v3.0": [],
+                    "v3.1": []
+                },
+                "nofill": true
+            }
+        ]
+    }
 }
 ```

--- a/docs/form_transformer/index.md
+++ b/docs/form_transformer/index.md
@@ -137,3 +137,4 @@ This (partial) example shows a `version_map` field transformation and a
     }
 }
 ```
+

--- a/gear/form_transformer/data/transformation-schemas.json
+++ b/gear/form_transformer/data/transformation-schemas.json
@@ -1,46 +1,55 @@
 {
-    "UDS": [
-        {
-            "version_map": {
-                "fieldname": "rmmodec2c2t",
-                "value_map": {
-                    "1": "C2"
+    "UDS": {
+        "field_transformations": [
+            {
+                "transform_type": "version_map",
+                "version_map": {
+                    "fieldname": "rmmodec2c2t",
+                    "value_map": {
+                        "1": "C2"
+                    },
+                    "default": "C2T"
                 },
-                "default": "C2T"
-            },
-            "fields": {
-                "C2": [],
-                "C2T": []
-            },
-            "nofill": true
-        },
-        {
-            "form_name": "d1c",
-            "retain_modes": ["1"],
-            "header_fields": [
-                "frmdated1c",
-                "initialsd1c",
-                "langd1c",
-                "d1cnot"
-            ],
-            "fields": [],
-            "nofill": true
-        }
-    ],
-    "LBD": [
-        {
-            "version_map": {
-                "fieldname": "formver",
-                "value_map": {
-                    "3.1": "v3.0"
+                "fields": {
+                    "C2": [],
+                    "C2T": []
                 },
-                "default": "v3.1"
-            },
-            "fields": {
-                "v3.0": [],
-                "v3.1": []
-            },
-            "nofill": true
-        }
-    ]
+                "nofill": true
+            }
+        ],
+        "form_transformations": [
+            {
+                "transform_type": "release_date",
+                "form_name": "d1c",
+                "retain_modes": ["1"],
+                "header_fields": [
+                    "frmdated1c",
+                    "initialsd1c",
+                    "langd1c",
+                    "d1cnot"
+                ],
+                "fields": [],
+                "nofill": true
+            }
+        ]
+    },
+    "LBD": {
+        "field_transformations": [
+            {
+                "transform_type": "version_map",
+                "version_map": {
+                    "fieldname": "formver",
+                    "value_map": {
+                        "3.1": "v3.0"
+                    },
+                    "default": "v3.1"
+                },
+                "fields": {
+                    "v3.0": [],
+                    "v3.1": []
+                },
+                "nofill": true
+            }
+        ]
+    }
 }

--- a/gear/form_transformer/src/docker/manifest.json
+++ b/gear/form_transformer/src/docker/manifest.json
@@ -45,7 +45,7 @@
       }
     },
     "transform_file": {
-      "description": "A JSON file with transform data",
+      "description": "A JSON file mapping each module to its transformations",
       "base": "file",
       "optional": true,
       "type": {

--- a/gear/form_transformer/src/python/form_csv_app/main.py
+++ b/gear/form_transformer/src/python/form_csv_app/main.py
@@ -264,12 +264,13 @@ class CSVTransformVisitor(CSVVisitor):
                     in self.__module_configs.preprocess_checks
                     and FieldNames.VISITNUM in self.__module_configs.required_fields
                 ):
-                    is_ivp = (
-                        transformed_row[FieldNames.PACKET]
-                        in self.__module_configs.initial_packets
-                    )
-                    visit_num = transformed_row[FieldNames.VISITNUM]
+                    if FieldNames.PACKET in self.__module_configs.required_fields:
+                        is_ivp = (
+                            transformed_row[FieldNames.PACKET]
+                            in self.__module_configs.initial_packets
+                        )
 
+                    visit_num = transformed_row[FieldNames.VISITNUM]
                     # check the validity of visit numbers within current batch
                     if visit_num not in prev_visit_nums:
                         prev_visit_nums.append(visit_num)

--- a/gear/form_transformer/src/python/form_csv_app/main.py
+++ b/gear/form_transformer/src/python/form_csv_app/main.py
@@ -162,9 +162,8 @@ class CSVTransformVisitor(CSVVisitor):
         if not self.__transformer:
             self.__transformer = self.__transformer_factory.create(
                 self.__module,
-                self.__date_field,
                 self.__error_writer,
-                self.__module_configs.release_dates,
+                self.__module_configs,
             )
 
         transformed_row = self.__transformer.transform(row, line_num)

--- a/gear/form_transformer/src/python/form_csv_app/run.py
+++ b/gear/form_transformer/src/python/form_csv_app/run.py
@@ -24,7 +24,7 @@ from keys.keys import DefaultValues
 from outputs.error_writer import ErrorWriter, ListErrorWriter
 from preprocess.preprocessor import FormPreprocessor
 from pydantic import ValidationError
-from transform.transformer import FieldTransformations, TransformerFactory
+from transform.transformer import TransformationSchema, TransformerFactory
 from utils.utils import parse_string_to_list
 
 from form_csv_app.main import run
@@ -183,7 +183,7 @@ class FormCSVtoJSONTransformer(GearExecutionEnvironment):
         """Loads the transformation file and creates a transformer factory.
 
         If the input is None, returns a factory for empty transformations.
-        Otherwise, loads the file as a FileTransformations object and creates
+        Otherwise, loads the file as a TransformationSchema object and creates
         a factory using those.
 
         Args:
@@ -193,14 +193,14 @@ class FormCSVtoJSONTransformer(GearExecutionEnvironment):
           the TransformerFactory for the input
         """
         if not transformer_input:
-            return TransformerFactory(FieldTransformations())
+            return TransformerFactory(TransformationSchema())
 
         with open(
             transformer_input.filepath, mode="r", encoding="utf-8-sig"
         ) as json_file:
             try:
                 return TransformerFactory(
-                    FieldTransformations.model_validate_json(json_file.read())
+                    TransformationSchema.model_validate_json(json_file.read())
                 )
             except ValidationError as error:
                 raise GearExecutionError(

--- a/gear/form_transformer/test/python/test_milestones_transform.py
+++ b/gear/form_transformer/test/python/test_milestones_transform.py
@@ -16,7 +16,7 @@ from test_mocks.mock_configs import milestone_ingest_configs
 from test_mocks.mock_flywheel import MockProjectAdaptor
 from test_mocks.mock_forms_store import MockFormsStore
 from transform.transformer import (
-    FieldTransformations,
+    TransformationSchema,
     TransformerFactory,
 )
 
@@ -48,10 +48,10 @@ def create_mlst_visitor(
     # transformer
     if transform_schema:
         transformer_factory = TransformerFactory(
-            FieldTransformations.model_validate_json(json.dumps(transform_schema))
+            TransformationSchema.model_validate_json(json.dumps(transform_schema))
         )
     else:
-        transformer_factory = TransformerFactory(FieldTransformations())
+        transformer_factory = TransformerFactory(TransformationSchema())
 
     form_store = MockFormsStore(date_field=date_field)
     project = MockProjectAdaptor(label="mlst-project")

--- a/gear/form_transformer/test/python/test_uds_transform.py
+++ b/gear/form_transformer/test/python/test_uds_transform.py
@@ -20,7 +20,7 @@ from test_mocks.mock_configs import uds_ingest_configs
 from test_mocks.mock_flywheel import MockProjectAdaptor
 from test_mocks.mock_forms_store import MockFormsStore
 from transform.transformer import (
-    FieldTransformations,
+    TransformationSchema,
     TransformerFactory,
 )
 
@@ -56,10 +56,10 @@ def create_uds_visitor(
     # transformer
     if transform_schema:
         transformer_factory = TransformerFactory(
-            FieldTransformations.model_validate_json(json.dumps(transform_schema))
+            TransformationSchema.model_validate_json(json.dumps(transform_schema))
         )
     else:
-        transformer_factory = TransformerFactory(FieldTransformations())
+        transformer_factory = TransformerFactory(TransformationSchema())
 
     # just use UDS for testing
     module_configs = uds_ingest_configs()
@@ -208,17 +208,20 @@ class TestUDSTransform:
         """Test bad transform - does a simple one just to check
         the errors."""
         schema = {
-            "UDS": [
-                {
-                    "version_map": {
-                        "fieldname": "transform",
-                        "value_map": {"1": "do_transform"},
-                        "default": "no_transform",
-                    },
-                    "nofill": True,
-                    "fields": {"do_transform": ["bad1", "bad2", "bad3"]},
-                }
-            ]
+            "UDS": {
+                "field_transformations": [
+                    {
+                        "transform_type": "version_map",
+                        "version_map": {
+                            "fieldname": "transform",
+                            "value_map": {"1": "do_transform"},
+                            "default": "no_transform",
+                        },
+                        "nofill": True,
+                        "fields": {"do_transform": ["bad1", "bad2", "bad3"]},
+                    }
+                ]
+            }
         }
         visitor, project, _ = create_uds_visitor(transform_schema=schema)
         record = create_record(


### PR DESCRIPTION
**Refactor form transformation schema into separated, categorized types**
The transformation schema mixed two conceptually different transforms in a single flat list per module, relying on Pydantic's fragile "smart-mode" union guessing to tell them apart. This PR restructures both the JSON schema and the processing code so transform types are cleanly separated by category, explicitly tagged, and given consistent domain terminology.

**Changes**
Each module now maps to { field_transformations: [...], form_transformations: [...] } — distinct category lists reflecting scope (field-level filtering vs. whole-form removal).
Every entry carries a transform_type tag ("version_map" / "release_date"), enabling new types per category via a discriminated union later.

Renamed *Filter → *Transformation; added a Transformation base plus FieldTransformation / FormTransformation category ABCs.
Replaced the Dict[module, List[union]] root with TransformationSchema → ModuleTransformations container.
TransformerFactory.create() and Transformation.apply() now take a single ModuleConfigs context object instead of separate date_field / release_dates args; each subclass pulls what it needs. FilterTransformer retained as the pipeline adapter.

Unit + gear tests updated for the new class names, grouped schema, and ModuleConfigs context (reusing the uds_ingest_configs() mock).