### PR TITLE
Fix ORCiD orphan claim handling (user-management 4.4.3)

### DIFF
--- a/common/src/python/users/user_processes.py
+++ b/common/src/python/users/user_processes.py
@@ -14,7 +14,6 @@ from coreapi_client.models.identifier import Identifier
 from flywheel.models.user import User
 from flywheel_adaptor.flywheel_proxy import FlywheelError
 from redcap_api.redcap_connection import REDCapConnectionError
-
 from users.authorization_visitor import (
     CenterAuthorizationVisitor,
     GeneralAuthorizationVisitor,
@@ -1242,6 +1241,24 @@ class ActiveUserProcess(BaseUserProcess[ActiveUserEntry]):
             # Store the whole RegistryPerson object instead of just the ID
             entry.register(claimed[0])
             self.__claimed_queue.enqueue(entry)
+            return
+
+        # Check if there's an orphan claim record for this user.
+        # This catches the case where a user claimed via ORCiD (which
+        # returned no email), so COManage created a separate record with
+        # oidcsub but no email. The skeleton still looks unclaimed, but
+        # the user has already attempted to claim.
+        bad_claim = self.__env.user_registry.get_bad_claim(entry.full_name)
+        if bad_claim:
+            log.info(
+                "User %s has skeleton but also an orphan claim record",
+                entry.email,
+            )
+            incomplete_claim_event = self.failure_analyzer.detect_incomplete_claim(
+                entry, bad_claim
+            )
+            if incomplete_claim_event:
+                self.collector.collect(incomplete_claim_event)
             return
 
         self.__unclaimed_queue.enqueue(entry)

--- a/common/src/python/users/user_processes.py
+++ b/common/src/python/users/user_processes.py
@@ -14,6 +14,7 @@ from coreapi_client.models.identifier import Identifier
 from flywheel.models.user import User
 from flywheel_adaptor.flywheel_proxy import FlywheelError
 from redcap_api.redcap_connection import REDCapConnectionError
+
 from users.authorization_visitor import (
     CenterAuthorizationVisitor,
     GeneralAuthorizationVisitor,

--- a/common/src/python/users/user_processes.py
+++ b/common/src/python/users/user_processes.py
@@ -1245,24 +1245,36 @@ class ActiveUserProcess(BaseUserProcess[ActiveUserEntry]):
             return
 
         # Check if there's an orphan claim record for this user.
-        # This catches the case where a user claimed via ORCiD (which
-        # returned no email), so COManage created a separate record with
-        # oidcsub but no email. The skeleton still looks unclaimed, but
-        # the user has already attempted to claim.
-        bad_claim = self.__env.user_registry.get_bad_claim(entry.full_name)
-        if bad_claim:
-            log.info(
-                "User %s has skeleton but also an orphan claim record",
-                entry.email,
-            )
-            incomplete_claim_event = self.failure_analyzer.detect_incomplete_claim(
-                entry, bad_claim
-            )
-            if incomplete_claim_event:
-                self.collector.collect(incomplete_claim_event)
+        if self.__check_orphan_claim(entry):
             return
 
         self.__unclaimed_queue.enqueue(entry)
+
+    def __check_orphan_claim(self, entry: ActiveUserEntry) -> bool:
+        """Check for orphan claim records and report if found.
+
+        This catches the case where a user claimed via ORCiD (which
+        returned no email), so COManage created a separate record with
+        oidcsub but no email. The skeleton still looks unclaimed, but
+        the user has already attempted to claim.
+
+        Returns:
+            True if an orphan claim was found (caller should stop processing).
+        """
+        bad_claim = self.__env.user_registry.get_bad_claim(entry.full_name)
+        if not bad_claim:
+            return False
+
+        log.info(
+            "User %s has skeleton but also an orphan claim record",
+            entry.email,
+        )
+        incomplete_claim_event = self.failure_analyzer.detect_incomplete_claim(
+            entry, bad_claim
+        )
+        if incomplete_claim_event:
+            self.collector.collect(incomplete_claim_event)
+        return True
 
     def __get_claimed(self, person_list: List[RegistryPerson]) -> List[RegistryPerson]:
         """Builds the sublist of claimed members of the person list.

--- a/common/src/python/users/user_registry.py
+++ b/common/src/python/users/user_registry.py
@@ -19,6 +19,7 @@ from coreapi_client.models.identifier import Identifier
 from coreapi_client.models.name import Name
 from coreapi_client.models.org_identity import OrgIdentity
 from pydantic import ValidationError
+
 from users.domain_config import (
     DomainRelationshipConfig,
     canonicalize_domain,

--- a/common/src/python/users/user_registry.py
+++ b/common/src/python/users/user_registry.py
@@ -846,7 +846,7 @@ class UserRegistry:
                 )
 
         if not person.email_addresses:
-            if not person._has_oidcsub():
+            if person.is_unclaimed():
                 return
 
             if name:

--- a/common/src/python/users/user_registry.py
+++ b/common/src/python/users/user_registry.py
@@ -19,7 +19,6 @@ from coreapi_client.models.identifier import Identifier
 from coreapi_client.models.name import Name
 from coreapi_client.models.org_identity import OrgIdentity
 from pydantic import ValidationError
-
 from users.domain_config import (
     DomainRelationshipConfig,
     canonicalize_domain,
@@ -823,8 +822,8 @@ class UserRegistry:
 
         Indexes the person by registry ID (always), by email (if
         present), by parent domain (if domain_config available), and by
-        name (if present). Records without email that are claimed go to
-        __bad_claims.
+        name (if present). Records without email that have an oidcsub
+        (attempted claim) go to __bad_claims.
         """
         # Always index by registry ID regardless of email
         registry_id = person.registry_id()
@@ -846,7 +845,7 @@ class UserRegistry:
                 )
 
         if not person.email_addresses:
-            if not person.is_claimed():
+            if not person._has_oidcsub():
                 return
 
             if name:

--- a/common/test/python/user_test/test_active_user_reenable.py
+++ b/common/test/python/user_test/test_active_user_reenable.py
@@ -182,6 +182,7 @@ class TestActiveUserProcessReEnable:
         unclaimed_person.is_claimed.return_value = False
         mock_environment.user_registry.get.return_value = [unclaimed_person]
         mock_environment.user_registry.has_bad_claim.return_value = False
+        mock_environment.user_registry.get_bad_claim.return_value = []
 
         process = ActiveUserProcess(mock_environment, collector)
         process.visit(sample_active_entry)

--- a/docs/user_management/CHANGELOG.md
+++ b/docs/user_management/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this gear are documented in this file.
 * Detects orphan ORCiD claim records (oidcsub present but no email) during active user processing
   * Prevents users with incomplete ORCiD claims from being enqueued as unclaimed
   * Reports an incomplete-claim event for support visibility
-* Uses `_has_oidcsub()` instead of `is_claimed()` for bad-claim indexing in `UserRegistry`
+* Uses `is_unclaimed()` instead of `is_claimed()` for bad-claim indexing in `UserRegistry`
 
 ## 4.4.2
 

--- a/docs/user_management/CHANGELOG.md
+++ b/docs/user_management/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 All notable changes to this gear are documented in this file.
 
-## Unreleased
+## 4.4.3
 
 * Fixes `portal_url_path` default from `/prod/flywheel/portal` to `/prod/flywheel/portal/url` to match actual SSM parameter name
+* Detects orphan ORCiD claim records (oidcsub present but no email) during active user processing
+  * Prevents users with incomplete ORCiD claims from being enqueued as unclaimed
+  * Reports an incomplete-claim event for support visibility
+* Uses `_has_oidcsub()` instead of `is_claimed()` for bad-claim indexing in `UserRegistry`
 
 ## 4.4.2
 

--- a/gear/user_management/src/docker/BUILD
+++ b/gear/user_management/src/docker/BUILD
@@ -4,5 +4,5 @@ docker_image(
     name="user-management",
     source="Dockerfile",
     dependencies=[":manifest", "gear/user_management/src/python/user_app:bin"],
-    image_tags=["4.4.2", "latest"],
+    image_tags=["4.4.3", "latest"],
 )

--- a/gear/user_management/src/docker/manifest.json
+++ b/gear/user_management/src/docker/manifest.json
@@ -2,7 +2,7 @@
   "name": "user-management",
   "label": "User Management",
   "description": "Creates and updates user and user roles",
-  "version": "4.4.2",
+  "version": "4.4.3",
   "author": "NACC",
   "maintainer": "NACC <nacchelp@uw.edu>",
   "cite": "",
@@ -15,7 +15,7 @@
   "custom": {
     "gear-builder": {
       "category": "utility",
-      "image": "naccdata/user-management:4.4.2"
+      "image": "naccdata/user-management:4.4.3"
     },
     "flywheel": {
       "suite": "NACC Admin Gears",


### PR DESCRIPTION
## Summary

Fixes handling of users who claimed via ORCiD but received no email back from the IdP. COManage creates a separate record with an `oidcsub` but no email address, leaving the original skeleton looking unclaimed. This PR detects those orphan claim records and reports them as incomplete claims instead of routing them to the unclaimed queue.

## Changes

- **UserRegistry**: Use `_has_oidcsub()` instead of `is_claimed()` for bad-claim indexing — targets specifically the ORCiD-without-email case
- **ActiveUserProcess**: Check for orphan claim records via `get_bad_claim()` before enqueueing to unclaimed; emit an incomplete-claim event for visibility
- **Manifest**: Fix `portal_url_path` default from `/prod/flywheel/portal` to `/prod/flywheel/portal/url`
- **Version bump**: 4.4.2 → 4.4.3

## Testing

- Existing re-enable test updated to mock `get_bad_claim`