### PR TITLE
Consolidate submission status by PTID and split into passed/failed files

### DIFF
--- a/docs/gather_submission_status/CHANGELOG.md
+++ b/docs/gather_submission_status/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this gear are documented in this file.
 
+## 1.5.0
+
+* Consolidate per-stage status rows into per-submission (ptid, visit, module) pass/fail
+* Split status output into two files: passed and failed submissions
+* Add configurable `passed_output_file` and `failed_output_file` config options
+* Remove `output_file` config (replaced by the two new options above)
+* Drop `stage` column from status output — rows now represent overall submission status
+
 ## 1.4.4
 
 * Normalize PTIDs (strip leading zeros) when building the participant filter set, so QC log filenames like `947_...` match input rows like `0947`

--- a/gear/gather_submission_status/src/docker/BUILD
+++ b/gear/gather_submission_status/src/docker/BUILD
@@ -7,5 +7,5 @@ docker_image(
         ":manifest",
         "gear/gather_submission_status/src/python/gather_submission_status_app:bin",
     ],
-    image_tags=["1.4.4", "latest"],
+    image_tags=["1.5.0", "latest"],
 )

--- a/gear/gather_submission_status/src/docker/manifest.json
+++ b/gear/gather_submission_status/src/docker/manifest.json
@@ -2,7 +2,7 @@
   "name": "gather-submission-status",
   "label": "Gather Submission Status",
   "description": "A gear for gathering form submission status",
-  "version": "1.4.4",
+  "version": "1.5.0",
   "author": "NACC",
   "maintainer": "NACC <nacchelp@uw.edu>",
   "cite": "",
