### PR TITLE
Add destination_project config to csv-subject-splitter

### DIFF
--- a/docs/csv_subject_splitter/CHANGELOG.md
+++ b/docs/csv_subject_splitter/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this gear are documented in this file.
 
+## 1.1.0
+
+* Adds `destination_project` config option to specify a Flywheel project path (group/project) where split files should be uploaded, enabling cross-project splitting. Defaults to the input file's parent project when empty.
+
 ## 1.0.8
 
 * Adds `normalize_dates` option to normalize date fields in the record. Reports an error and and skips the row if a specified date value cannot be normalized

--- a/gear/csv_subject_splitter/src/docker/BUILD
+++ b/gear/csv_subject_splitter/src/docker/BUILD
@@ -4,5 +4,5 @@ docker_image(
     name="csv-subject-splitter",
     source="Dockerfile",
     dependencies=[":manifest", "gear/csv_subject_splitter/src/python/csv_app:bin"],
-    image_tags=["1.0.8", "latest"],
+    image_tags=["1.1.0", "latest"],
 )

--- a/gear/csv_subject_splitter/src/docker/manifest.json
+++ b/gear/csv_subject_splitter/src/docker/manifest.json
@@ -2,7 +2,7 @@
   "name": "csv-subject-splitter",
   "label": "CSV Subject Splitter",
   "description": "Converts rows of CSV file to subject JSON files based on NACCID",
-  "version": "1.0.8",
+  "version": "1.1.0",
   "author": "NACC",
   "maintainer": "NACC <nacchelp@uw.edu>",
   "cite": "",
@@ -15,7 +15,7 @@
   "custom": {
     "gear-builder": {
       "category": "utility",
-      "image": "naccdata/csv-subject-splitter:1.0.8"
+      "image": "naccdata/csv-subject-splitter:1.1.0"
     },
     "flywheel": {
       "suite": "Curation",

--- a/gear/csv_subject_splitter/src/docker/manifest.json
+++ b/gear/csv_subject_splitter/src/docker/manifest.json
@@ -61,6 +61,11 @@
       "description": "Comma-deliminated list of fields to normalize to YYYY-MM-DD format - these normalizations will also be applied to any hierarchy labels that use these fields.",
       "type": "string",
       "default": ""
+    },
+    "destination_project": {
+      "description": "The Flywheel project path (group/project) where split files should be uploaded. Defaults to the input file's parent project if empty.",
+      "type": "string",
+      "default": ""
     }
   },
   "command": "/bin/run"

--- a/gear/csv_subject_splitter/src/python/csv_app/run.py
+++ b/gear/csv_subject_splitter/src/python/csv_app/run.py
@@ -44,6 +44,7 @@ class CsvToJsonVisitor(GearExecutionEnvironment):
         preserve_case: bool,
         req_fields: Set[str],
         normalize_dates: Set[str],
+        destination_project: str,
     ) -> None:
         self.__client = client
         self.__device_key = device_key
@@ -52,6 +53,7 @@ class CsvToJsonVisitor(GearExecutionEnvironment):
         self.__preserve_case = preserve_case
         self.__req_fields = req_fields
         self.__normalize_dates = normalize_dates
+        self.__destination_project = destination_project
 
     @classmethod
     def create(
@@ -98,6 +100,7 @@ class CsvToJsonVisitor(GearExecutionEnvironment):
         preserve_case = options.get("preserve_case", False)
         req_fields = set(parse_string_to_list(options.get("required_fields", "")))
         normalize_dates = set(parse_string_to_list(options.get("normalize_dates", "")))
+        destination_project = options.get("destination_project", "")
 
         return CsvToJsonVisitor(
             client=client,
@@ -107,6 +110,7 @@ class CsvToJsonVisitor(GearExecutionEnvironment):
             preserve_case=preserve_case,
             req_fields=req_fields,
             normalize_dates=normalize_dates,
+            destination_project=destination_project,
         )
 
     def run(self, context: GearContext) -> None:
@@ -126,7 +130,16 @@ class CsvToJsonVisitor(GearExecutionEnvironment):
                 f"Failed to find the input file: {error}"
             ) from error
 
-        project = self.__file_input.get_parent_project(proxy, file=file)
+        if self.__destination_project:
+            fw_project = proxy.lookup(self.__destination_project)
+            if not fw_project:
+                raise GearExecutionError(
+                    f"Failed to find destination project: {self.__destination_project}"
+                )
+            project = fw_project
+        else:
+            project = self.__file_input.get_parent_project(proxy, file=file)
+
         destination = ProjectAdaptor(project=project, proxy=proxy)
         template_map = self.__load_template(self.__hierarchy_labels)
 


### PR DESCRIPTION
## Summary

Adds a `destination_project` config option to the csv-subject-splitter gear, allowing split files to be uploaded to a different Flywheel project than the input file's parent project.

## Changes

- **manifest.json**: Added `destination_project` config (string, defaults to empty)
- **run.py**: Resolves destination project from config via `proxy.lookup()`, falls back to parent project when empty

## Release

Bumps csv-subject-splitter from 1.0.8 to 1.1.0.

## Testing

- mypy type checking passes
- All existing tests pass (1714 tests)