### PR TITLE
Bump curator to 2.3.6

### DIFF
--- a/docs/attribute_curator/CHANGELOG.md
+++ b/docs/attribute_curator/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this gear are documented in this file.
 
+## 1.3.11
+
+* Updates `nacc-attribute-deriver` to `2.3.6` - fixes bug with checking for legacy NCRAD biomarker rounds
+
 ## 1.3.10
 
 * Updates `nacc-attribute-deriver` to `2.3.5` - allows legacy NCRAD biomarker rounds to automatically pass embargo

--- a/docs/attribute_curator/CHANGELOG.md
+++ b/docs/attribute_curator/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this gear are documented in this file.
 
-## 1.3.11
+## 1.3.11 - 1.3.12
 
 * Updates `nacc-attribute-deriver` to `2.3.6` - fixes bug with checking for legacy NCRAD biomarker rounds
 

--- a/gear/attribute_curator/src/docker/BUILD
+++ b/gear/attribute_curator/src/docker/BUILD
@@ -7,5 +7,5 @@ docker_image(
         ":manifest",
         "gear/attribute_curator/src/python/attribute_curator_app:bin",
     ],
-    image_tags=["1.3.11", "latest"],
+    image_tags=["1.3.12", "latest"],
 )

--- a/gear/attribute_curator/src/docker/BUILD
+++ b/gear/attribute_curator/src/docker/BUILD
@@ -7,5 +7,5 @@ docker_image(
         ":manifest",
         "gear/attribute_curator/src/python/attribute_curator_app:bin",
     ],
-    image_tags=["1.3.10", "latest"],
+    image_tags=["1.3.11", "latest"],
 )

--- a/gear/attribute_curator/src/docker/manifest.json
+++ b/gear/attribute_curator/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "attribute-curator",
     "label": "Attribute Curator",
     "description": "Curates data for the data freeze",
-    "version": "1.3.11",
+    "version": "1.3.12",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "analysis",
-            "image": "naccdata/attribute-curator:1.3.11"
+            "image": "naccdata/attribute-curator:1.3.12"
         },
         "flywheel": {
             "suite": "Curation",

--- a/gear/attribute_curator/src/docker/manifest.json
+++ b/gear/attribute_curator/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "attribute-curator",
     "label": "Attribute Curator",
     "description": "Curates data for the data freeze",
-    "version": "1.3.10",
+    "version": "1.3.11",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "analysis",
-            "image": "naccdata/attribute-curator:1.3.10"
+            "image": "naccdata/attribute-curator:1.3.11"
         },
         "flywheel": {
             "suite": "Curation",

--- a/mypy.lock
+++ b/mypy.lock
@@ -42,21 +42,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53",
-              "url": "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl"
+              "hash": "f072f4d804ea359e4eaf198b1af7a8b0943881a87f31bb764f8bf219bb9419e0",
+              "url": "https://files.pythonhosted.org/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89",
-              "url": "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz"
+              "hash": "13b2beaad985e05e2d6407ee4c4f35590b11f8d693a258a561055cac8f64cab7",
+              "url": "https://files.pythonhosted.org/packages/5f/56/a8120250d128bed162cd73c76d45f6ef9991f3e068f62a8ee060afa3104a/annotated_types-0.8.0.tar.gz"
             }
           ],
           "project_name": "annotated-types",
-          "requires_dists": [
-            "typing-extensions>=4.0.0; python_version < \"3.9\""
-          ],
-          "requires_python": ">=3.8",
-          "version": "0.7.0"
+          "requires_dists": [],
+          "requires_python": ">=3.10",
+          "version": "0.8.0"
         },
         {
           "artifacts": [

--- a/python-default.lock
+++ b/python-default.lock
@@ -2041,7 +2041,7 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "5787ee11becb2c3efce74497859425307a4038dcb924fb551026cbaab27475d0",
+              "hash": "52a8c282d1dd9dec89c5873c3a27a2e473ec167810386e7a57eb0db72f9f33d9",
               "url": "https://github.com/naccdata/nacc-attribute-deriver/releases/download/v2.3.6/nacc_attribute_deriver-2.3.6-py3-none-any.whl"
             }
           ],

--- a/python-default.lock
+++ b/python-default.lock
@@ -18,7 +18,7 @@
 //     "fw-utils>=3",
 //     "hypothesis>=6.0.0",
 //     "moto[s3,ses,ssm]==5.1.14",
-//     "nacc_attribute_deriver @ https://github.com/naccdata/nacc-attribute-deriver/releases/download/v2.3.5/nacc_attribute_deriver-2.3.5-py3-none-any.whl",
+//     "nacc_attribute_deriver @ https://github.com/naccdata/nacc-attribute-deriver/releases/download/v2.3.6/nacc_attribute_deriver-2.3.6-py3-none-any.whl",
 //     "nacc_form_validator @ https://github.com/naccdata/nacc-form-validator/releases/download/v0.6.4/nacc_form_validator-0.6.4-py3-none-any.whl",
 //     "natsort",
 //     "pandas-stubs>=2.0.3",
@@ -75,21 +75,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53",
-              "url": "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl"
+              "hash": "f072f4d804ea359e4eaf198b1af7a8b0943881a87f31bb764f8bf219bb9419e0",
+              "url": "https://files.pythonhosted.org/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89",
-              "url": "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz"
+              "hash": "13b2beaad985e05e2d6407ee4c4f35590b11f8d693a258a561055cac8f64cab7",
+              "url": "https://files.pythonhosted.org/packages/5f/56/a8120250d128bed162cd73c76d45f6ef9991f3e068f62a8ee060afa3104a/annotated_types-0.8.0.tar.gz"
             }
           ],
           "project_name": "annotated-types",
