### PR TITLE
Pipeline Event Logger v0.2.0

### DIFF
--- a/.kiro/agents/committer.md
+++ b/.kiro/agents/committer.md
@@ -13,6 +13,11 @@ permissions:
         - "git show *"
       effect: allow
     - capability: shell
+      match:
+        - "git add *"
+        - "git commit *"
+      effect: ask
+    - capability: shell
       effect: deny
 ---
 
@@ -53,7 +58,6 @@ When a file could reasonably go in more than one group:
 
 ## Rules
 
-- Do NOT run git add or git commit. The user does that manually.
 - Present the full plan before walking through individual commits.
 - Wait for explicit user confirmation between each commit step.
 - If the user wants to reorder or regroup, adjust the plan and re-present.

--- a/.kiro/agents/committer.md
+++ b/.kiro/agents/committer.md
@@ -4,15 +4,16 @@ tools:
   - read
   - shell
 permissions:
-  - capability: shell
-    match:
-      - git status *
-      - git diff *
-      - git log *
-      - git show *
-    effect: allow
-  - capability: shell
-    effect: deny
+  rules:
+    - capability: shell
+      match:
+        - "git status *"
+        - "git diff *"
+        - "git log *"
+        - "git show *"
+      effect: allow
+    - capability: shell
+      effect: deny
 ---
 
 # Commit Grouping Agent

--- a/.kiro/agents/release.md
+++ b/.kiro/agents/release.md
@@ -11,8 +11,15 @@ permissions:
         - "git log *"
         - "git diff *"
         - "git show *"
-        - "git tag *"
+        - "git tag --list *"
       effect: allow
+    - capability: shell
+      match:
+        - "git add *"
+        - "git commit *"
+        - "git push *"
+        - "gh pr create *"
+      effect: ask
     - capability: shell
       effect: deny
 ---
@@ -81,25 +88,26 @@ Only include the subsections that apply. Match whatever format the existing CHAN
 
 Use git history to draft changelog entries. The typical workflow:
 
-1. Find the last version tag for the component:
-   - Gear: `git tag --list 'gear/{gear-name}/v*' --sort=-version:refname`
-   - Package: `git tag --list '{package-name}/v*' --sort=-version:refname`
-2. Get commits since that tag scoped to the component's directory:
-   - Gear: `git log <last-tag>..HEAD -- gear/{gear-name}/`
-   - Package: `git log <last-tag>..HEAD -- {package-name}/`
+1. Determine the baseline for changes:
+   - Check for a version tag: `git tag --list 'gear/{gear-name}/v*' --sort=-version:refname` (or `'{package-name}/v*'` for packages)
+   - If a tag exists, use it as the baseline
+   - If no tag exists, use `main` as the baseline
+2. Get commits since the baseline scoped to the component's directory:
+   - Gear: `git log <baseline>..HEAD -- gear/{gear-name}/`
+   - Package: `git log <baseline>..HEAD -- {package-name}/`
 3. Also check for changes in shared code that affect the component (e.g., `common/` changes relevant to a gear)
 4. Summarize the commits into user-facing changelog bullets — group by theme (features, fixes, breaking changes), drop noise (merge commits, formatting-only changes)
 5. Present the draft to the user for review before writing it
 
-If there are no tags for the component, ask the user for the baseline commit or just ask what changed.
+If the history is unclear or the user provides explicit changelog content, use what the user says.
 
 ## After Making Changes
 
-List all modified files so the user can review, commit, and tag manually. Remind them of the tag to create:
-- Gear: `git tag gear/{gear-name}/v{new-version}`
-- Package: `git tag {package-name}/v{new-version}`
-
-Do NOT run git add, git commit, or git tag. The user handles those.
+List all modified files so the user can review. Then:
+- Stage the modified files with `git add`
+- Commit with a message like `Prepare {component} v{version} release`
+- Push the branch with `git push`
+- Create a PR with `gh pr create`
 
 ## Rules
 

--- a/.kiro/agents/release.md
+++ b/.kiro/agents/release.md
@@ -5,15 +5,16 @@ tools:
   - write
   - shell
 permissions:
-  - capability: shell
-    match:
-      - git log *
-      - git diff *
-      - git show *
-      - git tag *
-    effect: allow
-  - capability: shell
-    effect: deny
+  rules:
+    - capability: shell
+      match:
+        - "git log *"
+        - "git diff *"
+        - "git show *"
+        - "git tag *"
+      effect: allow
+    - capability: shell
+      effect: deny
 ---
 
 # Release Agent

--- a/.kiro/agents/release.md
+++ b/.kiro/agents/release.md
@@ -15,10 +15,15 @@ permissions:
       effect: allow
     - capability: shell
       match:
+        - "gh pr view *"
+      effect: allow
+    - capability: shell
+      match:
         - "git add *"
         - "git commit *"
         - "git push *"
         - "gh pr create *"
+        - "gh pr edit *"
       effect: ask
     - capability: shell
       effect: deny
@@ -107,7 +112,13 @@ List all modified files so the user can review. Then:
 - Stage the modified files with `git add`
 - Commit with a message like `Prepare {component} v{version} release`
 - Push the branch with `git push`
-- Create a PR with `gh pr create`
+- Create a PR using `gh pr create` with `--body-file`:
+  1. Write the PR body to `scratch/pr-body.md` (using the write tool to preserve newlines)
+  2. Run `gh pr create --title "<title>" --body-file scratch/pr-body.md`
+  3. Verify with `gh pr view <number> --json body --jq .body`
+  4. Delete `scratch/pr-body.md`
+
+**Important**: Do not use `--body` with inline text — newlines get stripped by the shell execution layer. Always use `--body-file` instead.
 
 ## Rules
 

--- a/.kiro/agents/reviewer.md
+++ b/.kiro/agents/reviewer.md
@@ -5,21 +5,22 @@ tools:
   - shell
   - subagent
 permissions:
-  - capability: shell
-    match:
-      - git log *
-      - git diff *
-      - git show *
-      - git branch *
-      - git merge-base *
-      - git rev-parse *
-    effect: allow
-  - capability: shell
-    effect: deny
-  - capability: subagent
-    match:
-      - semantic_reviewer
-    effect: allow
+  rules:
+    - capability: shell
+      match:
+        - "git log *"
+        - "git diff *"
+        - "git show *"
+        - "git branch *"
+        - "git merge-base *"
+        - "git rev-parse *"
+      effect: allow
+    - capability: shell
+      effect: deny
+    - capability: subagent
+      match:
+        - "semantic_reviewer"
+      effect: allow
 ---
 
 # Code Reviewer Agent

