### PR TITLE
fix(pull-directory): compute dateRangeBegin in REDCap server timezone

### DIFF
--- a/docs/pull_directory/CHANGELOG.md
+++ b/docs/pull_directory/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this gear are documented in this file.
 
+## 4.1.3
+
+* Fixes timezone mismatch in incremental pull date range computation
+* Computes `dateRangeBegin` in America/Los_Angeles (Pacific) to match the REDCap server's PHP timezone configuration
+* Drops `dateRangeEnd` parameter, letting REDCap use its own server time as the upper bound
+* Previously the gear used container-local time, which could produce a query window in the wrong time range and return zero records
+
 ## 4.1.2
 
 * Skips writing the user file when no valid user entries are produced, preventing user-management from being triggered on empty incremental pulls

--- a/gear/pull_directory/src/docker/BUILD
+++ b/gear/pull_directory/src/docker/BUILD
@@ -4,5 +4,5 @@ docker_image(
     name="pull-directory",
     source="Dockerfile",
     dependencies=[":manifest", "gear/pull_directory/src/python/directory_app:bin"],
-    image_tags=["4.1.2", "latest"],
+    image_tags=["4.1.3", "latest"],
 )

--- a/gear/pull_directory/src/docker/manifest.json
+++ b/gear/pull_directory/src/docker/manifest.json
@@ -2,7 +2,7 @@
   "name": "pull-directory",
   "label": "Pull Directory",
   "description": "Pull user information from NACC directory and save to admin project",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "author": "NACC",
   "maintainer": "NACC <nacchelp@uw.edu>",
   "cite": "",