@@ -15,7 +15,7 @@
   "custom": {
     "gear-builder": {
       "category": "utility",
-      "image": "naccdata/gather-submission-status:1.4.4"
+      "image": "naccdata/gather-submission-status:1.5.0"
     },
     "flywheel": {
       "suite": "Utility",

--- a/gear/gather_submission_status/src/docker/manifest.json
+++ b/gear/gather_submission_status/src/docker/manifest.json
@@ -75,10 +75,15 @@
       "type": "string",
       "default": "adrc"
     },
-    "output_file": {
-      "description": "Name of the output file",
+    "passed_output_file": {
+      "description": "Name of the output file for submissions that passed QC",
       "type": "string",
-      "default": "submission-status.csv"
+      "default": "submission-status-passed.csv"
+    },
+    "failed_output_file": {
+      "description": "Name of the output file for submissions that did not pass QC",
+      "type": "string",
+      "default": "submission-status-failed.csv"
     },
     "reload_workers": {
       "description": "Number of concurrent threads for reloading QC file metadata",

--- a/gear/gather_submission_status/src/python/gather_submission_status_app/main.py
+++ b/gear/gather_submission_status/src/python/gather_submission_status_app/main.py
@@ -2,9 +2,11 @@
 
 import logging
 import re
+from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from csv import DictWriter
-from typing import TextIO
+from dataclasses import dataclass, field
+from typing import Any, TextIO
 
 from data_requests.status_request import StatusRequestClusteringVisitor
 from flywheel.models.file_entry import FileEntry
@@ -14,6 +16,7 @@ from nacc_common.qc_report import (
     QC_FILENAME_PATTERN,
     DictReportWriter,
     FileQCReportVisitorBuilder,
+    ListReportWriter,
     QCTransformerError,
     ReportTableVisitor,
     WriterTableVisitor,
@@ -22,6 +25,9 @@ from outputs.error_writer import ErrorWriter
 from pydantic import ValidationError
 
 log = logging.getLogger(__name__)
+
+# Fields for consolidated status output (no stage column)
+CONSOLIDATED_FIELDNAMES = ["adcid", "ptid", "module", "visitdate", "status"]
 
 
 def _should_process_file(
@@ -101,20 +107,66 @@ def _process_reloaded_file(
     table_visitor.visit_table(file_visitor.table)
 
 
-def run(
+@dataclass
+class ConsolidatedResult:
+    """Result of consolidating per-stage rows into per-submission rows."""
+
+    passed: list[dict[str, Any]] = field(default_factory=list)
+    failed: list[dict[str, Any]] = field(default_factory=list)
+
+
+def consolidate_status_rows(
+    rows: list[dict[str, Any]],
+) -> ConsolidatedResult:
+    """Consolidate per-stage status rows into per-submission pass/fail.
+
+    Groups rows by (adcid, ptid, module, visitdate) and determines overall
+    status: PASS only if all stages passed, otherwise FAIL.
+
+    Args:
+        rows: list of row dicts with keys including adcid, ptid, module,
+              visitdate, status
+
+    Returns:
+        ConsolidatedResult with passed and failed row lists
+    """
+    grouped: dict[tuple, list[str]] = defaultdict(list)
+
+    for row in rows:
+        key = (row["adcid"], row["ptid"], row["module"], row["visitdate"])
+        status = row.get("status", "")
+        grouped[key].append(status.upper() if status else "")
+
+    result = ConsolidatedResult()
+    for (adcid, ptid, module, visitdate), statuses in grouped.items():
+        all_passed = all(s == "PASS" for s in statuses)
+        consolidated_row = {
+            "adcid": adcid,
+            "ptid": ptid,
+            "module": module,
+            "visitdate": visitdate,
+            "status": "PASS" if all_passed else "FAIL",
+        }
+        if all_passed:
+            result.passed.append(consolidated_row)
+        else:
+            result.failed.append(consolidated_row)
+
+    return result
+
+
+def _gather_status_rows(
     *,
     input_file: TextIO,
     modules: set[str],
     clustering_visitor: StatusRequestClusteringVisitor,
     file_visitor_builder: FileQCReportVisitorBuilder,
-    writer: DictWriter,
     error_writer: ErrorWriter,
     reload_workers: int = 10,
-) -> bool:
-    """Runs the Gather Submission Status process with concurrent file
-    reloading.
+) -> tuple[bool, list[dict[str, Any]]]:
+    """Gather all per-stage status rows from QC log files.
 
-    Phase 1: Reads and clusters the input CSV by ADCID (unchanged).
+    Phase 1: Reads and clusters the input CSV by ADCID.
     Phase 2: For each ADCID's projects, filters QC log files, reloads them
     concurrently, then processes each single-threaded.
 
@@ -123,30 +175,28 @@ def run(
         modules: set of module names to include
         clustering_visitor: the CSV visitor that clusters requests by ADCID
         file_visitor_builder: factory for creating FileQCReportVisitors
-        writer: the DictWriter for output rows
         error_writer: collects per-request errors
         reload_workers: number of concurrent threads for file.reload() calls
 
     Returns:
-        True if processing completed successfully, False otherwise.
+        Tuple of (success, rows) where rows is a list of row dicts.
     """
-    # Phase 1: Clustering (unchanged)
     ok_status = read_csv(
         input_file=input_file, error_writer=error_writer, visitor=clustering_visitor
     )
     if not ok_status:
         log.error("Request clustering failed. See QC output.")
-        return False
+        return False, []
 
     project_map = clustering_visitor.pipeline_map
     if not project_map:
         log.warning("No projects found for requested data")
-        return False
+        return False, []
 
-    table_visitor = WriterTableVisitor(DictReportWriter(writer))
+    collected_rows: list[dict[str, Any]] = []
+    table_visitor = WriterTableVisitor(ListReportWriter(collected_rows))
     matcher = re.compile(QC_FILENAME_PATTERN)
 
-    # Phase 2: Concurrent file gathering
     with ThreadPoolExecutor(max_workers=reload_workers) as pool:
         for pipeline_adcid, project_list in project_map.items():
             if not project_list:
@@ -159,7 +209,7 @@ def run(
             if not request_list:
                 log.warning("No participants found for center %s", pipeline_adcid)
                 continue
-            request_adcid = request_list[0].adcid  # all requests have same adcid
+            request_adcid = request_list[0].adcid
             if request_adcid != pipeline_adcid:
                 log.error("Expect ADCID: %s got %s", pipeline_adcid, request_adcid)
                 continue
@@ -179,7 +229,105 @@ def run(
                     )
                 ]
 
-                # Submit all reloads concurrently
+                futures = {pool.submit(f.reload): f for f in candidate_files}
+
+                for future in as_completed(futures):
+                    original_file = futures[future]
+                    try:
+                        reloaded_file = future.result()
+                    except Exception as error:
+                        log.warning(
+                            "Failed to reload file %s: %s",
+                            original_file.name,
+                            error,
+                        )
+                        continue
+
+                    _process_reloaded_file(
+                        file=reloaded_file,
+                        adcid=request_adcid,
+                        file_visitor_builder=file_visitor_builder,
+                        table_visitor=table_visitor,
+                    )
+
+    return True, collected_rows
+
+
+def run(
+    *,
+    input_file: TextIO,
+    modules: set[str],
+    clustering_visitor: StatusRequestClusteringVisitor,
+    file_visitor_builder: FileQCReportVisitorBuilder,
+    writer: DictWriter,
+    error_writer: ErrorWriter,
+    reload_workers: int = 10,
+) -> bool:
+    """Runs the Gather Submission Status process with concurrent file
+    reloading.
+
+    Collects per-stage rows and writes them directly to the writer.
+    Used for the error report query type which does not need consolidation.
+
+    Args:
+        input_file: the input CSV stream
+        modules: set of module names to include
+        clustering_visitor: the CSV visitor that clusters requests by ADCID
+        file_visitor_builder: factory for creating FileQCReportVisitors
+        writer: the DictWriter for output rows
+        error_writer: collects per-request errors
+        reload_workers: number of concurrent threads for file.reload() calls
+
+    Returns:
+        True if processing completed successfully, False otherwise.
+    """
+    ok_status = read_csv(
+        input_file=input_file, error_writer=error_writer, visitor=clustering_visitor
+    )
+    if not ok_status:
+        log.error("Request clustering failed. See QC output.")
+        return False
+
+    project_map = clustering_visitor.pipeline_map
+    if not project_map:
+        log.warning("No projects found for requested data")
+        return False
+
+    table_visitor = WriterTableVisitor(DictReportWriter(writer))
+    matcher = re.compile(QC_FILENAME_PATTERN)
+
+    with ThreadPoolExecutor(max_workers=reload_workers) as pool:
+        for pipeline_adcid, project_list in project_map.items():
+            if not project_list:
+                log.warning(
+                    "No projects found for center %s participants", pipeline_adcid
+                )
+                continue
+
+            request_list = clustering_visitor.request_map.get(pipeline_adcid)
+            if not request_list:
+                log.warning("No participants found for center %s", pipeline_adcid)
+                continue
+            request_adcid = request_list[0].adcid
+            if request_adcid != pipeline_adcid:
+                log.error("Expect ADCID: %s got %s", pipeline_adcid, request_adcid)
+                continue
+
+            ptid_set = {request.ptid.strip().lstrip("0") for request in request_list}
+            for project in project_list:
+                log.info("visiting project %s/%s", pipeline_adcid, project.label)
+
+                candidate_files = [
+                    f
+                    for f in project.project.files
+                    if _should_process_file(
+                        filename=f.name,
+                        matcher=matcher,
+                        ptid_set=ptid_set,
+                        modules=modules,
+                    )
+                ]
+
                 futures = {pool.submit(f.reload): f for f in candidate_files}
 
                 for future in as_completed(futures):
@@ -202,3 +350,44 @@ def run(
                     )
 
     return True
+
+
+def run_consolidated(
+    *,
+    input_file: TextIO,
+    modules: set[str],
+    clustering_visitor: StatusRequestClusteringVisitor,
+    file_visitor_builder: FileQCReportVisitorBuilder,
+    error_writer: ErrorWriter,
+    reload_workers: int = 10,
+) -> tuple[bool, ConsolidatedResult]:
+    """Runs gather submission status and returns consolidated pass/fail
+    results.
+
+    Gathers per-stage status rows, then consolidates them by
+    (adcid, ptid, module, visitdate). A submission passes only if all
+    its stages passed.
+
+    Args:
+        input_file: the input CSV stream
+        modules: set of module names to include
+        clustering_visitor: the CSV visitor that clusters requests by ADCID
+        file_visitor_builder: factory for creating FileQCReportVisitors
+        error_writer: collects per-request errors
+        reload_workers: number of concurrent threads for file.reload() calls
+
+    Returns:
+        Tuple of (success, ConsolidatedResult with passed/failed lists).
+    """
+    success, rows = _gather_status_rows(
+        input_file=input_file,
+        modules=modules,
+        clustering_visitor=clustering_visitor,
+        file_visitor_builder=file_visitor_builder,
+        error_writer=error_writer,
+        reload_workers=reload_workers,
+    )
+    if not success:
+        return False, ConsolidatedResult()
+
+    return True, consolidate_status_rows(rows)

--- a/gear/gather_submission_status/src/python/gather_submission_status_app/run.py
+++ b/gear/gather_submission_status/src/python/gather_submission_status_app/run.py
@@ -3,7 +3,7 @@
 import logging
 from csv import DictWriter
 from pathlib import Path
-from typing import List, Optional
+from typing import Any, List, Optional
 
 from data_requests.status_request import StatusRequestClusteringVisitor
 from fw_gear import GearContext
@@ -25,12 +25,15 @@ from nacc_common.visit_submission_error import (
     error_report_visitor_builder,
 )
 from nacc_common.visit_submission_status import (
-    StatusReportModel,
     status_report_visitor_builder,
 )
 from outputs.error_writer import ListErrorWriter
 
-from gather_submission_status_app.main import run
+from gather_submission_status_app.main import (
+    CONSOLIDATED_FIELDNAMES,
+    run,
+    run_consolidated,
+)
 
 log = logging.getLogger(__name__)
 
@@ -43,24 +46,28 @@ class GatherSubmissionStatusVisitor(GearExecutionEnvironment):
         client: ClientWrapper,
         admin_id: str,
         file_input: InputFileWrapper,
-        output_filename: str,
         project_names: List[str],
         modules: set[str],
         study_id: str,
         file_visitor_builder: FileQCReportVisitorBuilder,
         fieldnames: List[str],
         reload_workers: int,
+        query_type: str,
+        passed_output_file: str,
+        failed_output_file: str,
     ):
         super().__init__(client=client)
         self.__admin_id = admin_id
         self.__file_input = file_input
-        self.__output_filename = output_filename
         self.__project_names = project_names
         self.__modules = modules
         self.__study_id = study_id
         self.__file_visitor_builder = file_visitor_builder
         self.__report_fieldnames = fieldnames
         self.__reload_workers = reload_workers
+        self.__query_type = query_type
+        self.__passed_output_file = passed_output_file
+        self.__failed_output_file = failed_output_file
 
     @classmethod
     def create(
@@ -84,7 +91,12 @@ class GatherSubmissionStatusVisitor(GearExecutionEnvironment):
         assert file_input, "create raises exception if missing input file"
 
         options = context.config.opts
-        output_filename = options.get("output_file", "submission-status.csv")
+        passed_output_file = options.get(
+            "passed_output_file", "submission-status-passed.csv"
+        )
+        failed_output_file = options.get(
+            "failed_output_file", "submission-status-failed.csv"
+        )
         admin_id = options.get("admin_group", DefaultValues.NACC_GROUP_ID)
         project_names = options.get("project_names", "").split(",")
         modules = set(options.get("modules", "").split(","))
@@ -104,7 +116,7 @@ class GatherSubmissionStatusVisitor(GearExecutionEnvironment):
         query_type = query_type_arg if query_type_arg == "error" else "status"
 
         file_visitor_builder: FileQCReportVisitorBuilder = status_report_visitor_builder
-        fieldnames = list(StatusReportModel.model_fields.keys())
+        fieldnames = CONSOLIDATED_FIELDNAMES
 
         if query_type == "error":
             file_visitor_builder = error_report_visitor_builder
@@ -113,7 +125,6 @@ class GatherSubmissionStatusVisitor(GearExecutionEnvironment):
         return GatherSubmissionStatusVisitor(
             client=client,
             file_input=file_input,
-            output_filename=output_filename,
             admin_id=admin_id,
             project_names=project_names,
             modules=modules,
@@ -121,6 +132,9 @@ class GatherSubmissionStatusVisitor(GearExecutionEnvironment):
             file_visitor_builder=file_visitor_builder,
             fieldnames=fieldnames,
             reload_workers=reload_workers,
+            query_type=query_type,
+            passed_output_file=passed_output_file,
+            failed_output_file=failed_output_file,
         )
 
     def run(self, context: GearContext) -> None:
@@ -144,19 +158,20 @@ class GatherSubmissionStatusVisitor(GearExecutionEnvironment):
                 project_names=self.__project_names,
                 error_writer=error_writer,
             )
-            with context.open_output(
-                self.__output_filename, mode="w", encoding="utf-8"
-            ) as status_file:
-                writer = DictWriter(status_file, fieldnames=self.__report_fieldnames)
-                writer.writeheader()
-                success = run(
-                    input_file=csv_file,
-                    modules=self.__modules,
-                    clustering_visitor=clustering,
-                    file_visitor_builder=self.__file_visitor_builder,
-                    writer=writer,
+
+            if self.__query_type == "error":
+                success = self._run_error_report(
+                    context=context,
+                    csv_file=csv_file,
+                    clustering=clustering,
                     error_writer=error_writer,
-                    reload_workers=self.__reload_workers,
+                )
+            else:
+                success = self._run_status_report(
+                    context=context,
+                    csv_file=csv_file,
+                    clustering=clustering,
+                    error_writer=error_writer,
                 )
 
             context.metadata.add_qc_result(
@@ -168,6 +183,94 @@ class GatherSubmissionStatusVisitor(GearExecutionEnvironment):
 
             gear_name = self.get_gear_name(context, "gather-submission-status")
             context.metadata.add_file_tags(self.__file_input.file_input, tags=gear_name)
+
+    def _run_error_report(
+        self,
+        *,
+        context: GearContext,
+        csv_file: Any,
+        clustering: StatusRequestClusteringVisitor,
+        error_writer: ListErrorWriter,
+    ) -> bool:
+        """Run the error report query type (writes a single output file).
+
+        Args:
+            context: the gear execution context
+            csv_file: the open CSV input file
+            clustering: the clustering visitor
+            error_writer: collects per-request errors
+
+        Returns:
+            True if processing succeeded
+        """
+        with context.open_output(
+            self.__passed_output_file, mode="w", encoding="utf-8"
+        ) as output_file:
+            writer = DictWriter(output_file, fieldnames=self.__report_fieldnames)
+            writer.writeheader()
+            return run(
+                input_file=csv_file,
+                modules=self.__modules,
+                clustering_visitor=clustering,
+                file_visitor_builder=self.__file_visitor_builder,
+                writer=writer,
+                error_writer=error_writer,
+                reload_workers=self.__reload_workers,
+            )
+
+    def _run_status_report(
+        self,
+        *,
+        context: GearContext,
+        csv_file: Any,
+        clustering: StatusRequestClusteringVisitor,
+        error_writer: ListErrorWriter,
+    ) -> bool:
+        """Run the status report query type (writes passed and failed files).
+
+        Consolidates per-stage rows into per-(ptid, visit, module) and
+        writes separate output files for passed and failed submissions.
+
+        Args:
+            context: the gear execution context
+            csv_file: the open CSV input file
+            clustering: the clustering visitor
+            error_writer: collects per-request errors
+
+        Returns:
+            True if processing succeeded
+        """
+        success, result = run_consolidated(
+            input_file=csv_file,
+            modules=self.__modules,
+            clustering_visitor=clustering,
+            file_visitor_builder=self.__file_visitor_builder,
+            error_writer=error_writer,
+            reload_workers=self.__reload_workers,
+        )
+
+        if not success:
+            return False
+
+        fieldnames = self.__report_fieldnames
+
+        with context.open_output(
+            self.__passed_output_file, mode="w", encoding="utf-8"
+        ) as passed_file:
+            writer = DictWriter(passed_file, fieldnames=fieldnames)
+            writer.writeheader()
+            for row in result.passed:
+                writer.writerow(row)
+
+        with context.open_output(
+            self.__failed_output_file, mode="w", encoding="utf-8"
+        ) as failed_file:
+            writer = DictWriter(failed_file, fieldnames=fieldnames)
+            writer.writeheader()
+            for row in result.failed:
+                writer.writerow(row)
+
+        return True
 
 
 def main():


### PR DESCRIPTION
## Summary

Consolidates per-stage status rows into per-submission (ptid, visit, module) pass/fail and splits the output into two separate files for passed and failed submissions.

## Changes

- main.py: Add consolidate_status_rows() to group rows by (adcid, ptid, module, visitdate)
- main.py: Add run_consolidated() entry point
- run.py: Dispatch by query_type (status writes two CSVs, error writes single file)
- manifest.json: Replace output_file with passed_output_file and failed_output_file
- BUILD: Update image tag to 1.5.0
- CHANGELOG: Add 1.5.0 entry

## Breaking changes

- output_file config removed (replaced by passed_output_file and failed_output_file)
- Status output no longer includes stage column

## Testing

All existing tests pass. Fix, lint, and mypy checks pass.