--- a/.kiro/steering/qc-conventions.md
+++ b/.kiro/steering/qc-conventions.md
@@ -81,6 +81,7 @@ For NACC gears following this convention, the error_configs entry is always:
 {
   "check_name": "<check_name>",
   "field_mapping": {
+    "type": "list",
     "message": "message",
     "error_type": "type",
     "error_code": "code"

--- a/.kiro/steering/qc-conventions.md
+++ b/.kiro/steering/qc-conventions.md
@@ -1,0 +1,126 @@
+---
+inclusion: fileMatch
+fileMatchPattern: '**/qc_reader.py,**/error_models.py,**/run.py,**/main.py'
+---
+
+# QC Metadata Conventions
+
+## Overview
+
+NACC gears that write QC results to `file.info.qc.<gear_name>` must follow these conventions so that `pipeline-event-logger` can consistently read aggregate status and extract structured errors without per-gear special-casing.
+
+## QC Result Structure
+
+Each gear writes one or more **check results** under its QC namespace, plus a `job_info` metadata entry:
+
+```json
+{
+  "job_info": { ... },
+  "<check_name>": {
+    "state": "PASS" | "FAIL" | "IN REVIEW",
+    "data": <list of error dicts> | null
+  }
+}
+```
+
+### Rules
+
+1. **`state`** — Required. Must be one of `"PASS"`, `"FAIL"`, or `"IN REVIEW"` (uppercase, exact strings).
+
+2. **`data`** — The error payload:
+   - On PASS or when there's nothing to report: `null`
+   - On FAIL or IN REVIEW: a **list** of error dicts, even if there's only one error
+   - Never a bare string, dict, or other type
+
+3. **`job_info`** — Reserved key for gear run metadata (config, inputs, job_id, version). Skipped by pipeline-event-logger during QC result iteration.
+
+4. **Check names** — Use lowercase with hyphens or underscores. Each check name becomes the key under `file.info.qc.<gear_name>`.
+
+## Error Dict Format (FileError Convention)
+
+Error dicts should serialize using the `FileError` model with `by_alias=True`, producing:
+
+```json
+{
+  "type": "error" | "warning" | "alert",
+  "code": "<error-code>",
+  "message": "<human-readable description>",
+  "value": "<offending value, optional>",
+  "timestamp": "<ISO timestamp, optional>",
+  "location": { ... optional ... },
+  "ptid": "<optional>",
+  "visitnum": "<optional>",
+  "date": "<optional>",
+  "naccid": "<optional>"
+}
+```
+
+Only `type`, `code`, and `message` are required for pipeline-event-logger extraction. The remaining fields provide context for QC status logs and downstream reporting.
+
+### Standard Implementation
+
+```python
+from nacc_common.error_models import FileErrorList
+
+# Write QC result
+context.metadata.add_qc_result(
+    file_input,
+    name="validation",
+    state="PASS" if success else "FAIL",
+    data=(errors.model_dump(by_alias=True) if errors else None),
+)
+```
+
+Where `errors` is a `FileErrorList` (Pydantic `RootModel[List[FileError]]`).
+
+## Pipeline-Event-Logger Error Config
+
+For NACC gears following this convention, the error_configs entry is always:
+
+```json
+{
+  "check_name": "<check_name>",
+  "field_mapping": {
+    "message": "message",
+    "error_type": "type",
+    "error_code": "code"
+  }
+}
+```
+
+No `data_key` override needed (defaults to `"data"`).
+
+## Third-Party Gears (e.g., dicom-qc)
+
+Third-party gears don't follow these conventions. Their check results may have:
+- String values in `data` (not extractable as structured errors)
+- Different field names in error objects (`name` instead of `message`, etc.)
+- Non-error dicts in `data` (classification blocks, metadata objects)
+
+For these gears, pipeline-event-logger uses custom `field_mapping` entries that map the gear-specific field names to `FileError` fields. See `gear/pipeline_event_logger/data/dicom-qc-config.json` for an example.
+
+## Existing Gears Following This Convention
+
+| Gear | Check name | Status |
+|------|-----------|--------|
+| `form-qc-checker` | `validation` | Compliant |
+| `image-identifier-lookup` | `validation` | Compliant |
+
+Both use `FileErrorList.model_dump(by_alias=True)` for their `data` field.
+
+## What Not to Do
+
+```python
+# ❌ Don't write a string as data
+data="Something went wrong with slice consistency"
+
+# ❌ Don't write a dict as data
+data={"filename": "example.dcm", "trace": []}
+
+# ❌ Don't write a bare list of strings
+data=["error 1", "error 2"]
+
+# ✅ Do write a list of FileError-shaped dicts (or null)
+data=[{"type": "error", "code": "system-error", "message": "..."}]
+data=None
+```

--- a/docs/pipeline_event_logger/CHANGELOG.md
+++ b/docs/pipeline_event_logger/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Pipeline Event Logger Changelog
 
+## 0.2.0
+
+* Discriminated field mapping for QC error extraction with three mapping types: `ListFieldMapping` (list-of-dicts), `StringFieldMapping` (string explanations), and `NoneFieldMapping` (null data on failure)
+* String check data used directly as error message; null data with non-PASS state synthesizes a generic failure message
+* State guard on `StringFieldMapping` for edge case handling
+* Added gear configuration files for deployment
+
 ## 0.1.1
 
 * Fix VisitEvent serialization: `modality` field is now included in serialized dicom events

--- a/docs/pipeline_event_logger/index.md
+++ b/docs/pipeline_event_logger/index.md
@@ -98,13 +98,18 @@ Gear configs are defined in [manifest.json](../../gear/pipeline_event_logger/src
   | Field | Type | Required | Description |
   |-------|------|----------|-------------|
   | `check_name` | string | Yes | Name of the check result to read (e.g., `"dicom-validator"`, `"validation"`) |
-  | `data_key` | string | No (default: `"data"`) | Key within the check result holding the error list |
-  | `field_mapping` | object | Yes | Maps source error fields to `FileError` fields |
+  | `data_key` | string | No (default: `"data"`) | Key within the check result holding the error data |
+  | `field_mapping` | object | Yes | Discriminated union describing expected data shape and how to produce `FileError` objects |
 
-  The `field_mapping` object:
+  The `field_mapping` object uses a `type` discriminator to declare the expected data shape:
+
+  #### `"type": "list"` — List of error dicts
+
+  For checks that produce a list of error objects in `data`. Each dict item is mapped to a `FileError` using field resolution.
 
   | Field | Type | Required | Description |
   |-------|------|----------|-------------|
+  | `type` | `"list"` | Yes | Discriminator |
   | `message` | string | Yes | Source key for the error message |
   | `error_type` | string | No (default: `"error"`) | Source key or literal for error type (`"error"`, `"warning"`, `"alert"`) |
   | `error_code` | string | No (default: `"qc-error"`) | Source key or literal for error code |
@@ -112,7 +117,27 @@ Gear configs are defined in [manifest.json](../../gear/pipeline_event_logger/src
 
   **Field resolution**: Each mapping value is first checked as a key in the source error object. If the key exists, the value from the source is used. Otherwise, the mapping value is treated as a literal string.
 
-  Example for a DICOM QC gear with two check types:
+  #### `"type": "string"` — String explanation
+
+  For checks that write a human-readable string to `data` on failure (e.g., `"Inconsistent slice intervals..."`). The string becomes the error message directly.
+
+  | Field | Type | Required | Description |
+  |-------|------|----------|-------------|
+  | `type` | `"string"` | Yes | Discriminator |
+  | `error_type` | string | No (default: `"error"`) | Literal error type |
+  | `error_code` | string | No (default: `"qc-error"`) | Literal error code |
+
+  #### `"type": "none"` — Null data with pass/fail state
+
+  For checks that write `null` to `data` regardless of outcome. Synthesizes a `"{check_name} failed"` error message when the check state is not PASS.
+
+  | Field | Type | Required | Description |
+  |-------|------|----------|-------------|
+  | `type` | `"none"` | Yes | Discriminator |
+  | `error_type` | string | No (default: `"error"`) | Literal error type |
+  | `error_code` | string | No (default: `"qc-error"`) | Literal error code |
+
+  Example for a DICOM QC gear with all three data shapes:
 
   ```json
   {
@@ -120,6 +145,7 @@ Gear configs are defined in [manifest.json](../../gear/pipeline_event_logger/src
       {
         "check_name": "dicom-validator",
         "field_mapping": {
+          "type": "list",
           "message": "name",
           "error_code": "dicom-validation"
         }
@@ -127,9 +153,24 @@ Gear configs are defined in [manifest.json](../../gear/pipeline_event_logger/src
       {
         "check_name": "jsonschema-validation",
         "field_mapping": {
+          "type": "list",
           "message": "error_message",
           "error_type": "error_type",
           "error_code": "jsonschema-validation"
+        }
+      },
+      {
+        "check_name": "slice_consistency",
+        "field_mapping": {
+          "type": "string",
+          "error_code": "slice-consistency"
+        }
+      },
+      {
+        "check_name": "check_zero_byte",
+        "field_mapping": {
+          "type": "none",
+          "error_code": "zero-byte"
         }
       }
     ]
@@ -137,8 +178,10 @@ Gear configs are defined in [manifest.json](../../gear/pipeline_event_logger/src
   ```
 
   In this example:
-  - For `dicom-validator`: each error object has a `"name"` key, so `message` resolves to `source["name"]`. `"dicom-validation"` is not a key in the source, so it's used as a literal error code.
-  - For `jsonschema-validation`: both `"error_message"` and `"error_type"` are keys in the source objects, so they resolve to the source values.
+  - `dicom-validator`: data is a list of dicts with a `"name"` key → `message` resolves to `source["name"]`. `"dicom-validation"` is not a source key → used as a literal error code.
+  - `jsonschema-validation`: data is a list of dicts with `"error_message"` and `"error_type"` keys → both resolve to source values.
+  - `slice_consistency`: data is a string like `"Inconsistent slice intervals..."` → becomes the error message directly.
+  - `check_zero_byte`: data is `null` → if the check failed, produces `"check_zero_byte failed"` as the error message.
 
 - **`event_actions`** (object, optional): Maps QC outcome keys to event action strings. If empty or not provided, no events are captured.
 
@@ -180,7 +223,12 @@ To prevent this, the gear waits for older instances of itself on the same projec
 
 1. **Read GearQC**: Reads `file.info.qc.{upstream_gear_name}` and constructs a `GearQC` object representing all check results for the upstream gear. Derives the aggregate QC status (PASS, FAIL, or IN REVIEW) using priority ordering: FAIL > IN REVIEW > PASS. Fails if missing or invalid.
 
-2. **Extract Errors**: If `error_configs` is provided, extracts errors from the targeted check results using the configured field mappings. Each matching check result's `data` (or configured `data_key`) is parsed into `FileError` objects. If no config is provided, an empty error list is used.
+2. **Extract Errors**: If `error_configs` is provided, extracts errors from the targeted check results using the configured field mappings. The `field_mapping.type` discriminator determines how data is handled:
+   - `"list"`: maps each dict item in the data list to a `FileError`
+   - `"string"`: uses the string data directly as the error message
+   - `"none"`: synthesizes a `"{check_name} failed"` message when state is not PASS
+   
+   If no config is provided, an empty error list is used.
 
 3. **Read Data Identification**: Reads `file.info.data_identification` and deserializes via `DataIdentification.from_visit_metadata()`. Fails if missing or invalid.
 
@@ -238,6 +286,7 @@ The rationale: the upstream gear's QC result is already safely stored in `file.i
     {
       "check_name": "dicom-validator",
       "field_mapping": {
+        "type": "list",
         "message": "name",
         "error_code": "dicom-validation"
       }
@@ -245,9 +294,38 @@ The rationale: the upstream gear's QC result is already safely stored in `file.i
     {
       "check_name": "jsonschema-validation",
       "field_mapping": {
+        "type": "list",
         "message": "error_message",
         "error_type": "error_type",
         "error_code": "jsonschema-validation"
+      }
+    },
+    {
+      "check_name": "slice_consistency",
+      "field_mapping": {
+        "type": "string",
+        "error_code": "slice-consistency"
+      }
+    },
+    {
+      "check_name": "instance_number_uniqueness",
+      "field_mapping": {
+        "type": "string",
+        "error_code": "instance-number-uniqueness"
+      }
+    },
+    {
+      "check_name": "check_zero_byte",
+      "field_mapping": {
+        "type": "none",
+        "error_code": "zero-byte"
+      }
+    },
+    {
+      "check_name": "embedded_localizer",
+      "field_mapping": {
+        "type": "none",
+        "error_code": "embedded-localizer"
       }
     }
   ],
@@ -272,6 +350,7 @@ For upstream gears that write `FileError` lists to `validation.data` (the NACC c
     {
       "check_name": "validation",
       "field_mapping": {
+        "type": "list",
         "message": "message",
         "error_type": "type",
         "error_code": "code"
@@ -307,6 +386,7 @@ When you only need to record the pass/fail status without detailed errors:
     {
       "check_name": "dicom-validator",
       "field_mapping": {
+        "type": "list",
         "message": "name",
         "error_code": "dicom-validation"
       }
@@ -347,7 +427,7 @@ The gear follows the standard NACC gear architecture:
 
 - `run.py`: Flywheel context management, dependency initialization, file/project retrieval, config parsing
 - `main.py`: Business logic — reads `GearQC`, extracts errors via config, updates QC log, captures events
-- `qc_reader.py`: Generic QC metadata reader — `GearQC`, `GearQCResult`, `QCErrorConfig`, and `ErrorFieldMapping` models
+- `qc_reader.py`: Generic QC metadata reader — `GearQC`, `GearQCResult`, `QCErrorConfig`, and discriminated `FieldMapping` models (`ListFieldMapping`, `StringFieldMapping`, `NoneFieldMapping`)
 
 The `qc_reader` module is intentionally independent of form-specific models (`FileQCModel`). It handles the general Flywheel QC convention where check results have a `state` field and gear-specific data. The `error_configs` mechanism allows the gear to extract errors from any upstream gear without hard-coding assumptions about the error structure.
 

--- a/gear/pipeline_event_logger/data/.gitignore
+++ b/gear/pipeline_event_logger/data/.gitignore
@@ -1,0 +1,7 @@
+# ignore everything
+*
+# except for
+!.gitignore
+!dicom-qc-config.json
+!form-qc-checker-config.json
+!image-identifier-lookup-config.json

--- a/gear/pipeline_event_logger/data/dicom-qc-config.json
+++ b/gear/pipeline_event_logger/data/dicom-qc-config.json
@@ -1,0 +1,70 @@
+{
+  "upstream_gear_name": "dicom-qc",
+  "error_configs": [
+    {
+      "check_name": "dicom-validator",
+      "field_mapping": {
+        "type": "list",
+        "message": "name",
+        "error_code": "dicom-validation"
+      }
+    },
+    {
+      "check_name": "jsonschema-validation",
+      "field_mapping": {
+        "type": "list",
+        "message": "error_message",
+        "error_type": "error_type",
+        "error_code": "jsonschema-validation"
+      }
+    },
+    {
+      "check_name": "slice_consistency",
+      "field_mapping": {
+        "type": "string",
+        "error_code": "slice-consistency"
+      }
+    },
+    {
+      "check_name": "instance_number_uniqueness",
+      "field_mapping": {
+        "type": "string",
+        "error_code": "instance-number-uniqueness"
+      }
+    },
+    {
+      "check_name": "bed_moving",
+      "field_mapping": {
+        "type": "string",
+        "error_code": "bed-moving"
+      }
+    },
+    {
+      "check_name": "check_zero_byte",
+      "field_mapping": {
+        "type": "none",
+        "error_code": "zero-byte"
+      }
+    },
+    {
+      "check_name": "embedded_localizer",
+      "field_mapping": {
+        "type": "none",
+        "error_code": "embedded-localizer"
+      }
+    },
+    {
+      "check_name": "series_consistency",
+      "field_mapping": {
+        "type": "none",
+        "error_code": "series-consistency"
+      }
+    }
+  ],
+  "event_actions": {
+    "pass": "pass-qc",
+    "fail": "not-pass-qc"
+  },
+  "event_environment": "prod",
+  "event_bucket": "submission-events"
+}

--- a/gear/pipeline_event_logger/data/form-qc-checker-config.json
+++ b/gear/pipeline_event_logger/data/form-qc-checker-config.json
@@ -1,0 +1,20 @@
+{
+  "upstream_gear_name": "form-qc-checker",
+  "error_configs": [
+    {
+      "check_name": "validation",
+      "field_mapping": {
+        "type": "list",
+        "message": "message",
+        "error_type": "type",
+        "error_code": "code"
+      }
+    }
+  ],
+  "event_actions": {
+    "pass": "pass-qc",
+    "fail": "not-pass-qc"
+  },
+  "event_environment": "prod",
+  "event_bucket": "submission-events"
+}

--- a/gear/pipeline_event_logger/data/image-identifier-lookup-config.json
+++ b/gear/pipeline_event_logger/data/image-identifier-lookup-config.json
@@ -1,0 +1,20 @@
+{
+  "upstream_gear_name": "image-identifier-lookup",
+  "error_configs": [
+    {
+      "check_name": "validation",
+      "field_mapping": {
+        "type": "list",
+        "message": "message",
+        "error_type": "type",
+        "error_code": "code"
+      }
+    }
+  ],
+  "event_actions": {
+    "pass": "pass-qc",
+    "fail": "not-pass-qc"
+  },
+  "event_environment": "prod",
+  "event_bucket": "submission-events"
+}

--- a/gear/pipeline_event_logger/src/docker/BUILD
+++ b/gear/pipeline_event_logger/src/docker/BUILD
@@ -7,5 +7,5 @@ docker_image(
         ":manifest",
         "gear/pipeline_event_logger/src/python/pipeline_event_logger_app:bin",
     ],
-    image_tags=["0.1.1", "latest"],
+    image_tags=["0.2.0", "latest"],
 )

--- a/gear/pipeline_event_logger/src/docker/manifest.json
+++ b/gear/pipeline_event_logger/src/docker/manifest.json
@@ -2,7 +2,7 @@
   "name": "pipeline-event-logger",
   "label": "Pipeline Event Logger",
   "description": "Reads QC results from upstream gears and propagates them to NACC QC status logs and S3 event capture",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "author": "NACC",
   "maintainer": "NACC <nacchelp@uw.edu>",
   "cite": "",
@@ -15,7 +15,7 @@
   "custom": {
     "gear-builder": {
       "category": "utility",
-      "image": "naccdata/pipeline-event-logger:0.1.1"
+      "image": "naccdata/pipeline-event-logger:0.2.0"
     },
     "flywheel": {
       "suite": "NACC Data Gears",

--- a/gear/pipeline_event_logger/src/python/pipeline_event_logger_app/qc_reader.py
+++ b/gear/pipeline_event_logger/src/python/pipeline_event_logger_app/qc_reader.py
@@ -10,12 +10,12 @@ check results ahead of time.
 """
 
 import logging
-from typing import Any, Optional
+from typing import Annotated, Any, Literal, Optional, Union
 
 from flywheel.models.file_entry import FileEntry
 from gear_execution.gear_execution import GearExecutionError
 from nacc_common.error_models import FileError, FileErrorList, QCStatus
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 log = logging.getLogger(__name__)
 
@@ -23,31 +23,53 @@ log = logging.getLogger(__name__)
 _VALID_STATES: set[str] = {"PASS", "FAIL", "IN REVIEW"}
 
 
-class ErrorFieldMapping(BaseModel):
-    """Maps gear-specific error fields to FileError fields.
+class ListFieldMapping(BaseModel):
+    """Field mapping for checks that produce a list of error dicts.
 
-    Each field value is interpreted as:
-    - If it matches a key in the source error object, the value from
-      that key is used.
+    Each field value is resolved against the source error dict:
+    - If it matches a key in the source, the value from that key is used.
     - Otherwise, it is treated as a literal value.
 
-    Example for dicom-validator results:
-        ErrorFieldMapping(message="name", error_code="dicom-validation")
-        # "name" is a key in the source -> uses source["name"]
+    Example for dicom-validator:
+        ListFieldMapping(type="list", message="name", error_code="dicom-validation")
+        # "name" is a key in source -> uses source["name"]
         # "dicom-validation" is not a key -> used as literal
-
-    Example for jsonschema-validation results:
-        ErrorFieldMapping(
-            message="error_message",
-            error_type="error_type",
-            error_code="jsonschema-validation",
-        )
     """
 
+    type: Literal["list"]
     message: str
     error_type: str = "error"
     error_code: str = "qc-error"
     value: Optional[str] = None
+
+
+class StringFieldMapping(BaseModel):
+    """Field mapping for checks that produce a string explanation on failure.
+
+    The string value of the data field becomes the error message
+    directly.
+    """
+
+    type: Literal["string"]
+    error_type: str = "error"
+    error_code: str = "qc-error"
+
+
+class NoneFieldMapping(BaseModel):
+    """Field mapping for checks that produce null data on failure.
+
+    Synthesizes a "{check_name} failed" message when state is not PASS.
+    """
+
+    type: Literal["none"]
+    error_type: str = "error"
+    error_code: str = "qc-error"
+
+
+FieldMapping = Annotated[
+    Union[ListFieldMapping, StringFieldMapping, NoneFieldMapping],
+    Field(discriminator="type"),
+]
 
 
 class QCErrorConfig(BaseModel):
@@ -56,14 +78,15 @@ class QCErrorConfig(BaseModel):
     Attributes:
         check_name: Which check result to read errors from
             (e.g., "dicom-validator", "validation").
-        data_key: Key within the check result holding the error list.
+        data_key: Key within the check result holding the error data.
             Defaults to "data".
-        field_mapping: How to map source error fields to FileError fields.
+        field_mapping: Discriminated union describing the expected data
+            shape and how to produce FileError objects from it.
     """
 
     check_name: str
     data_key: str = "data"
-    field_mapping: ErrorFieldMapping
+    field_mapping: FieldMapping
 
 
 class GearQCResult:
@@ -106,23 +129,38 @@ class GearQCResult:
     def extract_errors(self, config: QCErrorConfig) -> FileErrorList:
         """Extract errors from this check result using the given config.
 
-        Reads the list at self._raw[config.data_key] and maps each item
-        to a FileError using config.field_mapping.
+        Dispatches based on the field_mapping type:
+        - "list": expects data to be a list of dicts, maps each item
+        - "string": expects data to be a string, uses it as the message
+        - "none": expects data to be null, synthesizes "{check_name} failed"
 
         Returns:
-            FileErrorList of extracted errors. Empty if data is None,
-            not a list, or the check_name doesn't match this result.
+            FileErrorList of extracted errors. Empty if the check_name
+            doesn't match, or if the check passed with no data.
         """
         if self._name != config.check_name:
             return FileErrorList([])
 
         raw_data = self._raw.get(config.data_key)
-        if not raw_data or not isinstance(raw_data, list):
+        mapping = config.field_mapping
+
+        if isinstance(mapping, ListFieldMapping):
+            return self._extract_from_list(raw_data, mapping)
+        if isinstance(mapping, StringFieldMapping):
+            return self._extract_from_string(raw_data, mapping)
+        if isinstance(mapping, NoneFieldMapping):
+            return self._extract_from_none(mapping)
+
+        return FileErrorList([])
+
+    def _extract_from_list(
+        self, raw_data: Any, mapping: ListFieldMapping
+    ) -> FileErrorList:
+        """Extract errors from list-of-dicts data."""
+        if not isinstance(raw_data, list):
             return FileErrorList([])
 
         errors: list[FileError] = []
-        mapping = config.field_mapping
-
         for item in raw_data:
             if not isinstance(item, dict):
                 continue
@@ -144,8 +182,38 @@ class GearQCResult:
                     value=value,
                 )
             )
-
         return FileErrorList(errors)
+
+    def _extract_from_string(
+        self, raw_data: Any, mapping: StringFieldMapping
+    ) -> FileErrorList:
+        """Extract a single error from string data."""
+        if not isinstance(raw_data, str):
+            return FileErrorList([])
+
+        return FileErrorList(
+            [
+                FileError(
+                    message=raw_data,
+                    error_type=mapping.error_type,
+                    error_code=mapping.error_code,
+                )
+            ]
+        )
+
+    def _extract_from_none(self, mapping: NoneFieldMapping) -> FileErrorList:
+        """Synthesize an error when data is null and state is not PASS."""
+        if self.state and self.state != "PASS":
+            return FileErrorList(
+                [
+                    FileError(
+                        message=f"{self._name} failed",
+                        error_type=mapping.error_type,
+                        error_code=mapping.error_code,
+                    )
+                ]
+            )
+        return FileErrorList([])
 
     def __repr__(self) -> str:
         return f"GearQCResult(name={self._name!r}, state={self.state!r})"

--- a/gear/pipeline_event_logger/src/python/pipeline_event_logger_app/qc_reader.py
+++ b/gear/pipeline_event_logger/src/python/pipeline_event_logger_app/qc_reader.py
@@ -190,6 +190,8 @@ class GearQCResult:
         """Extract a single error from string data."""
         if not isinstance(raw_data, str):
             return FileErrorList([])
+        if self.state == "PASS":
+            return FileErrorList([])
 
         return FileErrorList(
             [

--- a/gear/pipeline_event_logger/test/python/pipeline_event_logger_test/test_qc_reader.py
+++ b/gear/pipeline_event_logger/test/python/pipeline_event_logger_test/test_qc_reader.py
@@ -1,0 +1,589 @@
+"""Tests for QC reader error extraction with discriminated field mappings."""
+
+import pytest
+from pipeline_event_logger_app.qc_reader import (
+    GearQC,
+    GearQCResult,
+    ListFieldMapping,
+    NoneFieldMapping,
+    QCErrorConfig,
+    StringFieldMapping,
+)
+
+# ===========================================================================
+# ListFieldMapping extraction
+# ===========================================================================
+
+
+class TestListFieldMapping:
+    """Tests for extracting errors from list-of-dicts data."""
+
+    def test_extracts_errors_from_list_of_dicts(self) -> None:
+        """Maps each dict item to a FileError using field_mapping."""
+        result = GearQCResult(
+            name="dicom-validator",
+            raw={
+                "state": "FAIL",
+                "data": [
+                    {"name": "Tag (0008,0050) is missing", "slices": "all"},
+                    {"name": "Tag (0010,0010) is missing", "slices": "all"},
+                ],
+            },
+        )
+        config = QCErrorConfig(
+            check_name="dicom-validator",
+            field_mapping=ListFieldMapping(
+                type="list",
+                message="name",
+                error_code="dicom-validation",
+            ),
+        )
+
+        errors = result.extract_errors(config)
+
+        assert len(errors) == 2
+        assert errors[0].message == "Tag (0008,0050) is missing"
+        assert errors[0].error_code == "dicom-validation"
+        assert errors[0].error_type == "error"
+        assert errors[1].message == "Tag (0010,0010) is missing"
+
+    def test_resolves_error_type_from_source(self) -> None:
+        """When error_type matches a key in source, uses source value."""
+        result = GearQCResult(
+            name="jsonschema-validation",
+            raw={
+                "state": "FAIL",
+                "data": [
+                    {
+                        "error_message": "'MR' is required",
+                        "error_type": "warning",
+                        "error_value": ["MR", "PT"],
+                    },
+                ],
+            },
+        )
+        config = QCErrorConfig(
+            check_name="jsonschema-validation",
+            field_mapping=ListFieldMapping(
+                type="list",
+                message="error_message",
+                error_type="error_type",
+                error_code="jsonschema-validation",
+            ),
+        )
+
+        errors = result.extract_errors(config)
+
+        assert len(errors) == 1
+        assert errors[0].message == "'MR' is required"
+        assert errors[0].error_type == "warning"
+        assert errors[0].error_code == "jsonschema-validation"
+
+    def test_literal_error_code_when_not_in_source(self) -> None:
+        """When error_code is not a key in source, uses it as literal."""
+        result = GearQCResult(
+            name="validator",
+            raw={
+                "state": "FAIL",
+                "data": [{"msg": "bad value"}],
+            },
+        )
+        config = QCErrorConfig(
+            check_name="validator",
+            field_mapping=ListFieldMapping(
+                type="list",
+                message="msg",
+                error_code="my-literal-code",
+            ),
+        )
+
+        errors = result.extract_errors(config)
+
+        assert len(errors) == 1
+        assert errors[0].error_code == "my-literal-code"
+
+    def test_empty_list_returns_no_errors(self) -> None:
+        """Empty data list produces no errors."""
+        result = GearQCResult(
+            name="validation",
+            raw={"state": "PASS", "data": []},
+        )
+        config = QCErrorConfig(
+            check_name="validation",
+            field_mapping=ListFieldMapping(type="list", message="message"),
+        )
+
+        errors = result.extract_errors(config)
+
+        assert len(errors) == 0
+
+    def test_non_list_data_returns_no_errors(self) -> None:
+        """Non-list data with list mapping produces no errors."""
+        result = GearQCResult(
+            name="validation",
+            raw={"state": "FAIL", "data": "some string"},
+        )
+        config = QCErrorConfig(
+            check_name="validation",
+            field_mapping=ListFieldMapping(type="list", message="message"),
+        )
+
+        errors = result.extract_errors(config)
+
+        assert len(errors) == 0
+
+    def test_null_data_returns_no_errors(self) -> None:
+        """Null data with list mapping produces no errors."""
+        result = GearQCResult(
+            name="validation",
+            raw={"state": "FAIL", "data": None},
+        )
+        config = QCErrorConfig(
+            check_name="validation",
+            field_mapping=ListFieldMapping(type="list", message="message"),
+        )
+
+        errors = result.extract_errors(config)
+
+        assert len(errors) == 0
+
+    def test_skips_non_dict_items_in_list(self) -> None:
+        """Non-dict items in the list are skipped."""
+        result = GearQCResult(
+            name="validation",
+            raw={
+                "state": "FAIL",
+                "data": [
+                    {"message": "real error"},
+                    "not a dict",
+                    42,
+                    {"message": "another error"},
+                ],
+            },
+        )
+        config = QCErrorConfig(
+            check_name="validation",
+            field_mapping=ListFieldMapping(type="list", message="message"),
+        )
+
+        errors = result.extract_errors(config)
+
+        assert len(errors) == 2
+        assert errors[0].message == "real error"
+        assert errors[1].message == "another error"
+
+    def test_value_field_extracted_when_configured(self) -> None:
+        """Optional value field is extracted when specified."""
+        result = GearQCResult(
+            name="validation",
+            raw={
+                "state": "FAIL",
+                "data": [
+                    {"message": "bad value", "value": "DX"},
+                ],
+            },
+        )
+        config = QCErrorConfig(
+            check_name="validation",
+            field_mapping=ListFieldMapping(
+                type="list", message="message", value="value"
+            ),
+        )
+
+        errors = result.extract_errors(config)
+
+        assert len(errors) == 1
+        assert errors[0].value == "DX"
+
+    def test_custom_data_key(self) -> None:
+        """Uses configured data_key instead of default 'data'."""
+        result = GearQCResult(
+            name="validation",
+            raw={
+                "state": "FAIL",
+                "errors": [{"msg": "found here"}],
+                "data": [{"msg": "not here"}],
+            },
+        )
+        config = QCErrorConfig(
+            check_name="validation",
+            data_key="errors",
+            field_mapping=ListFieldMapping(type="list", message="msg"),
+        )
+
+        errors = result.extract_errors(config)
+
+        assert len(errors) == 1
+        assert errors[0].message == "found here"
+
+
+# ===========================================================================
+# StringFieldMapping extraction
+# ===========================================================================
+
+
+class TestStringFieldMapping:
+    """Tests for extracting errors from string data."""
+
+    def test_string_data_becomes_error_message(self) -> None:
+        """String data is used directly as the error message."""
+        result = GearQCResult(
+            name="slice_consistency",
+            raw={
+                "state": "FAIL",
+                "data": "Inconsistent slice intervals. Majority are ~1.0mm(56)",
+            },
+        )
+        config = QCErrorConfig(
+            check_name="slice_consistency",
+            field_mapping=StringFieldMapping(
+                type="string",
+                error_code="slice-consistency",
+            ),
+        )
+
+        errors = result.extract_errors(config)
+
+        assert len(errors) == 1
+        assert errors[0].message == (
+            "Inconsistent slice intervals. Majority are ~1.0mm(56)"
+        )
+        assert errors[0].error_code == "slice-consistency"
+        assert errors[0].error_type == "error"
+
+    def test_custom_error_type(self) -> None:
+        """Uses configured error_type on synthesized error."""
+        result = GearQCResult(
+            name="bed_moving",
+            raw={"state": "FAIL", "data": "Bed moved during scan"},
+        )
+        config = QCErrorConfig(
+            check_name="bed_moving",
+            field_mapping=StringFieldMapping(
+                type="string",
+                error_type="warning",
+                error_code="bed-moving",
+            ),
+        )
+
+        errors = result.extract_errors(config)
+
+        assert len(errors) == 1
+        assert errors[0].error_type == "warning"
+
+    def test_null_data_returns_no_errors(self) -> None:
+        """Null data with string mapping produces no errors."""
+        result = GearQCResult(
+            name="slice_consistency",
+            raw={"state": "PASS", "data": None},
+        )
+        config = QCErrorConfig(
+            check_name="slice_consistency",
+            field_mapping=StringFieldMapping(
+                type="string", error_code="slice-consistency"
+            ),
+        )
+
+        errors = result.extract_errors(config)
+
+        assert len(errors) == 0
+
+    def test_list_data_returns_no_errors(self) -> None:
+        """List data with string mapping produces no errors."""
+        result = GearQCResult(
+            name="check",
+            raw={"state": "FAIL", "data": [{"msg": "something"}]},
+        )
+        config = QCErrorConfig(
+            check_name="check",
+            field_mapping=StringFieldMapping(type="string", error_code="check"),
+        )
+
+        errors = result.extract_errors(config)
+
+        assert len(errors) == 0
+
+
+# ===========================================================================
+# NoneFieldMapping extraction
+# ===========================================================================
+
+
+class TestNoneFieldMapping:
+    """Tests for synthesizing errors when data is null."""
+
+    def test_failed_check_with_null_data_synthesizes_message(self) -> None:
+        """FAIL state with null data synthesizes '{check_name} failed'."""
+        result = GearQCResult(
+            name="check_zero_byte",
+            raw={"state": "FAIL", "data": None},
+        )
+        config = QCErrorConfig(
+            check_name="check_zero_byte",
+            field_mapping=NoneFieldMapping(
+                type="none",
+                error_code="zero-byte",
+            ),
+        )
+
+        errors = result.extract_errors(config)
+
+        assert len(errors) == 1
+        assert errors[0].message == "check_zero_byte failed"
+        assert errors[0].error_code == "zero-byte"
+        assert errors[0].error_type == "error"
+
+    def test_in_review_state_synthesizes_message(self) -> None:
+        """IN REVIEW state with null data also synthesizes a message."""
+        result = GearQCResult(
+            name="embedded_localizer",
+            raw={"state": "IN REVIEW", "data": None},
+        )
+        config = QCErrorConfig(
+            check_name="embedded_localizer",
+            field_mapping=NoneFieldMapping(
+                type="none",
+                error_code="embedded-localizer",
+            ),
+        )
+
+        errors = result.extract_errors(config)
+
+        assert len(errors) == 1
+        assert errors[0].message == "embedded_localizer failed"
+
+    def test_pass_state_with_null_data_returns_no_errors(self) -> None:
+        """PASS state with null data produces no errors."""
+        result = GearQCResult(
+            name="check_zero_byte",
+            raw={"state": "PASS", "data": None},
+        )
+        config = QCErrorConfig(
+            check_name="check_zero_byte",
+            field_mapping=NoneFieldMapping(type="none", error_code="zero-byte"),
+        )
+
+        errors = result.extract_errors(config)
+
+        assert len(errors) == 0
+
+    def test_missing_data_key_with_fail_state(self) -> None:
+        """Missing data key (implicitly null) with FAIL state synthesizes."""
+        result = GearQCResult(
+            name="series_consistency",
+            raw={"state": "FAIL"},
+        )
+        config = QCErrorConfig(
+            check_name="series_consistency",
+            field_mapping=NoneFieldMapping(
+                type="none", error_code="series-consistency"
+            ),
+        )
+
+        errors = result.extract_errors(config)
+
+        assert len(errors) == 1
+        assert errors[0].message == "series_consistency failed"
+
+
+# ===========================================================================
+# Check name matching
+# ===========================================================================
+
+
+class TestCheckNameMatching:
+    """Tests that extraction only happens when check_name matches."""
+
+    def test_mismatched_check_name_returns_empty(self) -> None:
+        """Config targeting a different check returns no errors."""
+        result = GearQCResult(
+            name="dicom-validator",
+            raw={"state": "FAIL", "data": [{"name": "error"}]},
+        )
+        config = QCErrorConfig(
+            check_name="other-check",
+            field_mapping=ListFieldMapping(type="list", message="name"),
+        )
+
+        errors = result.extract_errors(config)
+
+        assert len(errors) == 0
+
+
+# ===========================================================================
+# GearQC.extract_errors integration
+# ===========================================================================
+
+
+class TestGearQCExtractErrors:
+    """Tests for GearQC-level error extraction across multiple configs."""
+
+    def test_aggregates_errors_from_multiple_configs(self) -> None:
+        """Combines errors from multiple check results."""
+        gear_qc = GearQC(
+            gear_name="dicom-qc",
+            raw={
+                "job_info": {"version": "0.5.9"},
+                "dicom-validator": {
+                    "state": "FAIL",
+                    "data": [{"name": "Tag missing", "slices": "all"}],
+                },
+                "slice_consistency": {
+                    "state": "FAIL",
+                    "data": "Inconsistent intervals",
+                },
+                "check_zero_byte": {
+                    "state": "FAIL",
+                    "data": None,
+                },
+                "embedded_localizer": {
+                    "state": "PASS",
+                    "data": None,
+                },
+            },
+        )
+        configs = [
+            QCErrorConfig(
+                check_name="dicom-validator",
+                field_mapping=ListFieldMapping(
+                    type="list", message="name", error_code="dicom-validation"
+                ),
+            ),
+            QCErrorConfig(
+                check_name="slice_consistency",
+                field_mapping=StringFieldMapping(
+                    type="string", error_code="slice-consistency"
+                ),
+            ),
+            QCErrorConfig(
+                check_name="check_zero_byte",
+                field_mapping=NoneFieldMapping(type="none", error_code="zero-byte"),
+            ),
+            QCErrorConfig(
+                check_name="embedded_localizer",
+                field_mapping=NoneFieldMapping(
+                    type="none", error_code="embedded-localizer"
+                ),
+            ),
+        ]
+
+        errors = gear_qc.extract_errors(configs)
+
+        # dicom-validator: 1 list error
+        # slice_consistency: 1 string error
+        # check_zero_byte: 1 synthesized error (FAIL + null)
+        # embedded_localizer: 0 (PASS + null)
+        assert len(errors) == 3
+        assert errors[0].message == "Tag missing"
+        assert errors[0].error_code == "dicom-validation"
+        assert errors[1].message == "Inconsistent intervals"
+        assert errors[1].error_code == "slice-consistency"
+        assert errors[2].message == "check_zero_byte failed"
+        assert errors[2].error_code == "zero-byte"
+
+    def test_no_configs_returns_empty(self) -> None:
+        """No error_configs returns empty list."""
+        gear_qc = GearQC(
+            gear_name="dicom-qc",
+            raw={
+                "dicom-validator": {"state": "FAIL", "data": [{"name": "err"}]},
+            },
+        )
+
+        errors = gear_qc.extract_errors(None)
+
+        assert len(errors) == 0
+
+    def test_config_for_missing_check_is_skipped(self) -> None:
+        """Config targeting a non-existent check is silently skipped."""
+        gear_qc = GearQC(
+            gear_name="dicom-qc",
+            raw={
+                "dicom-validator": {
+                    "state": "PASS",
+                    "data": [],
+                },
+            },
+        )
+        configs = [
+            QCErrorConfig(
+                check_name="nonexistent",
+                field_mapping=NoneFieldMapping(type="none", error_code="x"),
+            ),
+        ]
+
+        errors = gear_qc.extract_errors(configs)
+
+        assert len(errors) == 0
+
+
+# ===========================================================================
+# QCErrorConfig model validation
+# ===========================================================================
+
+
+class TestQCErrorConfigValidation:
+    """Tests that QCErrorConfig correctly parses discriminated field
+    mappings."""
+
+    def test_parses_list_mapping_from_dict(self) -> None:
+        """Validates list field mapping from raw dict."""
+        config = QCErrorConfig.model_validate(
+            {
+                "check_name": "validation",
+                "field_mapping": {
+                    "type": "list",
+                    "message": "message",
+                    "error_type": "type",
+                    "error_code": "code",
+                },
+            }
+        )
+
+        assert isinstance(config.field_mapping, ListFieldMapping)
+        assert config.field_mapping.message == "message"
+
+    def test_parses_string_mapping_from_dict(self) -> None:
+        """Validates string field mapping from raw dict."""
+        config = QCErrorConfig.model_validate(
+            {
+                "check_name": "slice_consistency",
+                "field_mapping": {
+                    "type": "string",
+                    "error_code": "slice-consistency",
+                },
+            }
+        )
+
+        assert isinstance(config.field_mapping, StringFieldMapping)
+        assert config.field_mapping.error_code == "slice-consistency"
+
+    def test_parses_none_mapping_from_dict(self) -> None:
+        """Validates none field mapping from raw dict."""
+        config = QCErrorConfig.model_validate(
+            {
+                "check_name": "check_zero_byte",
+                "field_mapping": {
+                    "type": "none",
+                    "error_code": "zero-byte",
+                },
+            }
+        )
+
+        assert isinstance(config.field_mapping, NoneFieldMapping)
+        assert config.field_mapping.error_code == "zero-byte"
+
+    def test_invalid_type_raises_validation_error(self) -> None:
+        """Invalid type discriminator raises ValidationError."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            QCErrorConfig.model_validate(
+                {
+                    "check_name": "check",
+                    "field_mapping": {
+                        "type": "invalid",
+                        "message": "msg",
+                    },
+                }
+            )

--- a/gear/pipeline_event_logger/test/python/pipeline_event_logger_test/test_qc_reader.py
+++ b/gear/pipeline_event_logger/test/python/pipeline_event_logger_test/test_qc_reader.py
@@ -288,6 +288,23 @@ class TestStringFieldMapping:
 
         assert len(errors) == 0
 
+    def test_pass_state_with_string_data_returns_no_errors(self) -> None:
+        """PASS state with non-null string data produces no errors."""
+        result = GearQCResult(
+            name="slice_consistency",
+            raw={"state": "PASS", "data": "All slices consistent"},
+        )
+        config = QCErrorConfig(
+            check_name="slice_consistency",
+            field_mapping=StringFieldMapping(
+                type="string", error_code="slice-consistency"
+            ),
+        )
+
+        errors = result.extract_errors(config)
+
+        assert len(errors) == 0
+
     def test_list_data_returns_no_errors(self) -> None:
         """List data with string mapping produces no errors."""
         result = GearQCResult(


### PR DESCRIPTION
## Summary

Bumps pipeline-event-logger from 0.1.1 to 0.2.0.

### Changes

* Discriminated field mapping for QC error extraction with three mapping types: ListFieldMapping, StringFieldMapping, and NoneFieldMapping
* String check data used directly as error message; null data with non-PASS state synthesizes a generic failure message
* State guard on StringFieldMapping for edge case handling
* Added gear configuration files for deployment

### Files modified

- gear/pipeline_event_logger/src/docker/manifest.json
- gear/pipeline_event_logger/src/docker/BUILD
- docs/pipeline_event_logger/CHANGELOG.md