-          "requires_dists": [
-            "typing-extensions>=4.0.0; python_version < \"3.9\""
-          ],
-          "requires_python": ">=3.8",
-          "version": "0.7.0"
+          "requires_dists": [],
+          "requires_python": ">=3.10",
+          "version": "0.8.0"
         },
         {
           "artifacts": [
@@ -154,42 +152,42 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "aef0cccd5bc4a443fb3e64fada023f7b5b9da36864cb4255b68cf93067476676",
-              "url": "https://files.pythonhosted.org/packages/27/86/4aaa23e1433a6f4021258b1d8e4ec129bf691e419339454806807595a93d/boto3-1.43.47-py3-none-any.whl"
+              "hash": "feb699d4ab241ef5c1b80bb58277be2aaad365cd4b672d7817e0bc59ee45131b",
+              "url": "https://files.pythonhosted.org/packages/b8/57/3a960c9f581c00f2a591901b46e035ff79ab3956d16607f12306b3b8d483/boto3-1.43.56-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "09a8ce4abab4391bf08315e2dcc449b4b33e97ce7654ee9398d9fe4ef73a33da",
-              "url": "https://files.pythonhosted.org/packages/eb/76/8c2b062b9a9f27db8d78c3183213efd2cb31493b9a81853025da5254652e/boto3-1.43.47.tar.gz"
+              "hash": "57c90df9fb026f2e6ae22530861198130203733c5c9ec4e5cca3a4037f5a8db4",
+              "url": "https://files.pythonhosted.org/packages/53/05/23e1aa8c9e4b0399a61e7fd65c4f9cc0625121f24760e37471f776404abb/boto3-1.43.56.tar.gz"
             }
           ],
           "project_name": "boto3",
           "requires_dists": [
-            "botocore<1.44.0,>=1.43.47",
+            "botocore<1.44.0,>=1.43.56",
             "botocore[crt]<2.0a0,>=1.21.0; extra == \"crt\"",
             "jmespath<2.0.0,>=0.7.1",
             "s3transfer<0.20.0,>=0.19.0"
           ],
           "requires_python": ">=3.10",
-          "version": "1.43.47"
+          "version": "1.43.56"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "625e6c09883f0ad10c76becaa40616ee04434e4518ae4e56a698be700ab9ff85",
-              "url": "https://files.pythonhosted.org/packages/96/91/222f5c23852233bef33d26a6b56261634ec277234be68fedb084484aa579/boto3_stubs-1.43.47-py3-none-any.whl"
+              "hash": "8d3529082b3330e8718986a6a05cc0cd8319f8fddd10104eb7624e1c94b20fd2",
+              "url": "https://files.pythonhosted.org/packages/a0/62/2ba9e5d2378be5b3e1cfc8b444ee9a1b5d826493feb15df15cf47eae5c69/boto3_stubs-1.43.56-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "32b16abe5553f31dd43e51013c9256fea70c9d33f7c92a86e002fc275b876807",
-              "url": "https://files.pythonhosted.org/packages/83/ee/a6ea97cc6537797802b51c7018bb73045ca27945d84d288876790cc9870b/boto3_stubs-1.43.47.tar.gz"
+              "hash": "fe3d8049eb74dd7756dadd42f5a73b0f85ec3ed15f75b6e583f893f4563a0d2f",
+              "url": "https://files.pythonhosted.org/packages/fb/bc/1f2beda73136f950fc8b5596633803a82b482d793a4a85bdde926bc818b9/boto3_stubs-1.43.56.tar.gz"
             }
           ],
           "project_name": "boto3-stubs",
           "requires_dists": [
             "boto3-stubs-full<1.44.0,>=1.43.0; extra == \"full\"",
-            "boto3==1.43.47; extra == \"boto3\"",
+            "boto3==1.43.56; extra == \"boto3\"",
             "botocore-stubs",
             "mypy-boto3-accessanalyzer<1.44.0,>=1.43.0; extra == \"accessanalyzer\"",
             "mypy-boto3-accessanalyzer<1.44.0,>=1.43.0; extra == \"all\"",
@@ -1052,30 +1050,30 @@
             "typing-extensions>=4.1.0; python_version < \"3.12\""
           ],
           "requires_python": ">=3.9",
-          "version": "1.43.47"
+          "version": "1.43.56"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "4d16559a3a1866fa7b9e651dd1422c1a033497e069f8a73cae5eebafe70ff39c",
-              "url": "https://files.pythonhosted.org/packages/28/c0/6a8f824d613c5e5b8755ce99e3cf83fd1db135f5df02da7ed5bf106abdfd/botocore-1.43.47-py3-none-any.whl"
+              "hash": "aafc741f1b10f6fd63253eaf6ea029680c1ff436d87e1b8969d62aefa0c76976",
+              "url": "https://files.pythonhosted.org/packages/5c/cd/86fe9e659e9699f62f8dd5ecd8c6725474334b23cab8aa71d82b5f56f1a4/botocore-1.43.56-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "9e04d8da7f9cff8a911b14284829f78b74e1ce785444833199837decb5ecc17a",
-              "url": "https://files.pythonhosted.org/packages/76/2c/279bf51f68e85a12323996aa4a7f2a163da84dad949ee751caa318928ce1/botocore-1.43.47.tar.gz"
+              "hash": "6c01f85f0ff9863076f4c761e74ee3aa96c5ccc1ad09fc1efd62ef8f2d22bf57",
+              "url": "https://files.pythonhosted.org/packages/b9/cc/7f84a5d3071fe878380e9f610ab36ca87b8cbbc4aa81ba2727f90e1f3ea3/botocore-1.43.56.tar.gz"
             }
           ],
           "project_name": "botocore",
           "requires_dists": [
-            "awscrt==0.32.2; extra == \"crt\"",
+            "awscrt==0.36.0; extra == \"crt\"",
             "jmespath<2.0.0,>=0.7.1",
             "python-dateutil<3.0.0,>=2.1",
             "urllib3!=2.2.0,<3,>=1.25.4"
           ],
           "requires_python": ">=3.10",
