### PR TITLE
Refactor gather-submission-status and fix QC filename pattern

### DIFF
--- a/.kiro/specs/gather-submission-status-performance/.config.kiro
+++ b/.kiro/specs/gather-submission-status-performance/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "9ae3968f-1c28-4490-ac42-300f8bc7121b", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/gather-submission-status-performance/design.md
+++ b/.kiro/specs/gather-submission-status-performance/design.md
@@ -1,0 +1,331 @@
+# Design Document: Gather Submission Status Performance
+
+## Overview
+
+This design refactors `gather_submission_status`'s file-processing phase from sequential per-file `reload()` calls to concurrent reloading using a `ThreadPoolExecutor`. The clustering phase (CSV reading + project resolution) is unchanged.
+
+The key change is in `main.py`: instead of delegating to `ProjectReportVisitor.visit_project()` (which reloads files one-at-a-time), the gear directly iterates project files, filters them, reloads matching files concurrently, then processes each reloaded file single-threaded through the existing `FileQCModel` → `FileQCReportVisitor` → `WriterTableVisitor` path.
+
+### Design Rationale
+
+The current implementation has three layers of sequential `file.reload()`:
+1. `ProjectReportVisitor.visit_project()` reloads each file to check `file.info.qc`
+2. `ProjectReportVisitor.visit_file()` reloads the file again
+3. `FileQCModel.create()` reloads the file a third time
+
+For a center with 500 QC log files per project across 3 projects, that's up to 4,500 sequential API round-trips. The refactored version reloads each file exactly once concurrently, reducing API calls to ~1,500 but with 10x concurrency — a net ~30x walltime improvement on the reload-dominated phase.
+
+### Why Not Modify nacc-common?
+
+`ProjectReportVisitor` is used by other gears (it's a general-purpose project-file visitor). Modifying it to support concurrency would require careful API design affecting all consumers. Since this gear's usage pattern is straightforward (filter → reload → process), it's simpler and safer to replicate the filtering logic locally and orchestrate concurrency in the gear itself.
+
+## Architecture
+
+```mermaid
+flowchart TD
+    A[Request CSV] --> B[StatusRequestClusteringVisitor]
+    B --> C{Clustering OK?}
+    C -->|Failed| D[Return False]
+    C -->|OK| E[For each ADCID/project]
+    E --> F[Filter project.files by pattern + ptid + module]
+    F --> G[Concurrent reload via ThreadPoolExecutor]
+    G --> H[For each reloaded file, single-threaded]
+    H --> I{file.info has 'qc'?}
+    I -->|No| J[Log warning, skip]
+    I -->|Yes| K[FileQCModel.model_validate]
+    K --> L[file_visitor_builder creates FileQCReportVisitor]
+    L --> M[qc_model.apply visitor]
+    M --> N[table_visitor.visit_table]
+    N --> O[DictWriter rows written]
+```
+
+### Processing Flow
+
+**Phase 1: Clustering** (unchanged)
+- `read_csv` + `StatusRequestClusteringVisitor` reads the CSV, validates rows, clusters by ADCID, and resolves projects. This phase makes ~1 API call per unique ADCID and is not a bottleneck.
+
+**Phase 2: File gathering** (refactored)
+- For each ADCID's projects, filter `project.project.files` by filename pattern + ptid_set + modules (no API calls — file list is already in memory from project resolution)
+- Reload all matching files concurrently with `ThreadPoolExecutor(max_workers=reload_workers)`
+- Process each successfully-reloaded file single-threaded: validate QC info, build `FileQCModel`, create `FileQCReportVisitor`, apply model, write results
+
+## Components and Interfaces
+
+### Files Modified
+
+| File | Change |
+|------|--------|
+| `gear/gather_submission_status/src/python/gather_submission_status_app/main.py` | Rewrite: concurrent reload orchestration replaces `ProjectReportVisitor` |
+| `gear/gather_submission_status/src/python/gather_submission_status_app/run.py` | Add `reload_workers` to `__init__`, `create()`, and pass to `main.run()` |
+| `gear/gather_submission_status/src/docker/manifest.json` | Add `reload_workers` config field |
+
+### Files Unchanged
+
+- `common/src/python/data_requests/status_request.py` — `StatusRequestClusteringVisitor` is reused as-is
+- `nacc-common/src/python/nacc_common/qc_report.py` — all classes reused without modification
+- `nacc-common/src/python/nacc_common/visit_submission_status.py` — builder reused as-is
+- `nacc-common/src/python/nacc_common/visit_submission_error.py` — builder reused as-is
+- `nacc-common/src/python/nacc_common/error_models.py` — `FileQCModel` reused as-is
+
+### New `main.py` Signature
+
+```python
+def run(
+    *,
+    input_file: TextIO,
+    modules: set[str],
+    clustering_visitor: StatusRequestClusteringVisitor,
+    file_visitor_builder: FileQCReportVisitorBuilder,
+    writer: DictWriter,
+    error_writer: ErrorWriter,
+    reload_workers: int = 10,
+) -> bool:
+    """Runs the Gather Submission Status process with concurrent file reloading.
+
+    Phase 1: Reads and clusters the input CSV by ADCID (unchanged).
+    Phase 2: For each ADCID's projects, filters QC log files, reloads them
+    concurrently, then processes each single-threaded.
+
+    Args:
+        input_file: the input CSV stream
+        modules: set of module names to include
+        clustering_visitor: the CSV visitor that clusters requests by ADCID
+        file_visitor_builder: factory for creating FileQCReportVisitors
+        writer: the DictWriter for output rows
+        error_writer: collects per-request errors
+        reload_workers: number of concurrent threads for file.reload() calls
+
+    Returns:
+        True if processing completed successfully, False otherwise.
+    """
+```
+
+The signature adds only `reload_workers`. All other parameters remain the same.
+
+### Updated `run.py` Integration
+
+`GatherSubmissionStatusVisitor` changes:
+
+```python
+# __init__ adds:
+self.__reload_workers = reload_workers
+
+# create() adds:
+reload_workers = int(options.get("reload_workers", 10))
+if reload_workers <= 0:
+    raise GearExecutionError(
+        f"reload_workers must be a positive integer, got {reload_workers}"
+    )
+
+# run() call changes from:
+success = run(
+    input_file=csv_file,
+    modules=self.__modules,
+    clustering_visitor=clustering,
+    file_visitor_builder=self.__file_visitor_builder,
+    writer=writer,
+    error_writer=error_writer,
+)
+
+# To:
+success = run(
+    input_file=csv_file,
+    modules=self.__modules,
+    clustering_visitor=clustering,
+    file_visitor_builder=self.__file_visitor_builder,
+    writer=writer,
+    error_writer=error_writer,
+    reload_workers=self.__reload_workers,
+)
+```
+
+### manifest.json Addition
+
+```json
+{
+  "config": {
+    "reload_workers": {
+      "description": "Number of concurrent threads for reloading QC file metadata",
+      "type": "integer",
+      "default": 10
+    }
+  }
+}
+```
+
+## Detailed Processing Algorithm
+
+### File Filtering (replicated from ProjectReportVisitor)
+
+The filtering logic in the new `main.py` replicates what `ProjectReportVisitor.visit_project()` and `ProjectReportVisitor.__should_process_file()` do:
+
+```python
+QC_FILENAME_PATTERN = r"^([!-~]{1,10})_(\d{4}-\d{2}-\d{2})_(\w+)_qc-status.log$"
+
+def _should_process_file(
+    filename: str,
+    matcher: re.Pattern[str],
+    ptid_set: set[str],
+    modules: set[str],
+) -> bool:
+    """Check if a file should be processed based on ptid and module filters.
+
+    Replicates ProjectReportVisitor.__should_process_file logic.
+    """
+    match = matcher.match(filename)
+    if not match:
+        return False
+
+    ptid = match.group(1)
+    if ptid not in ptid_set:
+        return False
+
+    module = match.group(3).upper()
+    return module.upper() in modules
+```
+
+**Design detail not in requirements:** The current `ProjectReportVisitor.__should_process_file` treats `ptid_set=None` as "accept all ptids" and `modules=None` as "accept all modules". In our gear's usage, both are always non-None (ptid_set comes from the CSV request list, modules from config). The new `_should_process_file` function therefore requires both to be non-empty sets, matching the gear's actual usage rather than the library's generalized interface. This simplification is safe because `run.py` always passes non-empty module sets and the clustering visitor always produces non-empty ptid_sets.
+
+### Concurrent Reload
+
+```python
+with ThreadPoolExecutor(max_workers=reload_workers) as pool:
+    for project in project_list:
+        candidate_files = [
+            f for f in project.project.files
+            if _should_process_file(f.name, matcher, ptid_set, modules)
+        ]
+
+        # Submit all reloads concurrently
+        futures = {pool.submit(f.reload): f for f in candidate_files}
+
+        for future in as_completed(futures):
+            original_file = futures[future]
+            try:
+                reloaded_file = future.result()
+            except Exception as error:
+                log.warning(
+                    "Failed to reload file %s: %s", original_file.name, error
+                )
+                continue
+
+            _process_reloaded_file(
+                file=reloaded_file,
+                adcid=request_adcid,
+                file_visitor_builder=file_visitor_builder,
+                table_visitor=table_visitor,
+            )
+```
+
+**Design detail not in requirements:** We use `concurrent.futures.as_completed` rather than `pool.map` for two reasons:
+1. It allows individual reload failures to be caught and logged without aborting the entire batch
+2. It processes results as they arrive rather than waiting for all to complete, reducing memory pressure (file info objects are released after processing)
+
+The tradeoff is that output row ordering becomes non-deterministic (files are processed in completion order rather than iteration order). Requirement 2.2 explicitly allows this: "independent of row ordering."
+
+### Single-Threaded File Processing
+
+```python
+def _process_reloaded_file(
+    *,
+    file: FileEntry,
+    adcid: int,
+    file_visitor_builder: FileQCReportVisitorBuilder,
+    table_visitor: ReportTableVisitor,
+) -> None:
+    """Process a single reloaded QC log file.
+
+    Replicates the logic from ProjectReportVisitor.visit_file but operates
+    on an already-reloaded file.
+    """
+    if not file.info or not file.info.get("qc"):
+        log.warning("file does not have qc: %s", file.name)
+        return
+
+    try:
+        qc_model = FileQCModel.model_validate(file.info, by_alias=True)
+    except ValidationError as error:
+        log.warning("Failed to load QC data for %s: %s", file.name, error)
+        return
+
+    file_visitor = file_visitor_builder(file, adcid)
+    if file_visitor.visit_details is None:
+        log.warning("Could not extract visit details from %s", file.name)
+        return
+
+    try:
+        qc_model.apply(file_visitor)
+    except QCTransformerError as error:
+        log.error(
+            "Unexpected QC transformation error for file %s: %s", file.name, error
+        )
+        return
+
+    table_visitor.visit_table(file_visitor.table)
+```
+
+**Design detail not in requirements:** We call `FileQCModel.model_validate(file.info, by_alias=True)` directly instead of `FileQCModel.create(file)`. The reason: `FileQCModel.create()` calls `file_entry.reload()` internally — but we've already reloaded the file. Calling `model_validate` on the already-populated `file.info` avoids a redundant API call. This is a deliberate divergence from using the `create()` factory to eliminate the triple-reload problem.
+
+**Design detail not in requirements:** The `WriterTableVisitor` and its underlying `DictWriter` are not thread-safe. All calls to `table_visitor.visit_table()` happen in the main thread (inside the `as_completed` loop), never from within the worker threads. The worker threads only perform `file.reload()` — pure I/O with no shared mutable state.
+
+### ThreadPoolExecutor Scope
+
+The `ThreadPoolExecutor` is created once for the entire `run()` call and shared across all ADCID/project iterations. This avoids the overhead of creating and destroying thread pools per-project while still respecting the `reload_workers` concurrency limit globally.
+
+```python
+def run(...):
+    # Phase 1: clustering (unchanged)
+    ...
+
+    table_visitor = WriterTableVisitor(DictReportWriter(writer))
+    matcher = re.compile(QC_FILENAME_PATTERN)
+
+    with ThreadPoolExecutor(max_workers=reload_workers) as pool:
+        for pipeline_adcid, project_list in project_map.items():
+            ...
+            for project in project_list:
+                # filter, reload concurrently, process single-threaded
+                ...
+
+    return True
+```
+
+**Design detail not in requirements:** A single pool across all projects means that if one project has 1,000 files and another has 10, the pool naturally load-balances between them. It also means the `reload_workers` limit applies globally (not per-project), which matches the intent of capping concurrent connections to the Flywheel API.
+
+## Data Models
+
+### No New Data Models
+
+No new pydantic models or dataclasses are introduced. The existing `StatusRequest`, `FileQCModel`, `FileQCReportVisitor`, `WriterTableVisitor`, and `DictReportWriter` are reused unchanged.
+
+## Correctness Properties
+
+### Property 1: Filter Equivalence
+
+*For any* project file list and (ptid_set, modules) pair, the set of filenames accepted by `_should_process_file` SHALL be identical to the set that would be accepted by `ProjectReportVisitor.__should_process_file` when constructed with the same ptid_set and modules.
+
+**Validates: Requirements 2.1, 2.2, 6.3**
+
+### Property 2: No Shared Mutable State in Worker Threads
+
+*For any* execution, the `ThreadPoolExecutor` worker threads SHALL only execute `file.reload()` — a method that returns a new/updated `FileEntry` and does not mutate the `DictWriter`, `WriterTableVisitor`, or any shared collection.
+
+**Validates: Requirements 1.2, 1.3, 2.2**
+
+### Property 3: Reload Failure Isolation
+
+*For any* file whose `reload()` raises an exception, the processing of all other files SHALL continue unaffected, and a warning SHALL be logged identifying the failed file.
+
+**Validates: Requirements 1.4**
+
+### Property 4: QC Validation Equivalence
+
+*For any* reloaded file with `file.info.qc` populated, the report rows produced by `_process_reloaded_file` SHALL be identical to those produced by `ProjectReportVisitor.visit_file` for the same file and adcid (given the same `file_visitor_builder` and `table_visitor`).
+
+**Validates: Requirements 2.1, 2.2, 6.2**
+
+### Property 5: Non-Positive reload_workers Rejected
+
+*For any* non-positive integer value assigned to `reload_workers`, the gear SHALL raise a `GearExecutionError` before any processing begins.
+
+**Validates: Requirements 5.2**

--- a/.kiro/specs/gather-submission-status-performance/requirements.md
+++ b/.kiro/specs/gather-submission-status-performance/requirements.md
@@ -1,0 +1,86 @@
+# Requirements Document
+
+## Introduction
+
+The `gather-submission-status` gear processes QC log files to produce submission status and error reports. Currently, `ProjectReportVisitor.visit_project()` iterates project-level files sequentially — each matching file requires a `file.reload()` API call to populate `file.info.qc`. For centers with hundreds or thousands of QC log files across multiple projects, this sequential reload is the performance bottleneck.
+
+This spec refactors the gear's `main.py` to bypass `ProjectReportVisitor.visit_project()` and instead orchestrate file reloading concurrently using a `ThreadPoolExecutor`, following the same pattern applied to `gather_form_data` and `center_form_export`. The `nacc-common` library (including `ProjectReportVisitor`, `FileQCReportVisitor`, `FileQCModel`) remains unchanged.
+
+## Glossary
+
+- **Gather_Submission_Status_Gear**: The Flywheel gear that reads a CSV of (adcid, ptid) rows, resolves projects per ADCID, and gathers QC submission status or error data from QC log files
+- **QC_Log_File**: A project-level file matching the pattern `{ptid}_{date}_{module}_qc-status.log` that contains QC metadata in `file.info.qc`
+- **StatusRequestClusteringVisitor**: The CSV visitor that reads (adcid, ptid) rows, clusters requests by ADCID, and resolves projects per ADCID using `proxy.get_pipeline(adcid)` filtered by project name
+- **ProjectReportVisitor**: The nacc-common class that iterates project files, matches QC filenames, reloads files, validates QC info, and applies a `FileQCReportVisitor` to each file (NOT modified by this spec)
+- **FileQCReportVisitor**: The nacc-common visitor that processes a single file's QC model and produces report table rows (NOT modified by this spec)
+- **FileQCModel**: The nacc-common pydantic model that validates and wraps `file.info.qc` data (NOT modified by this spec)
+- **Reload_Workers**: A configurable parameter controlling the number of concurrent threads used to reload file metadata (default 10)
+- **QC_Filename_Pattern**: The regex `^([!-~]{1,10})_(\d{4}-\d{2}-\d{2})_(\w+)_qc-status.log$` used to identify QC log files
+- **Error_Writer**: The component that collects per-request errors for inclusion in QC metadata
+- **WriterTableVisitor**: The nacc-common visitor that writes report table rows to a DictWriter
+
+## Requirements
+
+### Requirement 1: Concurrent File Reloading
+
+**User Story:** As a data manager, I want QC log file reloads to happen concurrently, so that the gear completes in minutes rather than hours for centers with many QC files.
+
+#### Acceptance Criteria
+
+1. WHEN processing a project's files, THE Gather_Submission_Status_Gear SHALL filter project-level files by QC_Filename_Pattern, ptid_set, and module set before reloading
+2. WHEN matching files are identified for a project, THE Gather_Submission_Status_Gear SHALL reload all matching files concurrently using a ThreadPoolExecutor with Reload_Workers threads
+3. WHEN files are reloaded, THE Gather_Submission_Status_Gear SHALL process each reloaded file single-threaded through the existing FileQCReportVisitor and FileQCModel path
+4. IF a file reload raises an exception, THEN THE Gather_Submission_Status_Gear SHALL log a warning identifying the file and continue processing remaining files
+
+### Requirement 2: Preserved Output Format and Content
+
+**User Story:** As a downstream consumer of this gear's output, I want the output CSV format and content to remain identical, so that no downstream pipelines break.
+
+#### Acceptance Criteria
+
+1. THE Gather_Submission_Status_Gear SHALL produce CSV output with the same columns as the current implementation for both status and error query types
+2. THE Gather_Submission_Status_Gear SHALL produce the same row data as the current sequential implementation for identical input, independent of row ordering
+3. WHEN query_type is "status", THE Gather_Submission_Status_Gear SHALL use the StatusReportModel fieldnames and status_report_visitor_builder, identical to the current implementation
+4. WHEN query_type is "error", THE Gather_Submission_Status_Gear SHALL use the ErrorReportModel fieldnames and error_report_visitor_builder, identical to the current implementation
+
+### Requirement 3: Preserved Error Reporting and QC Metadata
+
+**User Story:** As a data manager, I want error reporting and QC metadata to remain unchanged, so that I can identify issues the same way as before.
+
+#### Acceptance Criteria
+
+1. WHEN the CSV input fails header validation or contains malformed rows, THE Gather_Submission_Status_Gear SHALL report errors via the Error_Writer with the same error codes and message format as the current implementation
+2. WHEN an ADCID has no matching projects, THE Gather_Submission_Status_Gear SHALL report a "no-projects" error via the Error_Writer identifying that ADCID, consistent with the current behavior
+3. WHEN a file does not have QC info after reload, THE Gather_Submission_Status_Gear SHALL log a warning identifying the file and skip processing, consistent with the current behavior
+4. WHEN processing completes, THE Gather_Submission_Status_Gear SHALL attach QC metadata to the input file with state "PASS" if processing succeeded or "FAIL" if errors occurred
+5. WHEN processing completes, THE Gather_Submission_Status_Gear SHALL tag the input file with the gear name, consistent with the current behavior
+
+### Requirement 4: Preserved Input Contract
+
+**User Story:** As an existing user of this gear, I want the input contract (CSV file with adcid and ptid columns) and all existing config options to continue working unchanged.
+
+#### Acceptance Criteria
+
+1. THE Gather_Submission_Status_Gear SHALL accept the same input file format (CSV with adcid and ptid column headers, case-insensitive) as the current implementation
+2. THE Gather_Submission_Status_Gear SHALL continue to accept all existing configuration fields (admin_group, project_names, modules, query_type, study_id, output_file, dry_run, apikey_path_prefix) with identical semantics
+3. THE StatusRequestClusteringVisitor SHALL remain unchanged in behavior, continuing to cluster requests by ADCID and resolve projects via proxy.get_pipeline
+
+### Requirement 5: Configurable Performance Parameter
+
+**User Story:** As a system operator, I want reload_workers to be a configurable gear parameter, so that I can tune concurrency without code changes.
+
+#### Acceptance Criteria
+
+1. THE Gather_Submission_Status_Gear SHALL expose a `reload_workers` configuration field with a default value of 10
+2. IF reload_workers is set to a non-positive integer, THEN THE Gather_Submission_Status_Gear SHALL raise a gear execution error before processing begins
+3. THE Gather_Submission_Status_Gear SHALL pass the configured reload_workers value to the ThreadPoolExecutor max_workers parameter
+
+### Requirement 6: No Changes to nacc-common
+
+**User Story:** As a library maintainer, I want the nacc-common package to remain unchanged, so that other gears using ProjectReportVisitor are unaffected.
+
+#### Acceptance Criteria
+
+1. THE Gather_Submission_Status_Gear SHALL NOT modify any files in the nacc-common package
+2. THE Gather_Submission_Status_Gear SHALL reuse the existing FileQCReportVisitor, FileQCModel, WriterTableVisitor, and extract_visit_keys functions from nacc-common without modification
+3. THE Gather_Submission_Status_Gear SHALL replicate the file-filtering and QC-validation logic currently in ProjectReportVisitor.visit_project within its own main.py, using the same QC_Filename_Pattern and filter conditions

--- a/.kiro/specs/gather-submission-status-performance/tasks.md
+++ b/.kiro/specs/gather-submission-status-performance/tasks.md
@@ -1,0 +1,108 @@
+# Implementation Plan: Gather Submission Status Performance
+
+## Overview
+
+Refactor `gather_submission_status` to reload QC log files concurrently using a `ThreadPoolExecutor`, replacing the sequential `ProjectReportVisitor.visit_project()` pattern. The clustering phase is unchanged; only the file-gathering phase is rewritten for concurrency.
+
+## Tasks
+
+- [x] 1. Add `reload_workers` config to manifest and update `run.py`
+  - [x] 1.1 Add `reload_workers` config field to manifest.json
+    - Edit `gear/gather_submission_status/src/docker/manifest.json`
+    - Add `"reload_workers": {"description": "Number of concurrent threads for reloading QC file metadata", "type": "integer", "default": 10}` to the `config` section
+    - _Requirements: 5.1_
+
+  - [x] 1.2 Add `reload_workers` to `GatherSubmissionStatusVisitor` in `run.py`
+    - Edit `gear/gather_submission_status/src/python/gather_submission_status_app/run.py`
+    - Add `reload_workers: int` parameter to `__init__` and store as `self.__reload_workers`
+    - In `create()`: read `reload_workers = int(options.get("reload_workers", 10))`, validate > 0 (raise `GearExecutionError` if not), pass to constructor
+    - In `run()`: pass `reload_workers=self.__reload_workers` to `main.run()`
+    - _Requirements: 5.1, 5.2, 5.3_
+
+- [x] 2. Rewrite `main.py` with concurrent file reloading
+  - [x] 2.1 Rewrite `main.py` with concurrent reload orchestration
+    - Replace contents of `gear/gather_submission_status/src/python/gather_submission_status_app/main.py`
+    - New `run()` signature adds `reload_workers: int = 10` parameter
+    - Add `_should_process_file(filename, matcher, ptid_set, modules)` helper that replicates `ProjectReportVisitor.__should_process_file` logic using `QC_FILENAME_PATTERN`
+    - Add `_process_reloaded_file(file, adcid, file_visitor_builder, table_visitor)` helper that validates `file.info.qc`, calls `FileQCModel.model_validate(file.info, by_alias=True)`, creates visitor via factory, applies model, writes to table_visitor
+    - Phase 1 (clustering): unchanged — `read_csv` + `clustering_visitor` with existing checks
+    - Phase 2 (file gathering): create single `ThreadPoolExecutor(max_workers=reload_workers)` for entire run, iterate ADCID/project pairs, filter `project.project.files` with `_should_process_file`, submit `f.reload` futures, use `as_completed` to process results via `_process_reloaded_file`
+    - Handle reload exceptions per-file (log warning, continue)
+    - Remove `ProjectReportVisitor` import (no longer used)
+    - Import `ThreadPoolExecutor` from `concurrent.futures`, `as_completed` from `concurrent.futures`, `FileQCModel` from `nacc_common.error_models`, `QCTransformerError` from `nacc_common.qc_report`, `ReportTableVisitor` from `nacc_common.qc_report`
+    - Keep `QC_FILENAME_PATTERN` imported from `nacc_common.qc_report` (or define locally matching the same pattern)
+    - _Requirements: 1.1, 1.2, 1.3, 1.4, 2.1, 2.2, 3.3, 3.4, 4.1, 6.2, 6.3_
+
+- [x] 3. Write tests for the refactored gear
+  - [x] 3.1 Write tests for `_should_process_file` filter equivalence
+    - Create `gear/gather_submission_status/test/python/gather_submission_status_test/__init__.py`
+    - Create `gear/gather_submission_status/test/python/gather_submission_status_test/conftest.py` with shared fixtures
+    - Create `gear/gather_submission_status/test/python/gather_submission_status_test/test_file_filter.py`
+    - Create `gear/gather_submission_status/test/python/gather_submission_status_test/BUILD` with `python_tests(name="tests")`
+    - Test that filenames matching QC pattern with ptid in ptid_set and module in modules are accepted
+    - Test that filenames not matching pattern are rejected
+    - Test that filenames with ptid NOT in ptid_set are rejected
+    - Test that filenames with module NOT in modules are rejected
+    - Test case-insensitive module matching (e.g., "uds" in filename matches "UDS" in modules)
+    - Use Hypothesis property-based testing: for any filename matching the QC pattern with ptid in ptid_set and module in modules, `_should_process_file` returns True
+    - _Requirements: 6.3_ / _Property 1: Filter Equivalence_
+
+  - [x] 3.2 Write tests for `_process_reloaded_file` processing logic
+    - Create `gear/gather_submission_status/test/python/gather_submission_status_test/test_process_file.py`
+    - Test that a file with valid `file.info.qc` produces expected report rows via the table_visitor
+    - Test that a file without `file.info.qc` is skipped (logs warning, no rows written)
+    - Test that a file with invalid QC data (ValidationError) is skipped (logs warning)
+    - Test that a file causing QCTransformerError is skipped (logs error)
+    - Test that file_visitor_builder is called with correct (file, adcid) arguments
+    - Mock `FileEntry` with `.name`, `.info` attributes; mock `file_visitor_builder`; use `ListReportWriter` for assertions
+    - _Requirements: 2.1, 2.2, 3.3, 6.2_ / _Property 4: QC Validation Equivalence_
+
+  - [x] 3.3 Write integration test for end-to-end `main.run()` flow
+    - Create `gear/gather_submission_status/test/python/gather_submission_status_test/test_main_integration.py`
+    - Test happy path: CSV with valid rows, projects with matching QC files, correct output rows written to DictWriter
+    - Test mixed path: some files reload successfully, one fails — successful files still processed, failed file logged
+    - Test empty project (no matching files): no output rows, returns True
+    - Test clustering failure (bad CSV): returns False, no file processing attempted
+    - Mock `StatusRequestClusteringVisitor` (or use real one with mocked proxy), mock `project.project.files` with mock FileEntry objects, mock `file.reload()` to return pre-populated files
+    - Verify `reload_workers` parameter is passed to ThreadPoolExecutor (can verify via mock or by testing with reload_workers=1 for deterministic ordering)
+    - _Requirements: 1.1, 1.2, 1.3, 1.4, 2.1, 4.1_ / _Property 3: Reload Failure Isolation_
+
+  - [x] 3.4 Write test for `reload_workers` validation in `run.py`
+    - Create `gear/gather_submission_status/test/python/gather_submission_status_test/test_config_validation.py`
+    - Test that `reload_workers=0` raises `GearExecutionError`
+    - Test that `reload_workers=-5` raises `GearExecutionError`
+    - Test that `reload_workers=1` is accepted (valid minimum)
+    - Mock `GearContext` with appropriate config options
+    - _Requirements: 5.2_ / _Property 5: Non-Positive reload_workers Rejected_
+
+- [x] 4. Final verification
+  - [x] 4.1 Run full quality check
+    - Run `full_quality_check` on all code to verify fix → lint → check → test pass
+    - Address any issues found
+    - _Requirements: all_
+
+## Notes
+
+- `ProjectReportVisitor` in nacc-common is NOT deleted or modified — other gears may still use it
+- `QC_FILENAME_PATTERN` is already exported from `nacc_common.qc_report` — import it rather than duplicating the string
+- `hypothesis>=6.0.0` is already in `requirements.txt`
+- manifest.json changes are JSON-only — no Pants quality checks needed for task 1.1
+- Subagents run targeted `pants_fix` + `pants_check` (source) or `pants_fix` + `pants_test` (tests) per subtask
+- The `post-task-quality-check` hook runs `full_quality_check` at wave boundaries (parent task completion)
+- The `tailor-on-file-create` hook runs `pants_tailor` when new `.py` files are created
+- Test directories use `_test` suffix per project convention (`gather_submission_status_test/`)
+- The existing `test/python/test_status_file.py` tests StatusRequest serialization and remains unchanged
+- The existing `test/python/BUILD` file may need updating to include the new test subdirectory
+
+## Task Dependency Graph
+
+```json
+{
+  "waves": [
+    { "id": 0, "tasks": ["1.1", "1.2"] },
+    { "id": 1, "tasks": ["2.1"] },
+    { "id": 2, "tasks": ["3.1", "3.2", "3.3", "3.4"] },
+    { "id": 3, "tasks": ["4.1"] }
+  ]
+}
+```

--- a/.kiro/specs/gather-submission-status-performance/tasks.meta.json
+++ b/.kiro/specs/gather-submission-status-performance/tasks.meta.json
@@ -1,0 +1,174 @@
+{
+  "pbtResults": {
+    "3.1 Write tests for `_should_process_file` filter equivalence": {
+      "status": "passed",
+      "lastRunTimestamp": 1785442027597
+    }
+  },
+  "executionHistory": {
+    "1.1 Add `reload_workers` config field to manifest.json": [
+      {
+        "executionId": "ae9fe956-182e-4919-8305-b558c6cb594d",
+        "chatSessionId": "sess_1b268725-cd62-4b19-a96c-e62544b46183",
+        "timestamp": 1785440848489
+      },
+      {
+        "executionId": "ae9fe956-182e-4919-8305-b558c6cb594d",
+        "chatSessionId": "sess_1b268725-cd62-4b19-a96c-e62544b46183",
+        "timestamp": 1785440857874
+      },
+      {
+        "executionId": "ae9fe956-182e-4919-8305-b558c6cb594d",
+        "chatSessionId": "sess_1b268725-cd62-4b19-a96c-e62544b46183",
+        "timestamp": 1785441693072
+      }
+    ],
+    "1.2 Add `reload_workers` to `GatherSubmissionStatusVisitor` in `run.py`": [
+      {
+        "executionId": "ae9fe956-182e-4919-8305-b558c6cb594d",
+        "chatSessionId": "sess_1b268725-cd62-4b19-a96c-e62544b46183",
+        "timestamp": 1785440848515
+      },
+      {
+        "executionId": "ae9fe956-182e-4919-8305-b558c6cb594d",
+        "chatSessionId": "sess_1b268725-cd62-4b19-a96c-e62544b46183",
+        "timestamp": 1785440857889
+      },
+      {
+        "executionId": "ae9fe956-182e-4919-8305-b558c6cb594d",
+        "chatSessionId": "sess_1b268725-cd62-4b19-a96c-e62544b46183",
+        "timestamp": 1785441693980
+      }
+    ],
+    "2.1 Rewrite `main.py` with concurrent reload orchestration": [
+      {
+        "executionId": "ae9fe956-182e-4919-8305-b558c6cb594d",
+        "chatSessionId": "sess_1b268725-cd62-4b19-a96c-e62544b46183",
+        "timestamp": 1785440848550
+      },
+      {
+        "executionId": "ae9fe956-182e-4919-8305-b558c6cb594d",
+        "chatSessionId": "sess_1b268725-cd62-4b19-a96c-e62544b46183",
+        "timestamp": 1785441698486
+      },
+      {
+        "executionId": "ae9fe956-182e-4919-8305-b558c6cb594d",
+        "chatSessionId": "sess_1b268725-cd62-4b19-a96c-e62544b46183",
+        "timestamp": 1785441845822
+      }
+    ],
+    "3.1 Write tests for `_should_process_file` filter equivalence": [
+      {
+        "executionId": "ae9fe956-182e-4919-8305-b558c6cb594d",
+        "chatSessionId": "sess_1b268725-cd62-4b19-a96c-e62544b46183",
+        "timestamp": 1785440848576
+      },
+      {
+        "executionId": "ae9fe956-182e-4919-8305-b558c6cb594d",
+        "chatSessionId": "sess_1b268725-cd62-4b19-a96c-e62544b46183",
+        "timestamp": 1785441850185
+      },
+      {
+        "executionId": "ae9fe956-182e-4919-8305-b558c6cb594d",
+        "chatSessionId": "sess_1b268725-cd62-4b19-a96c-e62544b46183",
+        "timestamp": 1785442167506
+      }
+    ],
+    "3.2 Write tests for `_process_reloaded_file` processing logic": [
+      {
+        "executionId": "ae9fe956-182e-4919-8305-b558c6cb594d",
+        "chatSessionId": "sess_1b268725-cd62-4b19-a96c-e62544b46183",
+        "timestamp": 1785440848604
+      },
+      {
+        "executionId": "ae9fe956-182e-4919-8305-b558c6cb594d",
+        "chatSessionId": "sess_1b268725-cd62-4b19-a96c-e62544b46183",
+        "timestamp": 1785441851044
+      },
+      {
+        "executionId": "ae9fe956-182e-4919-8305-b558c6cb594d",
+        "chatSessionId": "sess_1b268725-cd62-4b19-a96c-e62544b46183",
+        "timestamp": 1785442168292
+      }
+    ],
+    "3.3 Write integration test for end-to-end `main.run()` flow": [
+      {
+        "executionId": "ae9fe956-182e-4919-8305-b558c6cb594d",
+        "chatSessionId": "sess_1b268725-cd62-4b19-a96c-e62544b46183",
+        "timestamp": 1785440848629
+      },
+      {
+        "executionId": "ae9fe956-182e-4919-8305-b558c6cb594d",
+        "chatSessionId": "sess_1b268725-cd62-4b19-a96c-e62544b46183",
+        "timestamp": 1785441851868
+      },
+      {
+        "executionId": "ae9fe956-182e-4919-8305-b558c6cb594d",
+        "chatSessionId": "sess_1b268725-cd62-4b19-a96c-e62544b46183",
+        "timestamp": 1785442169521
+      }
+    ],
+    "3.4 Write test for `reload_workers` validation in `run.py`": [
+      {
+        "executionId": "ae9fe956-182e-4919-8305-b558c6cb594d",
+        "chatSessionId": "sess_1b268725-cd62-4b19-a96c-e62544b46183",
+        "timestamp": 1785440848655
+      },
+      {
+        "executionId": "ae9fe956-182e-4919-8305-b558c6cb594d",
+        "chatSessionId": "sess_1b268725-cd62-4b19-a96c-e62544b46183",
+        "timestamp": 1785441852806
+      },
+      {
+        "executionId": "ae9fe956-182e-4919-8305-b558c6cb594d",
+        "chatSessionId": "sess_1b268725-cd62-4b19-a96c-e62544b46183",
+        "timestamp": 1785442170509
+      }
+    ],
+    "4.1 Run full quality check": [
+      {
+        "executionId": "ae9fe956-182e-4919-8305-b558c6cb594d",
+        "chatSessionId": "sess_1b268725-cd62-4b19-a96c-e62544b46183",
+        "timestamp": 1785440848678
+      },
+      {
+        "executionId": "ae9fe956-182e-4919-8305-b558c6cb594d",
+        "chatSessionId": "sess_1b268725-cd62-4b19-a96c-e62544b46183",
+        "timestamp": 1785442175158
+      },
+      {
+        "executionId": "ae9fe956-182e-4919-8305-b558c6cb594d",
+        "chatSessionId": "sess_1b268725-cd62-4b19-a96c-e62544b46183",
+        "timestamp": 1785442320770
+      }
+    ],
+    "1. Add `reload_workers` config to manifest and update `run.py`": [
+      {
+        "executionId": "ae9fe956-182e-4919-8305-b558c6cb594d",
+        "chatSessionId": "sess_1b268725-cd62-4b19-a96c-e62544b46183",
+        "timestamp": 1785441694000
+      }
+    ],
+    "2. Rewrite `main.py` with concurrent file reloading": [
+      {
+        "executionId": "ae9fe956-182e-4919-8305-b558c6cb594d",
+        "chatSessionId": "sess_1b268725-cd62-4b19-a96c-e62544b46183",
+        "timestamp": 1785441845853
+      }
+    ],
+    "3. Write tests for the refactored gear": [
+      {
+        "executionId": "ae9fe956-182e-4919-8305-b558c6cb594d",
+        "chatSessionId": "sess_1b268725-cd62-4b19-a96c-e62544b46183",
+        "timestamp": 1785442170533
+      }
+    ],
+    "4. Final verification": [
+      {
+        "executionId": "ae9fe956-182e-4919-8305-b558c6cb594d",
+        "chatSessionId": "sess_1b268725-cd62-4b19-a96c-e62544b46183",
+        "timestamp": 1785442320798
+      }
+    ]
+  }
+}

--- a/docs/gather_submission_status/CHANGELOG.md
+++ b/docs/gather_submission_status/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this gear are documented in this file.
 
+## 1.4.1
+
+* Add concurrent file reloading with configurable `reload_workers` parameter (default 10) for significantly faster processing of large projects
+* Fix qc-status file discovery to match filenames that include a visitnum segment (e.g., `2851_2025-09-02_10.00_uds_qc-status.log`). Previously only legacy filenames without visitnum were found.
+
 ## 1.4.0
 
 * Removes hardcoded module name restriction — any module name is now accepted without filtering or warnings

--- a/docs/nacc_common/CHANGELOG.md
+++ b/docs/nacc_common/CHANGELOG.md
@@ -4,6 +4,13 @@ Documentation of release versions of the `nacc-common` package.
 
 ## Unreleased
 
+## v3.1.2
+
+### Bug Fixes
+
+* Fix `QC_FILENAME_PATTERN` to match qc-status log files that include a visitnum segment (e.g., `2851_2025-09-02_10.00_uds_qc-status.log`). Files in the new format were previously invisible to all consumers of this pattern.
+* Switch pattern consumers (`extract_visit_keys`, `ProjectReportVisitor`, `_should_include_file`) to named capture groups for clarity.
+
 ## v3.1.1
 
 ### Bug Fixes

--- a/gear/gather_submission_status/src/docker/BUILD
+++ b/gear/gather_submission_status/src/docker/BUILD
@@ -7,5 +7,5 @@ docker_image(
         ":manifest",
         "gear/gather_submission_status/src/python/gather_submission_status_app:bin",
     ],
-    image_tags=["1.4.0", "latest"],
+    image_tags=["1.4.1", "latest"],
 )

