### PR TITLE
Skip disabled/deleted admin users in project-management

### DIFF
--- a/common/src/python/flywheel_adaptor/flywheel_proxy.py
+++ b/common/src/python/flywheel_adaptor/flywheel_proxy.py
@@ -30,11 +30,10 @@ from flywheel.models.subject import Subject
 from flywheel.models.user import User
 from flywheel.rest import ApiException
 from flywheel.view_builder import ViewBuilder
+from flywheel_adaptor.subject_adaptor import SubjectAdaptor
 from fw_client.client import FWClient
 from fw_utils import AttrDict
 from utils.decorators import api_retry
-
-from flywheel_adaptor.subject_adaptor import SubjectAdaptor
 
 log = logging.getLogger(__name__)
 
@@ -136,7 +135,7 @@ class FlywheelProxy:
             user_id: the ID to search for
 
         Returns:
-            a list with the user, or None if not found
+            the user, or None if not found
         """
         return self.__fw.users.find_first(f"_id={user_id}")
 
@@ -1498,14 +1497,15 @@ class ProjectAdaptor:
             permission.id for permission in permissions if permission.access == "admin"
         ]
         for user_id in admin_users:
+            if not user_id:
+                continue
             try:
                 self.add_user_role_assignments(
                     RolesRoleAssignment(id=user_id, role_ids=[admin_role.id])
                 )
             except ProjectError:
                 log.warning(
-                    "Unable to add admin user %s to project %s, user may not"
-                    " exist on this instance",
+                    "Unable to add admin user %s to project %s",
                     user_id,
                     self._project.label,
                 )

--- a/common/src/python/flywheel_adaptor/flywheel_proxy.py
+++ b/common/src/python/flywheel_adaptor/flywheel_proxy.py
@@ -30,10 +30,11 @@ from flywheel.models.subject import Subject
 from flywheel.models.user import User
 from flywheel.rest import ApiException
 from flywheel.view_builder import ViewBuilder
-from flywheel_adaptor.subject_adaptor import SubjectAdaptor
 from fw_client.client import FWClient
 from fw_utils import AttrDict
 from utils.decorators import api_retry
+
+from flywheel_adaptor.subject_adaptor import SubjectAdaptor
 
 log = logging.getLogger(__name__)
 

--- a/docs/project_management/CHANGELOG.md
+++ b/docs/project_management/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this gear are documented in this file.
 
 ## [Unreleased]
 
+## 2.6.1
+
+* Skips disabled or deleted admin users when assigning admin roles to projects, preventing stale permissions from being propagated
+
 ## 2.6.0
 
 * Adds flexible configuration support for page projects with center/study levels

--- a/gear/project_management/src/docker/BUILD
+++ b/gear/project_management/src/docker/BUILD
@@ -4,5 +4,5 @@ docker_image(
     name="project-management",
     source="Dockerfile",
     dependencies=[":manifest", "gear/project_management/src/python/project_app:bin"],
-    image_tags=["2.6.0", "latest"],
+    image_tags=["2.6.1", "latest"],
 )

--- a/gear/project_management/src/docker/manifest.json
+++ b/gear/project_management/src/docker/manifest.json
@@ -2,7 +2,7 @@
   "name": "project-management",
   "label": "Project management",
   "description": "Creates and updates projects from project YAML file",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "author": "NACC",
   "maintainer": "NACC <nacchelp@uw.edu>",
   "cite": "",
@@ -15,7 +15,7 @@
   "custom": {
     "gear-builder": {
       "category": "utility",
-      "image": "naccdata/project-management:2.6.0"
+      "image": "naccdata/project-management:2.6.1"
     },
     "flywheel": {
       "suite": "NACC Admin Gears",

--- a/gear/project_management/src/python/project_app/main.py
+++ b/gear/project_management/src/python/project_app/main.py
@@ -5,6 +5,7 @@ from typing import List, Optional
 
 from authorization.client import AuthorizationClient
 from centers.nacc_group import NACCGroup
+from flywheel.models.access_permission import AccessPermission
 from flywheel.models.group_role import GroupRole
 from flywheel_adaptor.flywheel_proxy import FlywheelProxy
 from projects.hierarchy_seeder import ResourceHierarchySeeder
@@ -12,6 +13,51 @@ from projects.study import StudyModel
 from projects.study_mapping import StudyMappingVisitor
 
 log = logging.getLogger(__name__)
+
+
+def get_active_admin_permissions(
+    proxy: FlywheelProxy, permissions: List[AccessPermission]
+) -> List[AccessPermission]:
+    """Filters admin permissions to only include active (non-disabled, non-
+    deleted) users.
+
+    Looks up each admin user once and excludes any that are disabled or
+    deleted in Flywheel.
+
+    Args:
+      proxy: the flywheel proxy for user lookups
+      permissions: the group access permissions
+
+    Returns:
+      the filtered list of permissions for active admin users
+    """
+    active_permissions: List[AccessPermission] = []
+    for permission in permissions:
+        if permission.access != "admin":
+            active_permissions.append(permission)
+            continue
+
+        if not permission.id:
+            continue
+
+        user = proxy.find_user(permission.id)
+        if not user:
+            log.warning(
+                "Admin user %s not found on this instance, excluding",
+                permission.id,
+            )
+            continue
+
+        if user.disabled or user.deleted:
+            log.info(
+                "Excluding disabled/deleted admin user %s",
+                permission.id,
+            )
+            continue
+
+        active_permissions.append(permission)
+
+    return active_permissions
 
 
 def get_project_roles(flywheel_proxy, role_names: List[str]) -> List[GroupRole]:
@@ -58,7 +104,9 @@ def run(
 
     visitor = StudyMappingVisitor(
         flywheel_proxy=proxy,
-        admin_permissions=admin_group.get_user_access(),
+        admin_permissions=get_active_admin_permissions(
+            proxy, admin_group.get_user_access()
+        ),
         hierarchy_seeder=seeder,
     )
     for study in study_list:

--- a/mypy-stubs/src/python/flywheel/models/user.pyi
+++ b/mypy-stubs/src/python/flywheel/models/user.pyi
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import List, Optional
 
 
@@ -14,13 +15,13 @@ class User:
         roles: Optional[List[str]] = None,
         root: Optional[bool] = None,
         disabled: Optional[bool] = None,
+        deleted: Optional[datetime] = None,
         # preferences: Optional[preferences],
         # wechat: Optional[wechat],
         # firstlogin: Optional[firstlogin],
         # lastlogin: Optional[lastlogin],
         # created: Optional[created],
         # modified: Optional[modified],
-        # deleted: Optional[deleted],
         # api_key: Optional[api_key],
         # api_keys: Optional[api_keys]
     ) -> None:
@@ -32,6 +33,14 @@ class User:
 
     @property
     def email(self) -> Optional[str]:
+        ...
+
+    @property
+    def disabled(self) -> Optional[bool]:
+        ...
+
+    @property
+    def deleted(self) -> Optional[datetime]:
         ...
 
     @property


### PR DESCRIPTION
## Summary

Fixes project-management gear to exclude disabled or deleted Flywheel users when assigning admin roles to projects.

## Changes

- Adds `get_active_admin_permissions()` in `project_app/main.py` that filters the admin group permissions once at startup, excluding users that are disabled or deleted in Flywheel
- Updates the mypy stub for `flywheel.models.User` to expose the `disabled` and `deleted` properties
- Bumps version to 2.6.1

## What was tested

- mypy type checking passes
- Lint passes