-          "version": "1.43.47"
+          "version": "1.43.56"
         },
         {
           "artifacts": [
@@ -1122,19 +1120,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db",
-              "url": "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl"
+              "hash": "62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775",
+              "url": "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432",
-              "url": "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz"
+              "hash": "741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55",
+              "url": "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz"
             }
           ],
           "project_name": "certifi",
           "requires_dists": [],
           "requires_python": ">=3.7",
-          "version": "2026.6.17"
+          "version": "2026.7.22"
         },
         {
           "artifacts": [
@@ -1446,8 +1444,8 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "c74496b4e406a8bd00e375a544e2389299f923deae8e6e00155ff0180b212159",
-              "url": "https://files.pythonhosted.org/packages/76/b9/5db1268ceed81c2e529f5e71f98e1e8b1dc75ece633b4c5d144fd7d6959d/fw_client-2.3.1-py3-none-any.whl"
+              "hash": "14badd576efcfef3b23f1f33f065d40c89b3e802d45f1f863cff75c74c0011d8",
+              "url": "https://files.pythonhosted.org/packages/7b/c2/221aff2da8afb06911eb8c3b854d7c70fd2401bd2c7a6ceb30fc721fc171/fw_client-2.3.2-py3-none-any.whl"
             }
           ],
           "project_name": "fw-client",
@@ -1458,7 +1456,7 @@
             "packaging>=23"
           ],
           "requires_python": "<4,>=3.10",
-          "version": "2.3.1"
+          "version": "2.3.2"
         },
         {
           "artifacts": [
@@ -1544,13 +1542,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "5ce35188de461d31e8d000bfb8ef8bf22c6c16587a211e5571deaa5e9bdf842a",
-              "url": "https://files.pythonhosted.org/packages/c9/a1/7564199d1a8728fe737b0a72e5b3f8d92dfe085a74ddf7cdd83bce5f206d/httpcore2-2.5.0-py3-none-any.whl"
+              "hash": "6182472379e855fe4221246a2bb7ecede403bc61c6798062ae1787d051ccde26",
+              "url": "https://files.pythonhosted.org/packages/9f/fb/46c52b781975c335a2bcf1072c7bbc007cbdc8d674217f5ee1daba2c848b/httpcore2-2.9.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "88aa170137c17328d5ac44234f9fd10706466d5fb347f3edac4d39b91137b09d",
-              "url": "https://files.pythonhosted.org/packages/47/06/5c12df521b5322fb1114a83d46911b2fbcb8855ddb3a635f11c01a214af5/httpcore2-2.5.0.tar.gz"
+              "hash": "4d8acbf8b306f48c9d6046591fd5ba4037d1b1b1000d140fc2c3eab1e9a0c0e2",
+              "url": "https://files.pythonhosted.org/packages/39/a8/20ed1ed79cbc2ecdf5301c0968ab7c85547212e2a7bd126ddd2d986e206e/httpcore2-2.9.1.tar.gz"
             }
           ],
           "project_name": "httpcore2",
@@ -1563,111 +1561,132 @@
             "truststore>=0.10"
           ],
           "requires_python": ">=3.10",
-          "version": "2.5.0"
+          "version": "2.9.1"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "3d2d4d9cf4b61f1a1f46a95947cfdb47e80cb56a2f91c6256ac8f58e4891df41",
-              "url": "https://files.pythonhosted.org/packages/31/22/859d8252dad9bc9adee34b52e62cde621ece07b042ccb2ab4da1be46695f/httpx2-2.5.0-py3-none-any.whl"
+              "hash": "1820fe14a9ab1107bfeff39259987429450b070ec0ff38cc87eb0d8c97fdc71a",
+              "url": "https://files.pythonhosted.org/packages/13/b8/cfd91c4ab9134d386d48f0b6ac662ff3d4be6efdee59ee1c67ebc3c0487c/httpx2-2.9.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e2df9cb4611021527ff8a675b1c320b610a2ec397acc8d6fe6e91df2d9b33c29",
-              "url": "https://files.pythonhosted.org/packages/d0/e2/b5dedc0cf35aa65de5f541ccd30d2bc1fd7f1d43c9ab09f8ed9a7342317b/httpx2-2.5.0.tar.gz"
+              "hash": "1932a768737e3666291582833da748cc4e563c337cf96706fccc04fa6e58764a",
+              "url": "https://files.pythonhosted.org/packages/21/14/38128fbafd7e0ed41d874df6c9a653d47c2d111cfe59e2b4ac95161b4abd/httpx2-2.9.1.tar.gz"
             }
           ],
           "project_name": "httpx2",
           "requires_dists": [
-            "anyio",
+            "anyio>=4.10",
             "brotli; platform_python_implementation == \"CPython\" and extra == \"brotli\"",
             "brotlicffi; platform_python_implementation != \"CPython\" and extra == \"brotli\"",
-            "click==8.*; extra == \"cli\"",
+            "click>=8.4; extra == \"cli\"",
             "h2<5,>=3; extra == \"http2\"",
-            "httpcore2==2.5.0",
+            "httpcore2==2.9.1",
             "idna>=3.18",
             "pygments==2.*; extra == \"cli\"",
             "rich<16,>=10; extra == \"cli\"",
             "socksio==1.*; extra == \"socks\"",
             "truststore>=0.10",
             "typing-extensions>=4.5.0; python_version < \"3.13\"",
+            "wsproto>=1.2; extra == \"ws\"",
             "zstandard>=0.18.0; python_version <= \"3.13\" and extra == \"zstd\""
           ],
           "requires_python": ">=3.10",