--- a/gear/gather_submission_status/src/docker/manifest.json
+++ b/gear/gather_submission_status/src/docker/manifest.json
@@ -2,7 +2,7 @@
   "name": "gather-submission-status",
   "label": "Gather Submission Status",
   "description": "A gear for gathering form submission status",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "author": "NACC",
   "maintainer": "NACC <nacchelp@uw.edu>",
   "cite": "",
@@ -15,7 +15,7 @@
   "custom": {
     "gear-builder": {
       "category": "utility",
-      "image": "naccdata/gather-submission-status:1.4.0"
+      "image": "naccdata/gather-submission-status:1.4.1"
     },
     "flywheel": {
       "suite": "Utility",

--- a/gear/gather_submission_status/src/docker/manifest.json
+++ b/gear/gather_submission_status/src/docker/manifest.json
@@ -79,6 +79,11 @@
       "description": "Name of the output file",
       "type": "string",
       "default": "submission-status.csv"
+    },
+    "reload_workers": {
+      "description": "Number of concurrent threads for reloading QC file metadata",
+      "type": "integer",
+      "default": 10
     }
   },
   "command": "/bin/run"

--- a/gear/gather_submission_status/src/python/gather_submission_status_app/main.py
+++ b/gear/gather_submission_status/src/python/gather_submission_status_app/main.py
@@ -1,38 +1,135 @@
 """Defines Gather Submission Status Gear."""
 
 import logging
