### PR TITLE
Fix get_url to use single-parameter SSM fetch

### DIFF
--- a/common/src/python/inputs/parameter_store.py
+++ b/common/src/python/inputs/parameter_store.py
@@ -382,9 +382,7 @@ class ParameterStore:
         try:
             parameter = self.__store.get_parameter(param_path)
         except self.__store.client.exceptions.ParameterNotFound as error:  # type: ignore
-            raise ParameterError(
-                f"No URL parameter found at {param_path}"
-            ) from error
+            raise ParameterError(f"No URL parameter found at {param_path}") from error
 
         url_value = parameter.get(parameter_name)
         if not url_value:

--- a/common/src/python/inputs/parameter_store.py
+++ b/common/src/python/inputs/parameter_store.py
@@ -368,14 +368,29 @@ class ParameterStore:
         """Pulls a URL parameter from the SSM parameter store at the given
         path.
 
+        Fetches a single SSM parameter whose value is a URL string.
+
         Args:
-          param_path: the path in the parameter store
+          param_path: the path/name of the parameter in the store
         Returns:
           the URL parameter stored at the path
         Raises:
           ParameterError if the parameter is missing
         """
-        return self.get_parameters(param_type=URLParameter, parameter_path=param_path)
+        param_path = param_path[:-1] if param_path.endswith("/") else param_path
+        parameter_name = param_path.split("/")[-1]
+        try:
+            parameter = self.__store.get_parameter(param_path)
+        except self.__store.client.exceptions.ParameterNotFound as error:  # type: ignore
+            raise ParameterError(
+                f"No URL parameter found at {param_path}"
+            ) from error
+
+        url_value = parameter.get(parameter_name)
+        if not url_value:
+            raise ParameterError(f"No URL value found at {param_path}")
+
+        return URLParameter(url=url_value)
 
     def get_support_emails(self, param_path: str) -> List[str]:
         """Pulls support email addresses from the SSM parameter store at the

--- a/docs/project_management/CHANGELOG.md
+++ b/docs/project_management/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this gear are documented in this file.
 
+## 2.7.2
+
+* Fixes `get_url` to fetch single SSM parameter by name instead of using path-based lookup (resolves authorization client creation failure)
+
 ## 2.7.1
 
 * Fixes `authorization_path` default from `/prod/authorization/api-endpoint` to `/production/authorization/api-endpoint`

--- a/docs/user_management/CHANGELOG.md
+++ b/docs/user_management/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this gear are documented in this file.
 
+## 4.4.2
+
+* Fixes `get_url` to fetch single SSM parameter by name instead of using path-based lookup (resolves authorization client creation failure)
+
 ## 4.4.1
 
 * Fixes `authorization_path` default from `/prod/authorization/api-endpoint` to `/production/authorization/api-endpoint`

--- a/gear/project_management/src/docker/BUILD
+++ b/gear/project_management/src/docker/BUILD
@@ -4,5 +4,5 @@ docker_image(
     name="project-management",
     source="Dockerfile",
     dependencies=[":manifest", "gear/project_management/src/python/project_app:bin"],
-    image_tags=["2.7.1"],
+    image_tags=["2.7.2"],
 )

--- a/gear/project_management/src/docker/manifest.json
+++ b/gear/project_management/src/docker/manifest.json
@@ -2,7 +2,7 @@
   "name": "project-management",
   "label": "Project management",
   "description": "Creates and updates projects from project YAML file",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "author": "NACC",
   "maintainer": "NACC <nacchelp@uw.edu>",
   "cite": "",
@@ -15,7 +15,7 @@
   "custom": {
     "gear-builder": {
       "category": "utility",
-      "image": "naccdata/project-management:2.7.1"
+      "image": "naccdata/project-management:2.7.2"
     },
     "flywheel": {
       "suite": "NACC Admin Gears",

--- a/gear/user_management/src/docker/BUILD
+++ b/gear/user_management/src/docker/BUILD
@@ -4,5 +4,5 @@ docker_image(
     name="user-management",
     source="Dockerfile",
     dependencies=[":manifest", "gear/user_management/src/python/user_app:bin"],
-    image_tags=["4.4.1", "latest"],
+    image_tags=["4.4.2", "latest"],
 )

--- a/gear/user_management/src/docker/manifest.json
+++ b/gear/user_management/src/docker/manifest.json
@@ -2,7 +2,7 @@
   "name": "user-management",
   "label": "User Management",
   "description": "Creates and updates user and user roles",
-  "version": "4.4.1",
+  "version": "4.4.2",
   "author": "NACC",
   "maintainer": "NACC <nacchelp@uw.edu>",
   "cite": "",
@@ -15,7 +15,7 @@
   "custom": {
     "gear-builder": {
       "category": "utility",
-      "image": "naccdata/user-management:4.4.1"
+      "image": "naccdata/user-management:4.4.2"
     },
     "flywheel": {
       "suite": "NACC Admin Gears",


### PR DESCRIPTION
## Summary

Fixes `ParameterStore.get_url()` to fetch a single SSM parameter by name instead of using path-based lookup. The authorization API endpoint is stored as a single parameter at `/production/authorization/api-endpoint`, not as a tree of child parameters — so `get_parameters_by_path` returned an empty dict and Pydantic validation failed.

## Changes

- **common**: Rewrite `get_url` to use `get_parameter` (same pattern as `get_api_key`)
- **project-management 2.7.2**: Version bump for redeployment
- **user-management 4.4.2**: Version bump for redeployment

## Error from production logs

```
Authorization client creation failed, hierarchy seeding disabled:
Incorrect parameters at /production/authorization/api-endpoint/:
1 validation error for URLParameter url Field required [type=missing, input_value={}, input_type=dict]
```