-          "version": "2.5.0"
+          "version": "2.9.1"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "4ca8cc26ea2d31d22cf7710e92951cfaa921f0f8aa1b6db33a5176335f583a4f",
-              "url": "https://files.pythonhosted.org/packages/c1/8c/7524c1e5279e7728eb47c99f2357cbc5f08ae92e9bce49bf50118b53f9c9/hypothesis-6.156.6-cp312-cp312-musllinux_1_2_x86_64.whl"
+              "hash": "ea8e7e6bed5407ab902026d8cac74d10cac894a496d82e261a0beaca499114dc",
+              "url": "https://files.pythonhosted.org/packages/44/db/02e30bcdb3434f4eee8fdbebf5cf151fecd37d2a76f2fc19f2745c93ca38/hypothesis-6.161.5-cp312-cp312-musllinux_1_2_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b4e66aaa7385538a5d617174d47c198ee807f06de99e282a67c6cb724c69340d",
-              "url": "https://files.pythonhosted.org/packages/00/a9/753806f5292b40aeab1d269e408e3a7e85be3c0d88828fb78ab4a34d6626/hypothesis-6.156.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "cee9f1a563830a9137b9d1505c9c4fac760bc43dfbfa5873bebefe36c8dca4ec",
+              "url": "https://files.pythonhosted.org/packages/07/0d/699436929d2980103c9ddba153872ebed55cfcc13f0f78c1741ac6128205/hypothesis-6.161.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7489b9a8f9df8227edd6c7cd8b9ccfab2483bab24da6a474c175973ca2294f58",
-              "url": "https://files.pythonhosted.org/packages/02/2f/4d852bb8a9c73a68b18eca9b5b085285282122166e158f4d2a477639bfee/hypothesis-6.156.6-cp312-cp312-macosx_11_0_arm64.whl"
+              "hash": "ba73a3c3b68e63a0bee5ea1a8a13efce60bcc7ee5fc7e71df2954db39c225b95",
+              "url": "https://files.pythonhosted.org/packages/17/94/d208ced653376e7e0a2f0429ee5be864dd0b59393b98a8b41a35ceb4d035/hypothesis-6.161.5.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "caf6a93d011c10972da111c38ceb34ced20feaa8581e2b350c0655b022e27875",
-              "url": "https://files.pythonhosted.org/packages/1a/dc/0c2a851f06c91d5ac9ef0f3b9615efc1ed650411d2eee23b6334f491c85e/hypothesis-6.156.6-cp310-abi3-macosx_10_12_x86_64.whl"
+              "hash": "fd37a0257647288be8c27d56a78a31da2b65e3b6254511f03164f5e1c786187a",
+              "url": "https://files.pythonhosted.org/packages/1a/1d/a3cf1441550dbf5a362dcfa19c831721f3bb6a749eb53ecbdfc983959027/hypothesis-6.161.5-cp310-abi3-musllinux_1_2_riscv64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "55f3ec50161b4a95bae63bff2b5166e45935b493013d3be30ede279bf6192318",
-              "url": "https://files.pythonhosted.org/packages/1e/79/c425d22d734be0268ca60d120c6296299e4220a1783cb1a4cc76232807bb/hypothesis-6.156.6-cp310-abi3-musllinux_1_2_x86_64.whl"
+              "hash": "99d8b2380d0bba602df963d6e42d56bb50cf1734376c1b9b14dcab3cec21814e",
+              "url": "https://files.pythonhosted.org/packages/32/c7/d126b9f66295fed5d5745f98ad92f485c98dee303dd67ea7a53fe4a903aa/hypothesis-6.161.5-cp310-abi3-manylinux_2_5_i686.manylinux1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "96de02faefa3ce079873541da96f42595583bb001e8e4219294ed7d4501cc4cc",
-              "url": "https://files.pythonhosted.org/packages/20/83/8dbe89bdb8c6f25a7a52e7898af6d82fe35dfef08e5c702f6e33231ce6c6/hypothesis-6.156.6.tar.gz"
+              "hash": "4c89e0c35d7cd70af2a0a5f0b5ad69d1898c369adf15115c6d4271d47bf1b280",
+              "url": "https://files.pythonhosted.org/packages/34/58/e48aa878d119474631fc097d511b5e70807dfe56be4b244cce0275f1805e/hypothesis-6.161.5-cp310-abi3-macosx_10_12_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5291bd33c4704d274d7c214d5c200e77f372a06644f5cbbe96dcbe53cb2fbf10",
-              "url": "https://files.pythonhosted.org/packages/38/a6/ae636d4ca7f996a1ccb4b3d5997d949f1718fba52b01559b3ab53b237b3f/hypothesis-6.156.6-cp310-abi3-musllinux_1_2_aarch64.whl"
+              "hash": "59088f6458d2a6ef04724a2a639418c97dd8b8c280bfd222fcc5566854560caf",
+              "url": "https://files.pythonhosted.org/packages/4e/fe/f0f87c38dc741687bace80553478f8c9796ba5b6e68793a80990d79ec5ac/hypothesis-6.161.5-cp312-cp312-musllinux_1_2_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7baca17f4803ad4aa151732326f3990baf54c3127df44aa872ac5bdf8a98a9a6",
-              "url": "https://files.pythonhosted.org/packages/68/d8/86a0023740434098d1b187a62bd5f99b198f098fb43e7fc58342283a8270/hypothesis-6.156.6-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "19e57e621c6abd98123a91bd4b022bde7760ba709f1ca121f822d9aa291bd001",
+              "url": "https://files.pythonhosted.org/packages/56/de/277a17091687f298079c197cadd806d64908c5a08c9c91bb27b834192503/hypothesis-6.161.5-cp310-abi3-musllinux_1_2_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "42760873d6db1069d6edbaa355a61b9078a9950259efcfc72fc695741d7db7cd",
-              "url": "https://files.pythonhosted.org/packages/74/89/b9968070ae042f9bf3149bb6ba6399d5f28f452e0fb7f638cafc69ff0b9a/hypothesis-6.156.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "cf9dfba054164e481f05774c70b65ea88ba735b986cdc44f5210ef40871a32e9",
+              "url": "https://files.pythonhosted.org/packages/57/e5/2616432d6144057b6c8f4409c95d95610bdbdf07fecb6618e98761861c24/hypothesis-6.161.5-cp310-abi3-musllinux_1_2_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "08796b674c0b31a5dd4119b2173823390055921588d13eb77324e861b00fd7f8",
-              "url": "https://files.pythonhosted.org/packages/85/88/8386d064d680be27e936eba94f1448bc93ef6fa05473ee5034139f1c4284/hypothesis-6.156.6-cp312-cp312-musllinux_1_2_aarch64.whl"
+              "hash": "2a5c6400c58c9c3d616ad7177ada12ae577e5103b3b0df6e79920729250bf100",
+              "url": "https://files.pythonhosted.org/packages/70/69/031913f7408ebb41e31a9b20e5bca75c5a64ab151d57ca75e944a09ba6e0/hypothesis-6.161.5-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a922eedcd8618f9c2e17b79fa7b3f3f0b2df34e201958611cc3f0f46cca33c10",
-              "url": "https://files.pythonhosted.org/packages/8a/c3/3a5557f52912f2fecc6ed59642dcf80dd8e89d0d9664502b68e23d66bf3d/hypothesis-6.156.6-cp310-abi3-manylinux_2_5_i686.manylinux1_i686.whl"
+              "hash": "d7fcf44f9876b7b4fdc40b607342219c634cf6a1acc708dc0ff88e8e48ae8ea2",
+              "url": "https://files.pythonhosted.org/packages/8a/a5/2c28b58d16443fd8ad63e4f287440291a42135073748e5e511084f32a6f3/hypothesis-6.161.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a2a728b514fceb81e3f0464508911d5220fd74dadc3270f859427a686b60c4cf",
-              "url": "https://files.pythonhosted.org/packages/8c/45/9f009005b9c796f4a40424484ac7e70847bc088456fd940a937f96bb4b6d/hypothesis-6.156.6-cp312-cp312-macosx_10_12_x86_64.whl"
+              "hash": "1bb987e519a6d00675bab124c925000637e2e59384196b0ded5d108dc1851449",
+              "url": "https://files.pythonhosted.org/packages/9c/ff/c83c1a4d5d3c4b6a4dc1fcb5069245171b7a30ad5dd31f44282e8881e089/hypothesis-6.161.5-cp310-abi3-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "07f2bc9df1aeba80e12029c1618e2ee54abc440068c305d7075ffd6b85251843",
-              "url": "https://files.pythonhosted.org/packages/8e/f8/59203ca978ab51595d12d6bc7e7a63300d7373431ab42ca3f1742e45db68/hypothesis-6.156.6-cp310-abi3-macosx_11_0_arm64.whl"
+              "hash": "71aa718e08bdfbacd1a5d8f86ffd55f1d86e64a57cec6a107144d883b522823e",
+              "url": "https://files.pythonhosted.org/packages/b9/95/360884e86ab99099340fca781531286c26d40ce32c853097e76537cc0726/hypothesis-6.161.5-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8083806645f84243aade727f4978185caaa0b7190af4318673999ee15fdbf424",
-              "url": "https://files.pythonhosted.org/packages/9b/82/673453915fd0c67673f35a4876ba88f48c621335f293f3537d77b27d4286/hypothesis-6.156.6-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "66912038467e1af791f76336bc079d669f7c8bbf7aeb85bdd52e83259d885122",
+              "url": "https://files.pythonhosted.org/packages/bc/5b/6f3c9fbe9191432f33c9aaf951cf5a5416533848999f2e2c6a20ec00098b/hypothesis-6.161.5-cp310-abi3-manylinux_2_31_riscv64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "37016b6b4842993b06ee453dda4dedac5ef328cefa6daa36372d261abf12db43",
+              "url": "https://files.pythonhosted.org/packages/bf/37/71a53545f2732574bdd7a45a6e073043bce3447fec4aa722211ebf742f2e/hypothesis-6.161.5-cp312-cp312-macosx_10_12_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "5990e9e2e145ff5369c95ad684bd6eee7ebd2d4de37d37eea4c6ca5e339e2a52",
+              "url": "https://files.pythonhosted.org/packages/d2/04/7a5ba16cd14340009d1d8aa46083bf3a3a55c5b0d1ccf553e6f6748ee0e8/hypothesis-6.161.5-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "3b74cced62995ed2e0096fa63d0b7babd1fa08ce1944cff41134275516848708",
+              "url": "https://files.pythonhosted.org/packages/d7/e5/3f15b1a43cb70b223427ce3a9a6afbe430bf1754b3346ac546a3df38b96b/hypothesis-6.161.5-cp310-abi3-musllinux_1_2_armv7l.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "d60a204b86936b29d8914f93a99c59a2ecd4e311be793bf32a3f94774d41e016",
+              "url": "https://files.pythonhosted.org/packages/e6/56/7f32ba1443d5819b324444e7d5ebcf207ba4a0f9219a1693a7994293fd3f/hypothesis-6.161.5-cp312-cp312-macosx_11_0_arm64.whl"
             }
           ],
           "project_name": "hypothesis",