+import re
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from csv import DictWriter
 from typing import TextIO
 
 from data_requests.status_request import StatusRequestClusteringVisitor
+from flywheel.models.file_entry import FileEntry
 from inputs.csv_reader import read_csv
+from nacc_common.error_models import FileQCModel
 from nacc_common.qc_report import (
+    QC_FILENAME_PATTERN,
     DictReportWriter,
     FileQCReportVisitorBuilder,
-    ProjectReportVisitor,
+    QCTransformerError,
+    ReportTableVisitor,
     WriterTableVisitor,
 )
 from outputs.error_writer import ErrorWriter
-
-ModuleName = str
+from pydantic import ValidationError
 
 log = logging.getLogger(__name__)
+
+
+def _should_process_file(
+    *,
+    filename: str,
+    matcher: re.Pattern[str],
+    ptid_set: set[str],
+    modules: set[str],
+) -> bool:
+    """Check if a file should be processed based on ptid and module filters.
+
+    Replicates ProjectReportVisitor.__should_process_file logic.
+
+    Args:
+        filename: the filename to check
+        matcher: compiled QC_FILENAME_PATTERN regex
+        ptid_set: set of participant IDs to include
+        modules: set of module names to include (uppercased)
+
+    Returns:
+        True if the file matches pattern and passes ptid/module filters.
+    """
+    match = matcher.match(filename)
+    if not match:
+        return False
+
+    ptid = match.group(1)
+    if ptid not in ptid_set:
+        return False
+
+    module = match.group(3).upper()
+    return module in modules
+
+
+def _process_reloaded_file(
+    *,
+    file: FileEntry,
+    adcid: int,
+    file_visitor_builder: FileQCReportVisitorBuilder,
+    table_visitor: ReportTableVisitor,
+) -> None:
+    """Process a single reloaded QC log file.
+
+    Validates QC info, builds the model, creates a file visitor, applies the
+    model, and writes results to the table visitor.
+
+    Args:
+        file: the reloaded file entry with populated info
+        adcid: the ADCID for this file's center
+        file_visitor_builder: factory for creating FileQCReportVisitors
+        table_visitor: visitor that writes report table rows
+    """
+    if not file.info or not file.info.get("qc"):
+        log.warning("file does not have qc: %s", file.name)
+        return
+
+    try:
+        qc_model = FileQCModel.model_validate(file.info, by_alias=True)
+    except ValidationError as error:
+        log.warning("Failed to load QC data for %s: %s", file.name, error)
+        return
+
+    file_visitor = file_visitor_builder(file, adcid)
+    if file_visitor.visit_details is None:
+        log.warning("Could not extract visit details from %s", file.name)
+        return
+
+    try:
+        qc_model.apply(file_visitor)
+    except QCTransformerError as error:
+        log.error(
+            "Unexpected QC transformation error for file %s: %s", file.name, error
+        )
+        return
+
+    table_visitor.visit_table(file_visitor.table)
 
 
 def run(
     *,
     input_file: TextIO,
-    modules: set[ModuleName],
+    modules: set[str],
     clustering_visitor: StatusRequestClusteringVisitor,
     file_visitor_builder: FileQCReportVisitorBuilder,
     writer: DictWriter,
     error_writer: ErrorWriter,
-):
-    """Runs the Gather Submission Status process.
+    reload_workers: int = 10,
+) -> bool:
+    """Runs the Gather Submission Status process with concurrent file
+    reloading.
+
+    Phase 1: Reads and clusters the input CSV by ADCID (unchanged).
+    Phase 2: For each ADCID's projects, filters QC log files, reloads them
+    concurrently, then processes each single-threaded.
 
     Args:
-        proxy: the proxy for the Flywheel instance
+        input_file: the input CSV stream
+        modules: set of module names to include
+        clustering_visitor: the CSV visitor that clusters requests by ADCID
+        file_visitor_builder: factory for creating FileQCReportVisitors
+        writer: the DictWriter for output rows
+        error_writer: collects per-request errors
+        reload_workers: number of concurrent threads for file.reload() calls
+
+    Returns:
+        True if processing completed successfully, False otherwise.
     """
+    # Phase 1: Clustering (unchanged)
     ok_status = read_csv(
         input_file=input_file, error_writer=error_writer, visitor=clustering_visitor
     )
@@ -45,30 +142,62 @@ def run(
         log.warning("No projects found for requested data")
         return False
 
-    for pipeline_adcid, project_list in project_map.items():
-        if not project_list:
-            log.warning("No projects found for center %s participants", pipeline_adcid)
-            continue
+    table_visitor = WriterTableVisitor(DictReportWriter(writer))
+    matcher = re.compile(QC_FILENAME_PATTERN)
 
-        request_list = clustering_visitor.request_map.get(pipeline_adcid)
-        if not request_list:
-            log.warning("No participants found for center %s", pipeline_adcid)
-            continue
-        request_adcid = request_list[0].adcid  # all requests have same adcid
-        if request_adcid != pipeline_adcid:
-            log.error("Expect ADCID: %s got %s", pipeline_adcid, request_adcid)
-            continue
+    # Phase 2: Concurrent file gathering
+    with ThreadPoolExecutor(max_workers=reload_workers) as pool:
+        for pipeline_adcid, project_list in project_map.items():
+            if not project_list:
+                log.warning(
+                    "No projects found for center %s participants", pipeline_adcid
+                )
+                continue
 
-        ptid_set = {request.ptid for request in request_list}
-        for project in project_list:
-            log.info("visiting project %s/%s", pipeline_adcid, project.label)
-            project_visitor = ProjectReportVisitor(
-                adcid=pipeline_adcid,
-                modules=set(modules),
-                ptid_set=ptid_set,
-                file_visitor_factory=file_visitor_builder,
-                table_visitor=WriterTableVisitor(DictReportWriter(writer)),
-            )
-            project_visitor.visit_project(project.project)
+            request_list = clustering_visitor.request_map.get(pipeline_adcid)
+            if not request_list:
+                log.warning("No participants found for center %s", pipeline_adcid)
+                continue
+            request_adcid = request_list[0].adcid  # all requests have same adcid
+            if request_adcid != pipeline_adcid:
+                log.error("Expect ADCID: %s got %s", pipeline_adcid, request_adcid)
+                continue
+
+            ptid_set = {request.ptid for request in request_list}
+            for project in project_list:
+                log.info("visiting project %s/%s", pipeline_adcid, project.label)
+
+                candidate_files = [
+                    f
+                    for f in project.project.files
+                    if _should_process_file(
+                        filename=f.name,
+                        matcher=matcher,
+                        ptid_set=ptid_set,
+                        modules=modules,
+                    )
+                ]
+
+                # Submit all reloads concurrently
+                futures = {pool.submit(f.reload): f for f in candidate_files}
+
+                for future in as_completed(futures):
+                    original_file = futures[future]
+                    try:
+                        reloaded_file = future.result()
+                    except Exception as error:
+                        log.warning(
+                            "Failed to reload file %s: %s",
+                            original_file.name,
+                            error,
+                        )
+                        continue
+
+                    _process_reloaded_file(
+                        file=reloaded_file,
+                        adcid=request_adcid,
+                        file_visitor_builder=file_visitor_builder,
+                        table_visitor=table_visitor,
+                    )
 
     return True

--- a/gear/gather_submission_status/src/python/gather_submission_status_app/main.py
+++ b/gear/gather_submission_status/src/python/gather_submission_status_app/main.py
@@ -49,11 +49,11 @@ def _should_process_file(
     if not match:
         return False
 
-    ptid = match.group(1)
+    ptid = match.group("ptid")
     if ptid not in ptid_set:
         return False
 
-    module = match.group(3).upper()
+    module = match.group("module").upper()
     return module in modules
 
 

--- a/gear/gather_submission_status/src/python/gather_submission_status_app/main.py
+++ b/gear/gather_submission_status/src/python/gather_submission_status_app/main.py
@@ -33,13 +33,14 @@ def _should_process_file(
 ) -> bool:
     """Check if a file should be processed based on ptid and module filters.
 
