### PR TITLE
Fix authorization_path default for project- and user-management

### DIFF
--- a/docs/project_management/CHANGELOG.md
+++ b/docs/project_management/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 All notable changes to this gear are documented in this file.
 
-## [Unreleased]
+## 2.7.1
+
+* Fixes `authorization_path` default from `/prod/authorization/api-endpoint` to `/production/authorization/api-endpoint`
 
 ## 2.7.0
 

--- a/docs/project_management/index.md
+++ b/docs/project_management/index.md
@@ -173,7 +173,7 @@ Authorization hierarchy seeding is optional and fault-isolated:
 
 ### Configuration
 
-The gear manifest includes an `authorization_path` config field (default: `/prod/authorization/api-endpoint`).
+The gear manifest includes an `authorization_path` config field (default: `/production/authorization/api-endpoint`).
 This is the SSM Parameter Store path where the Authorization API endpoint URL is stored.
 
 The integration activates automatically when:

--- a/docs/user_management/CHANGELOG.md
+++ b/docs/user_management/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this gear are documented in this file.
 
+## 4.4.1
+
+* Fixes `authorization_path` default from `/prod/authorization/api-endpoint` to `/production/authorization/api-endpoint`
+
 ## 4.4.0
 
 * Adds authorization sync to the user management pipeline

--- a/docs/user_management/index.md
+++ b/docs/user_management/index.md
@@ -208,7 +208,7 @@ Authorization sync is optional and fault-isolated:
 
 ### Configuration
 
-The gear manifest includes an `authorization_path` config field (default: `/prod/authorization/api-endpoint`).
+The gear manifest includes an `authorization_path` config field (default: `/production/authorization/api-endpoint`).
 This is the SSM Parameter Store path where the Authorization API endpoint URL is stored.
 
 The integration activates automatically when:

--- a/gear/project_management/src/docker/BUILD
+++ b/gear/project_management/src/docker/BUILD
@@ -4,5 +4,5 @@ docker_image(
     name="project-management",
     source="Dockerfile",
     dependencies=[":manifest", "gear/project_management/src/python/project_app:bin"],
-    image_tags=["2.7.0"],
+    image_tags=["2.7.1"],
 )

--- a/gear/project_management/src/docker/manifest.json
+++ b/gear/project_management/src/docker/manifest.json
@@ -2,7 +2,7 @@
   "name": "project-management",
   "label": "Project management",
   "description": "Creates and updates projects from project YAML file",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "author": "NACC",
   "maintainer": "NACC <nacchelp@uw.edu>",
   "cite": "",
@@ -15,7 +15,7 @@
   "custom": {
     "gear-builder": {
       "category": "utility",
-      "image": "naccdata/project-management:2.7.0"
+      "image": "naccdata/project-management:2.7.1"
     },
     "flywheel": {
       "suite": "NACC Admin Gears",
@@ -60,7 +60,7 @@
     "authorization_path": {
       "description": "Parameter path for the Authorization API endpoint URL",
       "type": "string",
-      "default": "/prod/authorization/api-endpoint"
+      "default": "/production/authorization/api-endpoint"
     }
   },
   "command": "/bin/run"

--- a/gear/project_management/test/python/test_run.py
+++ b/gear/project_management/test/python/test_run.py
@@ -77,13 +77,13 @@ class TestRunClientCreationSuccess:
             client=mock_client_wrapper,
             project_filepath=empty_project_file,
             parameter_store=mock_parameter_store,
-            authorization_path="/prod/authorization/api-endpoint",
+            authorization_path="/production/authorization/api-endpoint",
         )
 
         visitor.run(mock_gear_context)
 
         mock_parameter_store.get_url.assert_called_once_with(
-            "/prod/authorization/api-endpoint"
+            "/production/authorization/api-endpoint"
         )
         mock_create_client.assert_called_once_with(
             base_url="https://api.example.com/auth"
@@ -118,7 +118,7 @@ class TestRunClientCreationParameterError:
             client=mock_client_wrapper,
             project_filepath=empty_project_file,
             parameter_store=mock_parameter_store,
-            authorization_path="/prod/authorization/api-endpoint",
+            authorization_path="/production/authorization/api-endpoint",
         )
 
         visitor.run(mock_gear_context)
@@ -147,7 +147,7 @@ class TestRunClientCreationParameterError:
             client=mock_client_wrapper,
             project_filepath=empty_project_file,
             parameter_store=mock_parameter_store,
-            authorization_path="/prod/authorization/api-endpoint",
+            authorization_path="/production/authorization/api-endpoint",
         )
 
         with caplog.at_level(logging.ERROR):

--- a/gear/user_management/src/docker/BUILD
+++ b/gear/user_management/src/docker/BUILD
@@ -4,5 +4,5 @@ docker_image(
     name="user-management",
     source="Dockerfile",
     dependencies=[":manifest", "gear/user_management/src/python/user_app:bin"],
-    image_tags=["4.4.0", "latest"],
+    image_tags=["4.4.1", "latest"],
 )

--- a/gear/user_management/src/docker/manifest.json
+++ b/gear/user_management/src/docker/manifest.json
@@ -2,7 +2,7 @@
   "name": "user-management",
   "label": "User Management",
   "description": "Creates and updates user and user roles",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "author": "NACC",
   "maintainer": "NACC <nacchelp@uw.edu>",
   "cite": "",
@@ -15,7 +15,7 @@
   "custom": {
     "gear-builder": {
       "category": "utility",
-      "image": "naccdata/user-management:4.4.0"
+      "image": "naccdata/user-management:4.4.1"
     },
     "flywheel": {
       "suite": "NACC Admin Gears",
@@ -101,7 +101,7 @@
     "authorization_path": {
       "description": "Parameter path for the Authorization API endpoint URL",
       "type": "string",
-      "default": "/prod/authorization/api-endpoint"
+      "default": "/production/authorization/api-endpoint"
     }
   },
   "command": "/bin/run"


### PR DESCRIPTION
## Summary

Corrects the `authorization_path` config default from `/prod/authorization/api-endpoint` to `/production/authorization/api-endpoint` in both gears.

## Changes

- **project-management 2.7.1**: Fix default path in manifest, update BUILD image tag, update test values, update docs
- **user-management 4.4.1**: Fix default path in manifest, update BUILD image tag, update docs

## Why

The SSM Parameter Store path used in production is `/production/authorization/api-endpoint`, not `/prod/...`. Without this fix, the gears fail to resolve the Authorization API endpoint URL on deployment.