@@ -1677,15 +1696,15 @@
             "black>=20.8b0; extra == \"ghostwriter\"",
             "click>=7.0; extra == \"all\"",
             "click>=7.0; extra == \"cli\"",
-            "crosshair-tool>=0.0.107; extra == \"all\"",
-            "crosshair-tool>=0.0.107; extra == \"crosshair\"",
+            "crosshair-tool>=0.0.109; extra == \"all\"",
+            "crosshair-tool>=0.0.109; extra == \"crosshair\"",
             "django>=5.2; extra == \"all\"",
             "django>=5.2; extra == \"django\"",
             "dpcontracts>=0.4; extra == \"all\"",
             "dpcontracts>=0.4; extra == \"dpcontracts\"",
             "exceptiongroup>=1.0.0; python_full_version < \"3.11\"",
-            "hypothesis-crosshair>=0.0.28; extra == \"all\"",
-            "hypothesis-crosshair>=0.0.28; extra == \"crosshair\"",
+            "hypothesis-crosshair>=0.0.29; extra == \"all\"",
+            "hypothesis-crosshair>=0.0.29; extra == \"crosshair\"",
             "lark>=0.10.1; extra == \"all\"",
             "lark>=0.10.1; extra == \"lark\"",
             "libcst>=0.3.16; extra == \"all\"",