-    Replicates ProjectReportVisitor.__should_process_file logic.
+    Replicates ProjectReportVisitor.__should_process_file logic without the
+    Optional handling — callers must provide populated sets (not None).
 
     Args:
         filename: the filename to check
         matcher: compiled QC_FILENAME_PATTERN regex
-        ptid_set: set of participant IDs to include
-        modules: set of module names to include (uppercased)
+        ptid_set: set of participant IDs to include (must not be None)
+        modules: set of module names to include, uppercased (must not be None)
 
     Returns:
         True if the file matches pattern and passes ptid/module filters.

--- a/gear/gather_submission_status/src/python/gather_submission_status_app/run.py
+++ b/gear/gather_submission_status/src/python/gather_submission_status_app/run.py
@@ -49,6 +49,7 @@ class GatherSubmissionStatusVisitor(GearExecutionEnvironment):
         study_id: str,
         file_visitor_builder: FileQCReportVisitorBuilder,
         fieldnames: List[str],
+        reload_workers: int,
     ):
         super().__init__(client=client)
         self.__admin_id = admin_id
@@ -59,6 +60,7 @@ class GatherSubmissionStatusVisitor(GearExecutionEnvironment):
         self.__study_id = study_id
         self.__file_visitor_builder = file_visitor_builder
         self.__report_fieldnames = fieldnames
+        self.__reload_workers = reload_workers
 
     @classmethod
     def create(
@@ -89,6 +91,12 @@ class GatherSubmissionStatusVisitor(GearExecutionEnvironment):
 
         study_id = options.get("study_id", "adrc")
 
+        reload_workers = int(options.get("reload_workers", 10))
+        if reload_workers <= 0:
+            raise GearExecutionError(
+                f"reload_workers must be a positive integer, got {reload_workers}"
+            )
+
         query_type_arg = options.get("query_type", "status")
         if query_type_arg not in ["error", "status"]:
             raise GearExecutionError(f"Invalid query_type: {query_type_arg}")
@@ -112,6 +120,7 @@ class GatherSubmissionStatusVisitor(GearExecutionEnvironment):
             study_id=study_id,
             file_visitor_builder=file_visitor_builder,
             fieldnames=fieldnames,
+            reload_workers=reload_workers,
         )
 
     def run(self, context: GearContext) -> None:
@@ -147,6 +156,7 @@ class GatherSubmissionStatusVisitor(GearExecutionEnvironment):
                     file_visitor_builder=self.__file_visitor_builder,
                     writer=writer,
                     error_writer=error_writer,