@@ -15,7 +15,7 @@
   "custom": {
     "gear-builder": {
       "category": "utility",
-      "image": "naccdata/pull-directory:4.1.2"
+      "image": "naccdata/pull-directory:4.1.3"
     },
     "flywheel": {
       "suite": "NACC Admin Gears",

--- a/gear/pull_directory/src/python/directory_app/config.py
+++ b/gear/pull_directory/src/python/directory_app/config.py
@@ -1,9 +1,14 @@
 """Configuration handling for the pull-directory gear."""
 
 from datetime import datetime, timedelta
-from typing import Optional, Tuple
+from typing import Optional
+from zoneinfo import ZoneInfo
 
 from pydantic import BaseModel, Field, field_validator
+
+# REDCap server timezone — PHP is configured with
+# date.timezone = America/Los_Angeles
+REDCAP_SERVER_TIMEZONE = ZoneInfo("America/Los_Angeles")
 
 
 class TimeWindowConfig(BaseModel):
@@ -22,27 +27,29 @@ class TimeWindowConfig(BaseModel):
             raise ValueError("threshold must be non-negative")
         return value
 
-    def get_date_range(
-        self, now: Optional[datetime] = None
-    ) -> Optional[Tuple[str, str]]:
-        """Compute (dateRangeBegin, dateRangeEnd) or None if no filtering.
+    def get_date_range_begin(self, now: Optional[datetime] = None) -> Optional[str]:
+        """Compute dateRangeBegin in REDCap server time, or None if no
+        filtering.
+
+        Returns only the begin timestamp. The end is intentionally omitted
+        so that REDCap uses its own server time as the upper bound.
+
+        The timestamp is computed in America/Los_Angeles (Pacific) to match
+        the REDCap server's PHP timezone configuration.
 
         Args:
-            now: Reference time for computing the range. Defaults to
-                datetime.now() if not provided.
+            now: Reference time for computing the range. Defaults to the
+                current time in the REDCap server timezone.
 
         Returns:
-            A tuple of (begin, end) formatted as "YYYY-MM-DD HH:MM:SS",
-            or None when threshold is 0.
+            The begin timestamp formatted as "YYYY-MM-DD HH:MM:SS" in
+            REDCap server time, or None when threshold is 0 (full pull).
         """
         if self.threshold == 0:
             return None
 
         if now is None:
-            now = datetime.now()
+            now = datetime.now(REDCAP_SERVER_TIMEZONE)
 
         begin = now - timedelta(hours=self.threshold)
-        return (
-            begin.strftime("%Y-%m-%d %H:%M:%S"),
-            now.strftime("%Y-%m-%d %H:%M:%S"),
-        )
+        return begin.strftime("%Y-%m-%d %H:%M:%S")

--- a/gear/pull_directory/src/python/directory_app/run.py
+++ b/gear/pull_directory/src/python/directory_app/run.py
@@ -85,15 +85,13 @@ class DirectoryPullVisitor(GearExecutionEnvironment):
                 f"Invalid preceding_hours configuration: {error}"
             ) from error
 
-        date_range = threshold_config.get_date_range()
+        date_range_begin = threshold_config.get_date_range_begin()
 
-        if date_range:
-            begin_str, end_str = date_range
+        if date_range_begin:
             log.info(
-                "Incremental pull: preceding_hours=%s, date range %s to %s",
+                "Incremental pull: preceding_hours=%s, dateRangeBegin=%s (Pacific)",
                 threshold_config.threshold,
-                begin_str,
-                end_str,
+                date_range_begin,
             )
         else:
             log.info("Pulling all records (no date filtering)")
@@ -101,12 +99,10 @@ class DirectoryPullVisitor(GearExecutionEnvironment):
         try:
             connection = REDCapConnection.create_from(params)
             project = REDCapProject.create(connection)
-            if date_range:
-                begin_str, end_str = date_range
+            if date_range_begin:
                 records = project.export_records(
                     fields=get_directory_field_names(),
-                    date_range_begin=begin_str,
-                    date_range_end=end_str,
+                    date_range_begin=date_range_begin,
                 )
             else:
                 records = project.export_records(fields=get_directory_field_names())

--- a/gear/pull_directory/test/python/test_directory_pull_visitor_create.py
+++ b/gear/pull_directory/test/python/test_directory_pull_visitor_create.py
@@ -247,7 +247,7 @@ class TestDirectoryPullVisitorCreateDateRange:
         mock_parameter_store: MockParameterStore,
     ) -> None:
         """When preceding_hours > 0, export_records receives date_range_begin
-        and date_range_end kwargs.
+        but not date_range_end (REDCap uses server time as end).
 
         Validates: Requirements 3.3
         """
@@ -268,7 +268,7 @@ class TestDirectoryPullVisitorCreateDateRange:
 
             call_kwargs = mocks["project"].export_records.call_args
             assert "date_range_begin" in call_kwargs.kwargs
-            assert "date_range_end" in call_kwargs.kwargs
+            assert "date_range_end" not in call_kwargs.kwargs
             assert call_kwargs.kwargs["fields"] == get_directory_field_names()
 
     def test_export_records_called_without_date_range_when_preceding_hours_zero(
@@ -458,7 +458,8 @@ class TestDirectoryPullVisitorCreateLogging:
         log_messages = " ".join(caplog.messages)
         assert "Incremental pull" in log_messages
         assert "preceding_hours=6" in log_messages
-        assert "date range" in log_messages
+        assert "dateRangeBegin=" in log_messages
+        assert "(Pacific)" in log_messages
 
     def test_logs_full_pull_when_preceding_hours_zero(
         self,

--- a/gear/pull_directory/test/python/test_time_window_config.py
+++ b/gear/pull_directory/test/python/test_time_window_config.py
@@ -6,7 +6,7 @@ Feature: pull-directory-date-range
 from datetime import datetime, timedelta
 
 import pytest
-from directory_app.config import TimeWindowConfig
+from directory_app.config import REDCAP_SERVER_TIMEZONE, TimeWindowConfig
 from hypothesis import given, settings
 from hypothesis import strategies as st
 from pydantic import ValidationError
@@ -59,10 +59,10 @@ class TestNonNegativeValidation:
 class TestDateRangeComputation:
     """Property 2: Date range computation correctness.
 
-    For any positive preceding_hours value and any reference datetime now,
-    TimeWindowConfig(threshold=value).get_date_range(now) returns a tuple
-    (begin, end) where begin equals (now - timedelta(hours=value)).strftime(...)
-    and end equals now.strftime(...). When preceding_hours is 0, returns None.
+    For any positive preceding_hours value and any reference UTC datetime,
+    TimeWindowConfig(threshold=value).get_date_range_begin(now) returns
+    a string equal to (now - timedelta(hours=value)).strftime(...).
+    When preceding_hours is 0, returns None.
 
     Feature: pull-directory-date-range, Property 2
     Validates: Requirements 3.1, 3.2, 5.3
@@ -78,26 +78,24 @@ class TestDateRangeComputation:
         now=st.datetimes(
             min_value=datetime(1900, 1, 1),
             max_value=datetime(2200, 1, 1),
+            timezones=st.just(REDCAP_SERVER_TIMEZONE),
         ),
     )
     @settings(max_examples=200)
-    def test_date_range_computation_correctness(
+    def test_date_range_begin_computation_correctness(
         self,
         value: float,
         now: datetime,
     ) -> None:
-        """Positive preceding_hours returns correct date range tuple.
+        """Positive preceding_hours returns correct begin timestamp.
 
         **Validates: Requirements 3.1, 3.2, 5.3**
         """
         config = TimeWindowConfig(threshold=value)
-        result = config.get_date_range(now=now)
+        result = config.get_date_range_begin(now=now)
         assert result is not None
-        begin_str, end_str = result
         expected_begin = (now - timedelta(hours=value)).strftime("%Y-%m-%d %H:%M:%S")
-        expected_end = now.strftime("%Y-%m-%d %H:%M:%S")
-        assert begin_str == expected_begin
-        assert end_str == expected_end
+        assert result == expected_begin
 
     def test_zero_preceding_hours_returns_none(self) -> None:
         """threshold=0 returns None (no date filtering).
@@ -105,4 +103,21 @@ class TestDateRangeComputation:
         **Validates: Requirements 3.2, 5.3**
         """
         config = TimeWindowConfig(threshold=0)
-        assert config.get_date_range() is None
+        assert config.get_date_range_begin() is None
+
+    def test_default_uses_redcap_server_timezone(self) -> None:
+        """When no 'now' is provided, the method uses REDCap server timezone.
+
+        **Validates: Requirement 3.1**
+        """
+        config = TimeWindowConfig(threshold=1.0)
+        result = config.get_date_range_begin()
+        assert result is not None
+        # Verify the result is close to one hour before current Pacific time
+        expected = (datetime.now(REDCAP_SERVER_TIMEZONE) - timedelta(hours=1)).strftime(
+            "%Y-%m-%d %H:%M:%S"
+        )
+        # Allow 2 seconds of tolerance for test execution time
+        result_dt = datetime.strptime(result, "%Y-%m-%d %H:%M:%S")
+        expected_dt = datetime.strptime(expected, "%Y-%m-%d %H:%M:%S")
+        assert abs((result_dt - expected_dt).total_seconds()) < 2


### PR DESCRIPTION
## Summary

Fixes the incremental pull returning zero records due to a timezone mismatch between the Flywheel container and the REDCap server.

## Problem

The gear computed timestamps using `datetime.now()` (container-local time), but REDCap interprets `dateRangeBegin`/`dateRangeEnd` in its PHP timezone (`America/Los_Angeles`). This caused the query window to land in the wrong time range.

## Changes

- Compute `dateRangeBegin` in `America/Los_Angeles` (Pacific) to match REDCap's PHP `date.timezone` setting
- Drop `dateRangeEnd` parameter — REDCap defaults to its current server time (per API docs)
- Rename `get_date_range()` to `get_date_range_begin()` reflecting the single-value return
- Export `REDCAP_SERVER_TIMEZONE` constant for reuse

## Testing

All 1538 tests pass. Property-based tests updated to use Pacific-aware datetimes.

## Version

Bumped to 4.1.3.