@@ -1705,13 +1724,13 @@
             "rich>=9.0.0; extra == \"all\"",
             "rich>=9.0.0; extra == \"cli\"",
             "sortedcontainers<3.0.0,>=2.1.0",
-            "tzdata>=2026.2; (sys_platform == \"emscripten\" and extra == \"all\") or (sys_platform == \"win32\" and extra == \"all\")",
-            "tzdata>=2026.2; (sys_platform == \"emscripten\" and extra == \"zoneinfo\") or (sys_platform == \"win32\" and extra == \"zoneinfo\")",
+            "tzdata>=2026.3; (sys_platform == \"emscripten\" and extra == \"all\") or (sys_platform == \"win32\" and extra == \"all\")",
+            "tzdata>=2026.3; (sys_platform == \"emscripten\" and extra == \"zoneinfo\") or (sys_platform == \"win32\" and extra == \"zoneinfo\")",
             "watchdog>=4.0.0; extra == \"all\"",
             "watchdog>=4.0.0; extra == \"watchdog\""
           ],
           "requires_python": ">=3.10",
-          "version": "6.156.6"
+          "version": "6.161.5"
         },
         {
           "artifacts": [
@@ -2022,8 +2041,8 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "3334fef0d441a6ef8a711043687001d854acf728277e67fe9b79694f76c9cd98",
-              "url": "https://github.com/naccdata/nacc-attribute-deriver/releases/download/v2.3.5/nacc_attribute_deriver-2.3.5-py3-none-any.whl"
+              "hash": "5787ee11becb2c3efce74497859425307a4038dcb924fb551026cbaab27475d0",
+              "url": "https://github.com/naccdata/nacc-attribute-deriver/releases/download/v2.3.6/nacc_attribute_deriver-2.3.6-py3-none-any.whl"
             }
           ],
           "project_name": "nacc-attribute-deriver",
@@ -2031,7 +2050,7 @@
             "pydantic>=2.10.6"
           ],
           "requires_python": "==3.12.*",
-          "version": "2.3.5"
+          "version": "2.3.6"
         },
         {
           "artifacts": [
@@ -2169,38 +2188,38 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "f8894dc474d648fe7b6ff0ca9b0bd73950d19952bc1a6534540762c5d79d305c",
-              "url": "https://files.pythonhosted.org/packages/f8/45/830bb57f533a4604b355e07edcb8ea18cf88b5f94e5fca92f27052d7c597/pandas-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl"
+              "hash": "a5ad3b02ed6bc7d7ae9b70804b2c6aa31827489d150f8e623ce82491b82085d7",
+              "url": "https://files.pythonhosted.org/packages/9d/e2/bd9c98ad2df7b38bde002adde4cdf353519da51881634323b126c55997f9/pandas-3.0.5-cp312-cp312-musllinux_1_2_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "fed2ff7fd9779120e388e285fc029bd5cf9490cdd2e4166a9ee22c0e49a9ab09",
-              "url": "https://files.pythonhosted.org/packages/24/f1/392f8c5bfc16f66a0d2d41561c01627c228fe7ed2a0d056ef11315042570/pandas-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl"
+              "hash": "d373ce03ffd84010ed9839fa73672a9c8256990532e158440c0085db7d914b34",
+              "url": "https://files.pythonhosted.org/packages/12/98/e976540c1addf70442be7842a18cf70884a964abbf69442504f4d2939989/pandas-3.0.5-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0383c72c75cdcca61a9e116e611143902dbfd08bff356829c2f6d1cf40a9ca8c",
-              "url": "https://files.pythonhosted.org/packages/31/a8/fa2535168fffcedf67f4f6de28d2dd903a747ca7c8ea6989451aaeb3a92f/pandas-3.0.3-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl"
+              "hash": "fa290c16964d4963fbfbc358928239cf3bd755b20e988ce944877def2f44471d",
+              "url": "https://files.pythonhosted.org/packages/1c/54/1dc810ea558d1320b597aa140a514f2fdf1d2ea09c38cf556f13ea712ec9/pandas-3.0.5-cp312-cp312-macosx_10_13_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6dc0b3fd2169c9157deed50b4d519553a3655c8c6a96027136d654592be973a9",
-              "url": "https://files.pythonhosted.org/packages/65/b6/09b01cdbc15224e2850365192d17b7bdebb8bdbd8780ed221fcdf0d9a515/pandas-3.0.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl"
+              "hash": "c2e26bb46934b8a2ca0c3de1d3d606fc5f6746584791b2db264d58cf370e08dc",
+              "url": "https://files.pythonhosted.org/packages/68/56/fbe81c09195924d8b7b8d4461a20458fe80a6a5ed6b24f0314da684277e1/pandas-3.0.5-cp312-cp312-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7e65d5407dc0b394f509699650e4a2ec01c0514f21850f453fa60f3be79a5dbf",
-              "url": "https://files.pythonhosted.org/packages/c9/a4/2eb28f2fccb4ced4a2c79ab2a5dee9ade1ebf44922ebad6fea158c9f95d4/pandas-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl"
+              "hash": "2a29c53d85ea98c5e792c59ef82ee9fbe6ca902c0d0adb6b23f45ef894cd7bf6",
+              "url": "https://files.pythonhosted.org/packages/a4/8c/1f29b5be8d3fc47dd7567eb167fabba2085879b31e0287ce7cba6d3d2ff4/pandas-3.0.5-cp312-cp312-musllinux_1_2_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b168fc218fd80a6cbdbdbc1a97ddc7889ed057d7eb45f50d866ceab5f39904c4",
-              "url": "https://files.pythonhosted.org/packages/cf/3d/b16412745651e855f357e5e66930248688378853a6e2698a214e331fba1f/pandas-3.0.3-cp312-cp312-macosx_11_0_arm64.whl"
+              "hash": "dca3734d6ab7c906e6730f0788b0a1dbb9f2467731f9711f77995c8e9d62d712",
+              "url": "https://files.pythonhosted.org/packages/be/4f/5f3422a2afec5ffc46308b79e53291365a93748b498ac2e58bead0197916/pandas-3.0.5.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "696a4a00a2a2a35d4e5deb3fc946641b96c944f02230e4f76137fe35d806c4fc",
-              "url": "https://files.pythonhosted.org/packages/f8/87/4341c6252d1c47b08768c3d25ac487362bf403f0313ddae4a2a26c9b1b4c/pandas-3.0.3.tar.gz"
+              "hash": "73fa87b08a7ef706f8aafda39ddaccf2a99047bea62d8c88a0361bcafb2237bc",
+              "url": "https://files.pythonhosted.org/packages/e0/51/fac252f4a913ed5eabf3c11b880a9e8d5a6c10f0b2129d0462212d238b4d/pandas-3.0.5-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl"
             }
           ],
           "project_name": "pandas",