+                    reload_workers=self.__reload_workers,
                 )
 
             context.metadata.add_qc_result(

--- a/gear/gather_submission_status/test/python/gather_submission_status_test/BUILD
+++ b/gear/gather_submission_status/test/python/gather_submission_status_test/BUILD
@@ -1,0 +1,5 @@
+python_tests(name="tests")
+
+python_test_utils(
+    name="test_utils",
+)

--- a/gear/gather_submission_status/test/python/gather_submission_status_test/BUILD
+++ b/gear/gather_submission_status/test/python/gather_submission_status_test/BUILD
@@ -2,4 +2,5 @@ python_tests(name="tests")
 
 python_test_utils(
     name="test_utils",
+    sources=["conftest.py"],
 )

--- a/gear/gather_submission_status/test/python/gather_submission_status_test/conftest.py
+++ b/gear/gather_submission_status/test/python/gather_submission_status_test/conftest.py
@@ -1,0 +1,10 @@
+import re
+
+import pytest
+from nacc_common.qc_report import QC_FILENAME_PATTERN
+
+
+@pytest.fixture
+def qc_matcher() -> re.Pattern[str]:
+    """Compiled QC filename pattern matcher."""
+    return re.compile(QC_FILENAME_PATTERN)

--- a/gear/gather_submission_status/test/python/gather_submission_status_test/test_config_validation.py
+++ b/gear/gather_submission_status/test/python/gather_submission_status_test/test_config_validation.py
@@ -1,0 +1,67 @@
+"""Tests for reload_workers validation in run.py.
+
+Validates: Requirements 5.2 / Property 5: Non-Positive reload_workers Rejected
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+from gather_submission_status_app.run import GatherSubmissionStatusVisitor
+from gear_execution.gear_execution import GearExecutionError
+
+
+@pytest.fixture
+def mock_context():
+    """Create a mock GearContext with configurable options."""
+    context = Mock()
+    context.config.opts = {
+        "output_file": "test.csv",
+        "admin_group": "nacc",
+        "project_names": "ingest-form",
+        "modules": "UDS,FTLD",
+        "study_id": "adrc",
+        "query_type": "status",
+    }
+    return context
+
+
+@patch("gather_submission_status_app.run.InputFileWrapper.create")
+@patch("gather_submission_status_app.run.GearBotClient.create")
+def test_reload_workers_zero_raises(mock_bot_create, mock_input_create, mock_context):
+    """Test that reload_workers=0 raises GearExecutionError."""
+    mock_bot_create.return_value = Mock()
+    mock_input_create.return_value = Mock()
+    mock_context.config.opts["reload_workers"] = 0
+
+    with pytest.raises(
+        GearExecutionError, match="reload_workers must be a positive integer"
+    ):
+        GatherSubmissionStatusVisitor.create(mock_context)
+
+
+@patch("gather_submission_status_app.run.InputFileWrapper.create")
+@patch("gather_submission_status_app.run.GearBotClient.create")
+def test_reload_workers_negative_raises(
+    mock_bot_create, mock_input_create, mock_context
+):
+    """Test that reload_workers=-5 raises GearExecutionError."""
+    mock_bot_create.return_value = Mock()
+    mock_input_create.return_value = Mock()
+    mock_context.config.opts["reload_workers"] = -5
+
+    with pytest.raises(
+        GearExecutionError, match="reload_workers must be a positive integer"
+    ):
+        GatherSubmissionStatusVisitor.create(mock_context)
+
+
+@patch("gather_submission_status_app.run.InputFileWrapper.create")
+@patch("gather_submission_status_app.run.GearBotClient.create")
+def test_reload_workers_one_accepted(mock_bot_create, mock_input_create, mock_context):
+    """Test that reload_workers=1 is accepted (valid minimum)."""
+    mock_bot_create.return_value = Mock()
+    mock_input_create.return_value = Mock()
+    mock_context.config.opts["reload_workers"] = 1
+
+    visitor = GatherSubmissionStatusVisitor.create(mock_context)
+    assert visitor is not None

--- a/gear/gather_submission_status/test/python/gather_submission_status_test/test_file_filter.py
+++ b/gear/gather_submission_status/test/python/gather_submission_status_test/test_file_filter.py
@@ -1,0 +1,137 @@
+"""Tests for _should_process_file filter equivalence.
+
+Validates: Requirements 6.3 / Property 1: Filter Equivalence
+"""
+
+import datetime
+import re
+
+from gather_submission_status_app.main import _should_process_file
+from hypothesis import given
+from hypothesis import strategies as st
+from nacc_common.qc_report import QC_FILENAME_PATTERN
+
+
+class TestShouldProcessFileUnit:
+    """Unit tests for _should_process_file."""
+
+    def test_matching_filename_accepted(self, qc_matcher: re.Pattern[str]) -> None:
+        """Filename matching QC pattern with ptid in ptid_set and module in
+        modules is accepted."""
+        filename = "PT001_2024-01-15_UDS_qc-status.log"
+        ptid_set = {"PT001"}
+        modules = {"UDS"}
+
+        result = _should_process_file(
+            filename=filename,
+            matcher=qc_matcher,
+            ptid_set=ptid_set,
+            modules=modules,
+        )
+
+        assert result is True
+
+    def test_non_matching_pattern_rejected(self, qc_matcher: re.Pattern[str]) -> None:
+        """Filename not matching QC pattern is rejected."""
+        filename = "not-a-qc-file.csv"
+        ptid_set = {"PT001"}
+        modules = {"UDS"}
+
+        result = _should_process_file(
+            filename=filename,
+            matcher=qc_matcher,
+            ptid_set=ptid_set,
+            modules=modules,
+        )
+
+        assert result is False
+
+    def test_ptid_not_in_set_rejected(self, qc_matcher: re.Pattern[str]) -> None:
+        """Filename with ptid NOT in ptid_set is rejected."""
+        filename = "PT999_2024-01-15_UDS_qc-status.log"
+        ptid_set = {"PT001", "PT002"}
+        modules = {"UDS"}
+
+        result = _should_process_file(
+            filename=filename,
+            matcher=qc_matcher,
+            ptid_set=ptid_set,
+            modules=modules,
+        )
+
+        assert result is False
+
+    def test_module_not_in_modules_rejected(self, qc_matcher: re.Pattern[str]) -> None:
+        """Filename with module NOT in modules is rejected."""
+        filename = "PT001_2024-01-15_MDS_qc-status.log"
+        ptid_set = {"PT001"}
+        modules = {"UDS", "LBD"}
+
+        result = _should_process_file(
+            filename=filename,
+            matcher=qc_matcher,
+            ptid_set=ptid_set,
+            modules=modules,
+        )
+
+        assert result is False
+
+    def test_case_insensitive_module_matching(
+        self, qc_matcher: re.Pattern[str]
+    ) -> None:
+        """Module matching is case-insensitive: 'uds' in filename matches 'UDS'
+        in modules."""
+        filename = "PT001_2024-01-15_uds_qc-status.log"
+        ptid_set = {"PT001"}
+        modules = {"UDS"}
+
+        result = _should_process_file(
+            filename=filename,
+            matcher=qc_matcher,
+            ptid_set=ptid_set,
+            modules=modules,
+        )
+
+        assert result is True
+
+
+# Hypothesis strategies for generating valid QC filenames
+# ptid must match [!-~]{1,10} (ASCII 33-126). Exclude underscore to avoid
+# ambiguity with the literal '_' separators in the pattern.
+_ptid_alphabet = st.characters(
+    min_codepoint=33, max_codepoint=126, blacklist_characters="_"
+)
+_ptid_strategy = st.text(alphabet=_ptid_alphabet, min_size=1, max_size=10)
+_date_strategy = st.dates(
+    min_value=datetime.date(1000, 1, 1), max_value=datetime.date(9999, 12, 31)
+).map(lambda d: d.strftime("%Y-%m-%d"))
+# module must match \w+ — use ASCII letters and digits only to stay in the
+# ASCII subset that the regex expects.
+_module_alphabet = st.characters(
+    min_codepoint=48,
+    max_codepoint=122,
+    whitelist_categories=("Ll", "Lu", "Nd"),
+)
+_module_strategy = st.text(alphabet=_module_alphabet, min_size=1, max_size=10)
+
+
+@given(ptid=_ptid_strategy, date=_date_strategy, module=_module_strategy)
+def test_valid_filename_always_accepted(ptid: str, date: str, module: str) -> None:
+    """**Validates: Requirements 6.3**
+
+    Property: For any filename matching the QC pattern with ptid in ptid_set
+    and module (uppercased) in modules, _should_process_file returns True.
+    """
+    filename = f"{ptid}_{date}_{module}_qc-status.log"
+    matcher = re.compile(QC_FILENAME_PATTERN)
+    ptid_set = {ptid}
+    modules = {module.upper()}
+
+    result = _should_process_file(
+        filename=filename,
+        matcher=matcher,
+        ptid_set=ptid_set,
+        modules=modules,
+    )
+
+    assert result is True

--- a/gear/gather_submission_status/test/python/gather_submission_status_test/test_main_integration.py
+++ b/gear/gather_submission_status/test/python/gather_submission_status_test/test_main_integration.py
@@ -1,0 +1,507 @@
+"""Integration tests for end-to-end main.run() flow.
+
+Validates: Requirements 1.1, 1.2, 1.3, 1.4, 2.1, 4.1 /
+Property 3: Reload Failure Isolation
+"""
+
+import io
+from csv import DictWriter
+from typing import Any
+from unittest.mock import Mock, patch
+
+from gather_submission_status_app.main import run
+
+
+def _create_mock_file_entry(
+    name: str,
+    info: dict[str, Any] | None = None,
+    reload_side_effect: Exception | None = None,
+) -> Mock:
+    """Create a mock FileEntry with .name, .info, and .reload() method."""
+    file_entry = Mock()
+    file_entry.name = name
+    file_entry.info = info
+
+    if reload_side_effect:
+        file_entry.reload.side_effect = reload_side_effect
+    else:
+        # reload returns itself by default (already populated)
+        file_entry.reload.return_value = file_entry
+
+    return file_entry
+
+
+def _create_mock_clustering_visitor(
+    pipeline_map: dict[int, list[Any]],
+    request_map: dict[int, list[Any]],
+) -> Mock:
+    """Create a mock StatusRequestClusteringVisitor with pipeline_map and
+    request_map."""
+    visitor = Mock()
+    visitor.pipeline_map = pipeline_map
+    visitor.request_map = request_map
+    return visitor
+
+
+def _create_mock_project(label: str, files: list[Mock]) -> Mock:
+    """Create a mock ProjectAdaptor with .label and .project.files."""
+    project_adaptor = Mock()
+    project_adaptor.label = label
+    project_adaptor.project = Mock()
+    project_adaptor.project.files = files
+    return project_adaptor
+
+
+def _create_mock_request(adcid: int, ptid: str) -> Mock:
+    """Create a mock StatusRequest with .adcid and .ptid."""
+    request = Mock()
+    request.adcid = adcid
+    request.ptid = ptid
+    return request
+
+
+def _create_file_visitor_builder() -> Mock:
+    """Create a mock file_visitor_builder that returns a visitor with table
+    rows."""
+    mock_report_row = Mock()
+    mock_report_row.model_dump.return_value = {
+        "adcid": 1,
+        "ptid": "PT001",
+        "module": "UDS",
+        "visitdate": "2024-01-15",
+        "stage": "form-qc-checker",
+        "status": "PASS",
+    }
+
+    mock_file_visitor = Mock()
+    mock_file_visitor.visit_details = Mock()  # non-None
+    mock_file_visitor.table = [mock_report_row]
+
+    builder = Mock(return_value=mock_file_visitor)
+    return builder
+
+
+def _create_writer() -> tuple[DictWriter, io.StringIO]:
+    """Create a DictWriter backed by a StringIO buffer."""
+    output = io.StringIO()
+    fieldnames = ["adcid", "ptid", "module", "visitdate", "stage", "status"]
+    writer = DictWriter(output, fieldnames=fieldnames)
+    writer.writeheader()
+    return writer, output
+
+
+class TestHappyPath:
+    """Test the end-to-end happy path through main.run()."""
+
+    @patch("gather_submission_status_app.main.read_csv")
+    def test_valid_rows_produce_correct_output(self, mock_read_csv: Mock) -> None:
+        """CSV with valid rows, projects with matching QC files, correct output
+        rows written to DictWriter.
+
+        **Validates: Requirements 1.1, 1.2, 1.3, 2.1, 4.1**
+        """
+        # Setup read_csv to succeed
+        mock_read_csv.return_value = True
+
+        # Create file entries matching QC pattern
+        file_info = {
+            "qc": {
+                "form-qc-checker": {
+                    "validation": {"state": "PASS", "data": [], "cleared": []}
+                }
+            }
+        }
+        mock_file = _create_mock_file_entry(
+            name="PT001_2024-01-15_UDS_qc-status.log", info=file_info
+        )
+
+        # Create project with the matching file
+        project = _create_mock_project(label="ingest-project", files=[mock_file])
+
+        # Create clustering visitor results
+        adcid = 1
+        request = _create_mock_request(adcid=adcid, ptid="PT001")
+        clustering_visitor = _create_mock_clustering_visitor(
+            pipeline_map={adcid: [project]},
+            request_map={adcid: [request]},
+        )
+
+        # Create file_visitor_builder
+        builder = _create_file_visitor_builder()
+
+        # Create writer
+        writer, output = _create_writer()
+        error_writer = Mock()
+
+        input_file = io.StringIO("adcid,ptid\n1,PT001\n")
+
+        result = run(
+            input_file=input_file,
+            modules={"UDS"},
+            clustering_visitor=clustering_visitor,
+            file_visitor_builder=builder,
+            writer=writer,
+            error_writer=error_writer,
+            reload_workers=1,
+        )
+
+        assert result is True
+        # Verify the file was reloaded
+        mock_file.reload.assert_called_once()
+        # Verify file_visitor_builder was called
+        builder.assert_called_once()
+        # Verify output was written
+        output_content = output.getvalue()
+        assert "PT001" in output_content
+        assert "PASS" in output_content
+
+    @patch("gather_submission_status_app.main.read_csv")
+    def test_multiple_files_all_processed(self, mock_read_csv: Mock) -> None:
+        """Multiple matching files in a project all get processed.
+
+        **Validates: Requirements 1.1, 1.2, 1.3**
+        """
+        mock_read_csv.return_value = True
+
+        file_info = {
+            "qc": {
+                "form-qc-checker": {
+                    "validation": {"state": "PASS", "data": [], "cleared": []}
+                }
+            }
+        }
+        mock_file1 = _create_mock_file_entry(
+            name="PT001_2024-01-15_UDS_qc-status.log", info=file_info
+        )
+        mock_file2 = _create_mock_file_entry(
+            name="PT002_2024-02-20_UDS_qc-status.log", info=file_info
+        )
+
+        project = _create_mock_project(
+            label="ingest-project", files=[mock_file1, mock_file2]
+        )
+
+        adcid = 1
+        requests = [
+            _create_mock_request(adcid=adcid, ptid="PT001"),
+            _create_mock_request(adcid=adcid, ptid="PT002"),
+        ]
+        clustering_visitor = _create_mock_clustering_visitor(
+            pipeline_map={adcid: [project]},
+            request_map={adcid: requests},
+        )
+
+        # Builder returns distinct visitors for each file
+        call_count = {"n": 0}
+
+        def builder_side_effect(file: Any, adcid_arg: int) -> Mock:
+            call_count["n"] += 1
+            mock_row = Mock()
+            mock_row.model_dump.return_value = {
+                "adcid": adcid_arg,
+                "ptid": file.name.split("_")[0],
+                "module": "UDS",
+                "visitdate": "2024-01-15",
+                "stage": "form-qc-checker",
+                "status": "PASS",
+            }
+            visitor = Mock()
+            visitor.visit_details = Mock()
+            visitor.table = [mock_row]
+            return visitor
+
+        builder = Mock(side_effect=builder_side_effect)
+
+        writer, output = _create_writer()
+        error_writer = Mock()
+
+        result = run(
+            input_file=io.StringIO("adcid,ptid\n1,PT001\n1,PT002\n"),
+            modules={"UDS"},
+            clustering_visitor=clustering_visitor,
+            file_visitor_builder=builder,
+            writer=writer,
+            error_writer=error_writer,
+            reload_workers=1,
+        )
+
+        assert result is True
+        assert builder.call_count == 2
+        output_content = output.getvalue()
+        assert "PT001" in output_content
+        assert "PT002" in output_content
+
+
+class TestMixedPath:
+    """Tests where some files succeed and some fail."""
+
+    @patch("gather_submission_status_app.main.read_csv")
+    def test_reload_failure_does_not_block_others(self, mock_read_csv: Mock) -> None:
+        """Some files reload successfully, one fails — successful files still
+        processed, failed file logged.
+
+        **Validates: Requirements 1.4** / Property 3: Reload Failure Isolation
+        """
+        mock_read_csv.return_value = True
+
+        file_info = {
+            "qc": {
+                "form-qc-checker": {
+                    "validation": {"state": "PASS", "data": [], "cleared": []}
+                }
+            }
+        }
+
+        # File that reloads successfully
+        good_file = _create_mock_file_entry(
+            name="PT001_2024-01-15_UDS_qc-status.log", info=file_info
+        )
+
+        # File that fails to reload
+        bad_file = _create_mock_file_entry(
+            name="PT002_2024-02-20_UDS_qc-status.log",
+            info=file_info,
+            reload_side_effect=RuntimeError("API timeout"),
+        )
+
+        project = _create_mock_project(
+            label="ingest-project", files=[good_file, bad_file]
+        )
+
+        adcid = 1
+        requests = [
+            _create_mock_request(adcid=adcid, ptid="PT001"),
+            _create_mock_request(adcid=adcid, ptid="PT002"),
+        ]
+        clustering_visitor = _create_mock_clustering_visitor(
+            pipeline_map={adcid: [project]},
+            request_map={adcid: requests},
+        )
+
+        builder = _create_file_visitor_builder()
+
+        writer, output = _create_writer()
+        error_writer = Mock()
+
+        result = run(
+            input_file=io.StringIO("adcid,ptid\n1,PT001\n1,PT002\n"),
+            modules={"UDS"},
+            clustering_visitor=clustering_visitor,
+            file_visitor_builder=builder,
+            writer=writer,
+            error_writer=error_writer,
+            reload_workers=1,
+        )
+
+        assert result is True
+        # The good file should still be processed
+        good_file.reload.assert_called_once()
+        builder.assert_called_once()
+        output_content = output.getvalue()
+        assert "PT001" in output_content
+
+
+class TestEmptyProject:
+    """Tests where projects have no matching files."""
+
+    @patch("gather_submission_status_app.main.read_csv")
+    def test_no_matching_files_returns_true(self, mock_read_csv: Mock) -> None:
+        """Empty project (no matching files): no output rows, returns True.
+
+        **Validates: Requirements 1.1**
+        """
+        mock_read_csv.return_value = True
+
+        # Only non-matching files in the project
+        non_matching_file = _create_mock_file_entry(name="random_data.csv", info=None)
+
+        project = _create_mock_project(
+            label="ingest-project", files=[non_matching_file]
+        )
+
+        adcid = 1
+        request = _create_mock_request(adcid=adcid, ptid="PT001")
+        clustering_visitor = _create_mock_clustering_visitor(
+            pipeline_map={adcid: [project]},
+            request_map={adcid: [request]},
+        )
+
+        builder = Mock()
+        writer, output = _create_writer()
+        error_writer = Mock()
+
+        result = run(
+            input_file=io.StringIO("adcid,ptid\n1,PT001\n"),
+            modules={"UDS"},
+            clustering_visitor=clustering_visitor,
+            file_visitor_builder=builder,
+            writer=writer,
+            error_writer=error_writer,
+            reload_workers=1,
+        )
+
+        assert result is True
+        # No file processing should have happened
+        builder.assert_not_called()
+        # Output should only contain the header
+        lines = output.getvalue().strip().split("\n")
+        assert len(lines) == 1  # header only
+
+
+class TestClusteringFailure:
+    """Tests where CSV clustering fails."""
+
+    @patch("gather_submission_status_app.main.read_csv")
+    def test_bad_csv_returns_false(self, mock_read_csv: Mock) -> None:
+        """Clustering failure (bad CSV): returns False, no file processing
+        attempted.
+
+        **Validates: Requirements 4.1**
+        """
+        mock_read_csv.return_value = False
+
+        clustering_visitor = _create_mock_clustering_visitor(
+            pipeline_map={}, request_map={}
+        )
+        builder = Mock()
+        writer, _ = _create_writer()
+        error_writer = Mock()
+
+        result = run(
+            input_file=io.StringIO("bad,csv\n"),
+            modules={"UDS"},
+            clustering_visitor=clustering_visitor,
+            file_visitor_builder=builder,
+            writer=writer,
+            error_writer=error_writer,
+            reload_workers=1,
+        )
+
+        assert result is False
+        builder.assert_not_called()
+
+
+class TestReloadWorkersParameter:
+    """Tests that reload_workers is properly passed through."""
+
+    @patch("gather_submission_status_app.main.ThreadPoolExecutor")
+    @patch("gather_submission_status_app.main.read_csv")
+    def test_reload_workers_passed_to_executor(
+        self, mock_read_csv: Mock, mock_executor_cls: Mock
+    ) -> None:
+        """Verify reload_workers parameter is passed to ThreadPoolExecutor.
+
+        **Validates: Requirements 1.2**
+        """
+        mock_read_csv.return_value = True
+
+        # Setup the mock executor context manager
+        mock_pool = Mock()
+        mock_executor_cls.return_value.__enter__ = Mock(return_value=mock_pool)
+        mock_executor_cls.return_value.__exit__ = Mock(return_value=False)
+        mock_pool.submit = Mock()
+
+        # Create a project with no matching files so we don't need full
+        # as_completed mocking
+        project = _create_mock_project(label="ingest-project", files=[])
+
+        adcid = 1
+        request = _create_mock_request(adcid=adcid, ptid="PT001")
+        clustering_visitor = _create_mock_clustering_visitor(
+            pipeline_map={adcid: [project]},
+            request_map={adcid: [request]},
+        )
+
+        builder = Mock()
+        writer, _ = _create_writer()
+        error_writer = Mock()
+
+        run(
+            input_file=io.StringIO("adcid,ptid\n1,PT001\n"),
+            modules={"UDS"},
+            clustering_visitor=clustering_visitor,
+            file_visitor_builder=builder,
+            writer=writer,
+            error_writer=error_writer,
+            reload_workers=5,
+        )
+
+        mock_executor_cls.assert_called_once_with(max_workers=5)
+
+    @patch("gather_submission_status_app.main.read_csv")
+    def test_reload_workers_1_deterministic_ordering(self, mock_read_csv: Mock) -> None:
+        """With reload_workers=1, processing is deterministic (single thread).
+
+        **Validates: Requirements 1.2**
+        """
+        mock_read_csv.return_value = True
+
+        file_info = {
+            "qc": {
+                "form-qc-checker": {
+                    "validation": {"state": "PASS", "data": [], "cleared": []}
+                }
+            }
+        }
+        mock_file = _create_mock_file_entry(
+            name="PT001_2024-01-15_UDS_qc-status.log", info=file_info
+        )
+
+        project = _create_mock_project(label="ingest-project", files=[mock_file])
+
+        adcid = 1
+        request = _create_mock_request(adcid=adcid, ptid="PT001")
+        clustering_visitor = _create_mock_clustering_visitor(
+            pipeline_map={adcid: [project]},
+            request_map={adcid: [request]},
+        )
+
+        builder = _create_file_visitor_builder()
+        writer, _output = _create_writer()
+        error_writer = Mock()
+
+        result = run(
+            input_file=io.StringIO("adcid,ptid\n1,PT001\n"),
+            modules={"UDS"},
+            clustering_visitor=clustering_visitor,
+            file_visitor_builder=builder,
+            writer=writer,
+            error_writer=error_writer,
+            reload_workers=1,
+        )
+
+        assert result is True
+        mock_file.reload.assert_called_once()
+
+
+class TestEmptyPipelineMap:
+    """Tests edge case where pipeline_map is empty."""
+
+    @patch("gather_submission_status_app.main.read_csv")
+    def test_empty_pipeline_map_returns_false(self, mock_read_csv: Mock) -> None:
+        """If clustering produces no projects, run returns False.
+
+        **Validates: Requirements 1.1**
+        """
+        mock_read_csv.return_value = True
+
+        clustering_visitor = _create_mock_clustering_visitor(
+            pipeline_map={}, request_map={}
+        )
+
+        builder = Mock()
+        writer, _ = _create_writer()
+        error_writer = Mock()
+
+        result = run(
+            input_file=io.StringIO("adcid,ptid\n1,PT001\n"),
+            modules={"UDS"},
+            clustering_visitor=clustering_visitor,
+            file_visitor_builder=builder,
+            writer=writer,
+            error_writer=error_writer,
+            reload_workers=1,
+        )
+
+        assert result is False
+        builder.assert_not_called()

--- a/gear/gather_submission_status/test/python/gather_submission_status_test/test_process_file.py
+++ b/gear/gather_submission_status/test/python/gather_submission_status_test/test_process_file.py
@@ -173,31 +173,15 @@ class TestProcessReloadedFileSkipped:
         assert len(results) == 0
         mock_builder.assert_not_called()
 
-    @patch("gather_submission_status_app.main.FileQCModel.model_validate")
-    def test_invalid_qc_data_validation_error_skipped(
-        self, mock_validate: Mock
-    ) -> None:
+    def test_invalid_qc_data_validation_error_skipped(self) -> None:
         """A file with invalid QC data (ValidationError) is skipped (logs
         warning).
 
         **Validates: Requirements 3.3**
         """
-        from pydantic import ValidationError
-
-        mock_validate.side_effect = ValidationError.from_exception_data(
-            title="FileQCModel",
-            line_errors=[
-                {
-                    "type": "missing",
-                    "loc": ("qc",),
-                    "input": {},
-                }
-            ],
-        )
-
-        file_entry = _create_mock_file_entry(
-            info={"qc": "invalid_structure_that_gets_past_guard"}
-        )
+        # Provide data that passes the guard (truthy 'qc' value) but fails
+        # Pydantic validation — qc must be Dict[str, GearQCModel], not a string
+        file_entry = _create_mock_file_entry(info={"qc": "not_a_dict"})
         table_visitor, results = _create_table_visitor()
         mock_builder = Mock()
 
@@ -251,15 +235,11 @@ class TestProcessReloadedFileSkipped:
 
         assert len(results) == 0
 
-    @patch("gather_submission_status_app.main.FileQCModel.model_validate")
-    def test_visit_details_none_skipped(self, mock_validate: Mock) -> None:
+    def test_visit_details_none_skipped(self) -> None:
         """A file where the visitor has visit_details=None is skipped.
 
         **Validates: Requirements 3.3**
         """
-        mock_qc_model = Mock()
-        mock_validate.return_value = mock_qc_model
-
         file_info = {
             "qc": {
                 "form-qc-checker": {
@@ -286,4 +266,3 @@ class TestProcessReloadedFileSkipped:
         )
 
         assert len(results) == 0
-        mock_qc_model.apply.assert_not_called()

--- a/gear/gather_submission_status/test/python/gather_submission_status_test/test_process_file.py
+++ b/gear/gather_submission_status/test/python/gather_submission_status_test/test_process_file.py
@@ -1,0 +1,289 @@
+"""Tests for _process_reloaded_file processing logic.
+
+Validates: Requirements 2.1, 2.2, 3.3, 6.2 / Property 4: QC Validation Equivalence
+"""
+
+from typing import Any
+from unittest.mock import Mock, patch
+
+from gather_submission_status_app.main import _process_reloaded_file
+from nacc_common.qc_report import (
+    ListReportWriter,
+    QCTransformerError,
+    WriterTableVisitor,
+)
+
+
+def _create_mock_file_entry(
+    name: str = "PT001_2024-01-15_UDS_qc-status.log",
+    info: dict[str, Any] | None = None,
+) -> Mock:
+    """Create a mock FileEntry with .name and .info attributes."""
+    file_entry = Mock()
+    file_entry.name = name
+    file_entry.info = info
+    return file_entry
+
+
+def _create_table_visitor() -> tuple[WriterTableVisitor, list[dict[str, Any]]]:
+    """Create a WriterTableVisitor with ListReportWriter for assertions."""
+    results: list[dict[str, Any]] = []
+    writer = ListReportWriter(results)
+    table_visitor = WriterTableVisitor(writer)
+    return table_visitor, results
+
+
+class TestProcessReloadedFileValid:
+    """Tests for valid QC file processing."""
+
+    def test_valid_qc_produces_report_rows(self) -> None:
+        """A file with valid file.info.qc produces expected report rows via the
+        table_visitor.
+
+        **Validates: Requirements 2.1, 2.2**
+        """
+        file_info = {
+            "qc": {
+                "form-qc-checker": {
+                    "validation": {
+                        "state": "PASS",
+                        "data": [],
+                        "cleared": [],
+                    }
+                }
+            }
+        }
+        file_entry = _create_mock_file_entry(info=file_info)
+        table_visitor, results = _create_table_visitor()
+
+        # Create a mock visitor with a populated table
+        mock_report_row = Mock()
+        mock_report_row.model_dump.return_value = {"col1": "val1", "col2": "val2"}
+
+        mock_file_visitor = Mock()
+        mock_file_visitor.visit_details = Mock()  # non-None
+        mock_file_visitor.table = [mock_report_row]
+
+        mock_builder = Mock(return_value=mock_file_visitor)
+
+        _process_reloaded_file(
+            file=file_entry,
+            adcid=1,
+            file_visitor_builder=mock_builder,
+            table_visitor=table_visitor,
+        )
+
+        assert len(results) == 1
+        assert results[0] == {"col1": "val1", "col2": "val2"}
+
+    def test_file_visitor_builder_called_with_correct_args(self) -> None:
+        """file_visitor_builder is called with correct (file, adcid) arguments.
+
+        **Validates: Requirements 6.2**
+        """
+        file_info = {
+            "qc": {
+                "form-qc-checker": {
+                    "validation": {
+                        "state": "PASS",
+                        "data": [],
+                        "cleared": [],
+                    }
+                }
+            }
+        }
+        file_entry = _create_mock_file_entry(info=file_info)
+        table_visitor, _ = _create_table_visitor()
+
+        mock_file_visitor = Mock()
+        mock_file_visitor.visit_details = Mock()
+        mock_file_visitor.table = []
+
+        mock_builder = Mock(return_value=mock_file_visitor)
+        adcid = 42
+
+        _process_reloaded_file(
+            file=file_entry,
+            adcid=adcid,
+            file_visitor_builder=mock_builder,
+            table_visitor=table_visitor,
+        )
+
+        mock_builder.assert_called_once_with(file_entry, adcid)
+
+
+class TestProcessReloadedFileSkipped:
+    """Tests for files that should be skipped."""
+
+    def test_file_without_info_skipped(self) -> None:
+        """A file with info=None is skipped (logs warning, no rows written).
+
+        **Validates: Requirements 3.3**
+        """
+        file_entry = _create_mock_file_entry(info=None)
+        table_visitor, results = _create_table_visitor()
+        mock_builder = Mock()
+
+        _process_reloaded_file(
+            file=file_entry,
+            adcid=1,
+            file_visitor_builder=mock_builder,
+            table_visitor=table_visitor,
+        )
+
+        assert len(results) == 0
+        mock_builder.assert_not_called()
+
+    def test_file_without_qc_key_skipped(self) -> None:
+        """A file with info={} (no 'qc' key) is skipped.
+
+        **Validates: Requirements 3.3**
+        """
+        file_entry = _create_mock_file_entry(info={"other": "data"})
+        table_visitor, results = _create_table_visitor()
+        mock_builder = Mock()
+
+        _process_reloaded_file(
+            file=file_entry,
+            adcid=1,
+            file_visitor_builder=mock_builder,
+            table_visitor=table_visitor,
+        )
+
+        assert len(results) == 0
+        mock_builder.assert_not_called()
+
+    def test_file_with_empty_qc_skipped(self) -> None:
+        """A file with info={'qc': {}} (empty qc dict evaluating as falsy) is
+        skipped.
+
+        **Validates: Requirements 3.3**
+        """
+        file_entry = _create_mock_file_entry(info={"qc": {}})
+        table_visitor, results = _create_table_visitor()
+        mock_builder = Mock()
+
+        _process_reloaded_file(
+            file=file_entry,
+            adcid=1,
+            file_visitor_builder=mock_builder,
+            table_visitor=table_visitor,
+        )
+
+        assert len(results) == 0
+        mock_builder.assert_not_called()
+
+    @patch("gather_submission_status_app.main.FileQCModel.model_validate")
+    def test_invalid_qc_data_validation_error_skipped(
+        self, mock_validate: Mock
+    ) -> None:
+        """A file with invalid QC data (ValidationError) is skipped (logs
+        warning).
+
+        **Validates: Requirements 3.3**
+        """
+        from pydantic import ValidationError
+
+        mock_validate.side_effect = ValidationError.from_exception_data(
+            title="FileQCModel",
+            line_errors=[
+                {
+                    "type": "missing",
+                    "loc": ("qc",),
+                    "input": {},
+                }
+            ],
+        )
+
+        file_entry = _create_mock_file_entry(
+            info={"qc": "invalid_structure_that_gets_past_guard"}
+        )
+        table_visitor, results = _create_table_visitor()
+        mock_builder = Mock()
+
+        _process_reloaded_file(
+            file=file_entry,
+            adcid=1,
+            file_visitor_builder=mock_builder,
+            table_visitor=table_visitor,
+        )
+
+        assert len(results) == 0
+        mock_builder.assert_not_called()
+
+    @patch("gather_submission_status_app.main.FileQCModel.model_validate")
+    def test_qc_transformer_error_skipped(self, mock_validate: Mock) -> None:
+        """A file causing QCTransformerError during apply is skipped (logs
+        error).
+
+        **Validates: Requirements 2.2**
+        """
+        mock_qc_model = Mock()
+        mock_qc_model.apply.side_effect = QCTransformerError(
+            "Unexpected transformation error"
+        )
+        mock_validate.return_value = mock_qc_model
+
+        file_info = {
+            "qc": {
+                "form-qc-checker": {
+                    "validation": {
+                        "state": "PASS",
+                        "data": [],
+                        "cleared": [],
+                    }
+                }
+            }
+        }
+        file_entry = _create_mock_file_entry(info=file_info)
+        table_visitor, results = _create_table_visitor()
+
+        mock_file_visitor = Mock()
+        mock_file_visitor.visit_details = Mock()  # non-None
+        mock_builder = Mock(return_value=mock_file_visitor)
+
+        _process_reloaded_file(
+            file=file_entry,
+            adcid=1,
+            file_visitor_builder=mock_builder,
+            table_visitor=table_visitor,
+        )
+
+        assert len(results) == 0
+
+    @patch("gather_submission_status_app.main.FileQCModel.model_validate")
+    def test_visit_details_none_skipped(self, mock_validate: Mock) -> None:
+        """A file where the visitor has visit_details=None is skipped.
+
+        **Validates: Requirements 3.3**
+        """
+        mock_qc_model = Mock()
+        mock_validate.return_value = mock_qc_model
+
+        file_info = {
+            "qc": {
+                "form-qc-checker": {
+                    "validation": {
+                        "state": "PASS",
+                        "data": [],
+                        "cleared": [],
+                    }
+                }
+            }
+        }
+        file_entry = _create_mock_file_entry(info=file_info)
+        table_visitor, results = _create_table_visitor()
+
+        mock_file_visitor = Mock()
+        mock_file_visitor.visit_details = None  # Cannot extract visit details
+        mock_builder = Mock(return_value=mock_file_visitor)
+
+        _process_reloaded_file(
+            file=file_entry,
+            adcid=1,
+            file_visitor_builder=mock_builder,
+            table_visitor=table_visitor,
+        )
+
+        assert len(results) == 0
+        mock_qc_model.apply.assert_not_called()

--- a/nacc-common/pyproject.toml
+++ b/nacc-common/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nacc-common"
-version = "3.1.1"
+version = "3.1.2"
 description = "NACC Data Platform utilities"
 license-files = ["LICENSE"]
 authors = [{ name = "NACC", email = "nacchelp@uw.edu" }]

--- a/nacc-common/src/python/nacc_common/error_data.py
+++ b/nacc-common/src/python/nacc_common/error_data.py
@@ -4,6 +4,8 @@ from typing import Any, Optional
 
 from flywheel.models.file_entry import FileEntry
 from flywheel.models.project import Project
+from pydantic import ValidationError
+
 from nacc_common.data_identification import DataIdentification
 from nacc_common.error_models import FileQCModel
 from nacc_common.qc_report import (
@@ -21,7 +23,6 @@ from nacc_common.visit_submission_status import (
     StatusReportModel,
     status_report_visitor_builder,
 )
-from pydantic import ValidationError
 
 log = logging.getLogger(__name__)
 

--- a/nacc-common/src/python/nacc_common/error_data.py
+++ b/nacc-common/src/python/nacc_common/error_data.py
@@ -4,8 +4,6 @@ from typing import Any, Optional
 
 from flywheel.models.file_entry import FileEntry
 from flywheel.models.project import Project
-from pydantic import ValidationError
-
 from nacc_common.data_identification import DataIdentification
 from nacc_common.error_models import FileQCModel
 from nacc_common.qc_report import (
@@ -23,6 +21,7 @@ from nacc_common.visit_submission_status import (
     StatusReportModel,
     status_report_visitor_builder,
 )
+from pydantic import ValidationError
 
 log = logging.getLogger(__name__)
 
@@ -91,11 +90,11 @@ def _should_include_file(
     if not match:
         return False
 
-    ptid = match.group(1)
+    ptid = match.group("ptid")
     if ptids is not None and ptid not in ptids:
         return False
 
-    module = match.group(3).upper()
+    module = match.group("module").upper()
     return modules is None or module in modules
 
 

--- a/nacc-common/src/python/nacc_common/qc_report.py
+++ b/nacc-common/src/python/nacc_common/qc_report.py
@@ -7,6 +7,8 @@ from csv import DictWriter
 from typing import Any, Callable, List, Optional
 
 from flywheel.models.file_entry import FileEntry
+from pydantic import BaseModel, ValidationError
+
 from nacc_common.data_identification import DataIdentification
 from nacc_common.error_models import (
     ClearedAlertModel,
@@ -17,7 +19,6 @@ from nacc_common.error_models import (
     QCVisitor,
     ValidationModel,
 )
-from pydantic import BaseModel, ValidationError
 
 ModuleName = str
 log = logging.getLogger(__name__)

--- a/nacc-common/src/python/nacc_common/qc_report.py
+++ b/nacc-common/src/python/nacc_common/qc_report.py
@@ -7,8 +7,6 @@ from csv import DictWriter
 from typing import Any, Callable, List, Optional
 
 from flywheel.models.file_entry import FileEntry
-from pydantic import BaseModel, ValidationError
-
 from nacc_common.data_identification import DataIdentification
 from nacc_common.error_models import (
     ClearedAlertModel,
@@ -19,13 +17,17 @@ from nacc_common.error_models import (
     QCVisitor,
     ValidationModel,
 )
+from pydantic import BaseModel, ValidationError
 
 ModuleName = str
 log = logging.getLogger(__name__)
 
 # TODO: Consider consolidating QC filename pattern usage - currently duplicated
 # between ProjectReportVisitor and FileQCReportVisitor
-QC_FILENAME_PATTERN = r"^([!-~]{1,10})_(\d{4}-\d{2}-\d{2})_(\w+)_qc-status.log$"
+QC_FILENAME_PATTERN = (
+    r"^(?P<ptid>[!-~]{1,10})_(?P<date>\d{4}-\d{2}-\d{2})"
+    r"_(?:(?P<visitnum>\d+\.\d+)_)?(?P<module>\w+)_qc-status.log$"
+)
 
 
 def extract_visit_keys(
@@ -46,9 +48,9 @@ def extract_visit_keys(
     if not match:
         raise TypeError(f"file name does not match qc-status log: {file.name}")
 
-    ptid = match.group(1)
-    visitdate = match.group(2)
-    module = match.group(3).upper()
+    ptid = match.group("ptid")
+    visitdate = match.group("date")
+    module = match.group("module").upper()
 
     return DataIdentification.from_visit_metadata(
         ptid=ptid, date=visitdate, module=module, adcid=adcid
@@ -345,12 +347,12 @@ class ProjectReportVisitor:
         if not match:
             return False
 
-        ptid = match.group(1)
+        ptid = match.group("ptid")
         if self.__ptid_set is not None and ptid not in self.__ptid_set:
             return False
 
-        module = match.group(3).upper()
-        return self.__modules is None or module.upper() in self.__modules
+        module = match.group("module").upper()
+        return self.__modules is None or module in self.__modules
 
     def visit_file(self, file: FileEntry) -> None:
         """Creates a file visitor for the QC log file and processes it.


### PR DESCRIPTION
## Summary

- **nacc-common v3.1.2**: Fix `QC_FILENAME_PATTERN` to match qc-status log files that include a visitnum segment (e.g., `2851_2025-09-02_10.00_uds_qc-status.log`). Files in the new format were previously invisible to all consumers.
- **gather-submission-status v1.4.1**: Add concurrent file reloading with configurable `reload_workers` parameter (default 10) for faster processing, plus the filename pattern fix.

## Changes

### nacc-common
- Update `QC_FILENAME_PATTERN` to include optional visitnum group
- Switch all consumers to named capture groups for clarity

### gather-submission-status
- Replace `ProjectReportVisitor` with direct file filtering and concurrent `file.reload()` via ThreadPoolExecutor
- Add `reload_workers` config option (default 10)
- Use named groups for QC filename matching

## Testing

All 1714 tests pass across nacc-common and gather-submission-status.