@@ -2260,8 +2279,8 @@
             "pyreadstat>=1.2.8; extra == \"spss\"",
             "pytest-xdist>=3.6.1; extra == \"all\"",
             "pytest-xdist>=3.6.1; extra == \"test\"",
+            "pytest<9.1,>=8.3.4; extra == \"test\"",
             "pytest>=8.3.4; extra == \"all\"",
-            "pytest>=8.3.4; extra == \"test\"",
             "python-calamine>=0.3.0; extra == \"all\"",
             "python-calamine>=0.3.0; extra == \"excel\"",
             "python-dateutil>=2.8.2",
@@ -2291,7 +2310,7 @@
             "zstandard>=0.23.0; extra == \"compression\""
           ],
           "requires_python": ">=3.11",
-          "version": "3.0.3"
+          "version": "3.0.5"
         },
         {
           "artifacts": [
@@ -2668,19 +2687,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "04156e608bee23d3792fd45c94ae47fae1036688e75032eea2e3bf0323d1f126",
-              "url": "https://files.pythonhosted.org/packages/ec/dd/96da98f892250475bdf2328112d7468abdd4acc7b902b6af23f4ed958ea0/pytz-2026.2-py2.py3-none-any.whl"
+              "hash": "dd95840dd199baea12d9cc096a1d452caa6596a1c1e4b5f3dbd1541855d5e815",
+              "url": "https://files.pythonhosted.org/packages/0f/7b/39c34ca613b0b198cb866466651b26b045e2009864c5183c979a3b83f383/pytz-2026.3.post1-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0e60b47b29f21574376f218fe21abc009894a2321ea16c6754f3cad6eb7cdd6a",
-              "url": "https://files.pythonhosted.org/packages/ff/46/dd499ec9038423421951e4fad73051febaa13d2df82b4064f87af8b8c0c3/pytz-2026.2.tar.gz"
+              "hash": "2211d3fcf9a797d3405cac96ac7f61d80e6a644f72a3309607282fe8a2010c5d",
+              "url": "https://files.pythonhosted.org/packages/fb/48/fb042503b6ca6cd271261dc559fd6432f7d8c713153e9ec5c591af4dfc1c/pytz-2026.3.post1.tar.gz"
             }
           ],
           "project_name": "pytz",
           "requires_dists": [],
           "requires_python": null,
-          "version": "2026.2"
+          "version": "2026.3.post1"
         },
         {
           "artifacts": [
@@ -2979,13 +2998,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "d5fd7005ee39307455ad5f310b5ea67f4b1960d7fed5b3671ee50c249de675de",
-              "url": "https://files.pythonhosted.org/packages/24/23/e84c64ad0e8bc59cd1b2ef98def848deff0ef3456c542afe74d51e9e8c85/s3transfer-0.19.1-py3-none-any.whl"
+              "hash": "d8168eccca828cbb2cd573675333f3bddd254313a9c42494b84c76b539e8ba25",
+              "url": "https://files.pythonhosted.org/packages/bc/e7/5c595c75e9f41a44f30e526eda465ea0b4eec93470e074e4a111b253f13a/s3transfer-0.19.2-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d3d6371dc3f1e5c5427b2b457bcf13bcf87bec334c95aed18642eae61f6926f3",
-              "url": "https://files.pythonhosted.org/packages/65/da/4bef7ce7bb989b222aa4785a413896dbec53306dfc59c6ce7d16a7ffbd6a/s3transfer-0.19.1.tar.gz"
+              "hash": "ba0309fd86be3c27dbf78cdd813c13c5e1df16e5874b99d2535ebbdfb9892993",
+              "url": "https://files.pythonhosted.org/packages/76/43/35e4d8aa320bffe8287fe8f65f578fa2d2db0a64212f0e710dce58267854/s3transfer-0.19.2.tar.gz"
             }
           ],
           "project_name": "s3transfer",
@@ -2994,7 +3013,7 @@
             "botocore[crt]<2.0a.0,>=1.37.4; extra == \"crt\""
           ],
           "requires_python": ">=3.10",
-          "version": "0.19.1"
+          "version": "0.19.2"
         },
         {
           "artifacts": [
@@ -3179,19 +3198,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "d6a9c5bd0de61460c8fdef8ab2b400f956a1a1075cce08d4e2b4434e478c50b8",
-              "url": "https://files.pythonhosted.org/packages/36/22/169273273ca34e9ab0ae2f387ba72ed7e09faaaf834da01d6b89c2bea71a/types_python_dateutil-2.9.0.20260518-py3-none-any.whl"
+              "hash": "1ae41d51a5c5f6bbeeb7f1f34df7086d55ff1605cf88d2ed71a7a276e1a7794e",
+              "url": "https://files.pythonhosted.org/packages/16/85/cff97326a81e7e8877803e78e3ea56c840b85bb811934b9c936f7c40f185/types_python_dateutil-2.9.0.20260716-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "51f02dc03b61c7f6a07df45797d4dfe8a1aa47f0b7db9ad89f6fd3a1a70e1b51",
-              "url": "https://files.pythonhosted.org/packages/8d/e8/c01bdf0d7c3659428c091fbd693177093639565bcbc86bc20098e6d37cc6/types_python_dateutil-2.9.0.20260518.tar.gz"
+              "hash": "1d55d1c3024bdb4861bb6a6622c9ec800c433d87bdc5b16fb84cdd0eed4ef2cb",
+              "url": "https://files.pythonhosted.org/packages/df/9a/aefb9f80ff79641d36149352afe66ca835c5e6894deb518418f786f4b8ad/types_python_dateutil-2.9.0.20260716.tar.gz"
             }
           ],
           "project_name": "types-python-dateutil",
           "requires_dists": [],
           "requires_python": ">=3.10",
-          "version": "2.9.0.20260518"
+          "version": "2.9.0.20260716"
         },
         {
           "artifacts": [
@@ -3215,19 +3234,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "d2150f75a231c9fe9c7463bd29487d93e60bac90400287351384bc2284eba7cd",
-              "url": "https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl"
+              "hash": "d57db930a4b2efbc57cf430ec8882765d246929432fa253092f383902329a453",
+              "url": "https://files.pythonhosted.org/packages/8b/42/0337fefc615e20ee55d1c8f71b774a9b2b734a04669139c20753b27a2a3a/types_pyyaml-6.0.12.20260724-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d917f83fb38462550338c1297faedd860b3ec83912b96b1e3d73255f7473e466",
-              "url": "https://files.pythonhosted.org/packages/b8/83/4a1afc3fbfcf5b8d46fc390cd95ed6b0dc9010a265f4e9f46314efffa37a/types_pyyaml-6.0.12.20260518.tar.gz"
+              "hash": "3c1ce1bb73cd5ec02e90390c2b1f00e810d241d8825fd73ff359696839271b6b",
+              "url": "https://files.pythonhosted.org/packages/3f/6f/a28f44bcd56bebed42b028a2894c79853e2f5e6b5279e633cb3f287a05e7/types_pyyaml-6.0.12.20260724.tar.gz"
             }
           ],
           "project_name": "types-pyyaml",
           "requires_dists": [],
           "requires_python": ">=3.10",
-          "version": "6.0.12.20260518"
+          "version": "6.0.12.20260724"
         },
         {
           "artifacts": [
@@ -3438,7 +3457,7 @@
     "fw-utils>=3",
     "hypothesis>=6.0.0",
     "moto[s3,ses,ssm]==5.1.14",
-    "nacc_attribute_deriver @ https://github.com/naccdata/nacc-attribute-deriver/releases/download/v2.3.5/nacc_attribute_deriver-2.3.5-py3-none-any.whl",
+    "nacc_attribute_deriver @ https://github.com/naccdata/nacc-attribute-deriver/releases/download/v2.3.6/nacc_attribute_deriver-2.3.6-py3-none-any.whl",
     "nacc_form_validator @ https://github.com/naccdata/nacc-form-validator/releases/download/v0.6.4/nacc_form_validator-0.6.4-py3-none-any.whl",
     "natsort",
     "pandas-stubs>=2.0.3",

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,4 +31,4 @@ ratelimit>=2.2.1
 ratelimit-types>=0.0.1
 redcap_api@ https://github.com/naccdata/redcap-api/releases/download/v0.3.0/redcap_api-0.3.0-py3-none-any.whl
 nacc_form_validator@ https://github.com/naccdata/nacc-form-validator/releases/download/v0.6.4/nacc_form_validator-0.6.4-py3-none-any.whl
-nacc_attribute_deriver@ https://github.com/naccdata/nacc-attribute-deriver/releases/download/v2.3.5/nacc_attribute_deriver-2.3.5-py3-none-any.whl
+nacc_attribute_deriver@ https://github.com/naccdata/nacc-attribute-deriver/releases/download/v2.3.6/nacc_attribute_deriver-2.3.6-py3-none-any.whl


### PR DESCRIPTION
Updated dependencies:

```
                                                                  
Lockfile diff: python-default.lock [python-default]
                                                                  
==                    Upgraded dependencies                     ==

  annotated-types                0.7.0        -->   0.8.0
  boto3                          1.43.47      -->   1.43.56
  boto3-stubs                    1.43.47      -->   1.43.56
  botocore                       1.43.47      -->   1.43.56
  certifi                        2026.6.17    -->   2026.7.22
  fw-client                      2.3.1        -->   2.3.2
  httpcore2                      2.5.0        -->   2.9.1
  httpx2                         2.5.0        -->   2.9.1
  hypothesis                     6.156.6      -->   6.161.5
  nacc-attribute-deriver         2.3.5        -->   2.3.6
  pandas                         3.0.3        -->   3.0.5
  pytz                           2026.2       -->   2026.3.post1
  s3transfer                     0.19.1       -->   0.19.2
  types-python-dateutil          2.9.0.20260518   -->   2.9.0.20260716
  types-pyyaml                   6.0.12.20260518   -->   6.0.12.20260724
                                                                  
Lockfile diff: mypy.lock [mypy]
                                                                  
==                    Upgraded dependencies                     ==

  annotated-types                0.7.0        -->   0.8.0
```