### PR TITLE
Attribute Curator: Update deriver to 2.4.1

### DIFF
--- a/docs/attribute_curator/CHANGELOG.md
+++ b/docs/attribute_curator/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this gear are documented in this file.
 
+## 1.4.1
+
+* Updates `nacc-attribute-deriver` to `2.4.1` - bugfixes and removal of NACCNVST
+
 ## 1.4.0
 
 * Updates `nacc-attribute-deriver` to `2.4.0` - adds D1c form variables and various bugfixes related to I4/FVP V4 behavior

--- a/gear/attribute_curator/src/docker/BUILD
+++ b/gear/attribute_curator/src/docker/BUILD
@@ -7,5 +7,5 @@ docker_image(
         ":manifest",
         "gear/attribute_curator/src/python/attribute_curator_app:bin",
     ],
-    image_tags=["1.4.0", "latest"],
+    image_tags=["1.4.1", "latest"],
 )

--- a/gear/attribute_curator/src/docker/manifest.json
+++ b/gear/attribute_curator/src/docker/manifest.json
@@ -2,7 +2,7 @@
     "name": "attribute-curator",
     "label": "Attribute Curator",
     "description": "Curates data for the data freeze",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "author": "NACC",
     "maintainer": "NACC <nacchelp@uw.edu>",
     "cite": "",
@@ -15,7 +15,7 @@
     "custom": {
         "gear-builder": {
             "category": "analysis",
-            "image": "naccdata/attribute-curator:1.4.0"
+            "image": "naccdata/attribute-curator:1.4.1"
         },
         "flywheel": {
             "suite": "Curation",

--- a/mypy.lock
+++ b/mypy.lock
@@ -60,142 +60,162 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "4ed29121da8b3fdc291002801a1de0f76248fa07dce89157a5f277842cf6126e",
-              "url": "https://files.pythonhosted.org/packages/95/93/5524a3dc6c3f593de3228ed9cbef73afa047625b7000ec21b7f58e6eb4d4/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_x86_64.whl"
+              "hash": "6f18048fe9f6dd266bd577cdec48bdcecb74faaa01fe941324435483b013ed2a",
+              "url": "https://files.pythonhosted.org/packages/5c/cd/440c798957e14e31776bfeb024d8fafe0bb1d5b89c51c2f067e69938f7b0/ast_serialize-0.8.0-cp39-abi3-musllinux_1_2_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "cdc4e6f930b9090c2f92c9036ad12ffb8e6e44d4a5ba06f1458a05d60f203f7b",
-              "url": "https://files.pythonhosted.org/packages/0e/4b/3676ca2191f39bafb75f93f99b2f429ec464586158fece2165f3572805dc/ast_serialize-0.6.0-cp39-abi3-manylinux_2_31_riscv64.whl"
+              "hash": "3ccebbed24f1281062d5852353c72c47502955926cfcb8345ffb3a44d87ff3d3",
+              "url": "https://files.pythonhosted.org/packages/1a/90/f5058f209756dd70e958b7538aaa82d25d24944baf9ec8ae6f27b06fcacc/ast_serialize-0.8.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "c7b8b8f0c42f752ea00b2b7d7c090b3f80d9c1c5c75cadf16423790a0cc74081",
-              "url": "https://files.pythonhosted.org/packages/4d/21/087957bba486242afc52f49b2d9e21c9dad00289356cf9efe67084015a9d/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+              "hash": "e94f9121d13fa36cbf21314783c77d05ae3a0868decd18cf5233fdcc6de49ac8",
+              "url": "https://files.pythonhosted.org/packages/2d/3d/084882eca93c842bd4262591a071ec7f825340644035e51501208cc5a8d4/ast_serialize-0.8.0-cp39-abi3-musllinux_1_2_armv7l.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "093cb8bb91b720d8523580498d031791bb1bbaa048599c3d21085d380e11a596",
-              "url": "https://files.pythonhosted.org/packages/52/19/ac8348ae8711c9b5ae834634f635780cab62a0f5e6f988882e048b89c2ae/ast_serialize-0.6.0-cp39-abi3-macosx_10_12_x86_64.whl"
+              "hash": "9118ad3e369727060b2696fc4078f250ecffca4248ba87f537f55cea9f9dce06",
+              "url": "https://files.pythonhosted.org/packages/4e/54/8c20ed4eea805516a3fd23dd4a721ce28c64f50f0e4b359969f60a8c97a6/ast_serialize-0.8.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "aadd3ffcf4858c9726bf3515f7b199c7eadbe504f96028e4a87172c0da65a8fe",
-              "url": "https://files.pythonhosted.org/packages/58/ad/0d70a3a2d6e01968d985415259e8ec7ad3f777903f9b1c1f3c8c44642c60/ast_serialize-0.6.0.tar.gz"
+              "hash": "485f1113af805e9e170b95ef993ca3fbd4f89c04bab25c58b4fc632d854801ab",
+              "url": "https://files.pythonhosted.org/packages/6f/c4/ce2d41a1bc22508e82618901f7e10f2a5e2f9556553fea90624daf9875e2/ast_serialize-0.8.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "4d6ef91590258ada18909b9caea344dac4de2013906b035473cd674a43f4b790",
-              "url": "https://files.pythonhosted.org/packages/64/64/62fb99d6faf199b4c3e5b08a07136e9a0d7664bb249c6de3670e5b63e9b6/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+              "hash": "1f9caa63fad8241257ae401b5ff0a64026c6adb36b8e86cbe8782d9ea505daf6",
+              "url": "https://files.pythonhosted.org/packages/8c/80/7e0fd2e2e2aba257820db4a8657c4c356844d36b914b20a4af294bcfb902/ast_serialize-0.8.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "305802f2ce2a7c4e87835078ea85c58b586ddda8095b92fe2ead9364ae19c80a",
-              "url": "https://files.pythonhosted.org/packages/6f/02/613a7534a41d0122f37d1e0c64aa8ac78bfb831f8c92f6db057a311abb3c/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "ddd3b61f45c132da66c5476b281891e08c1fd87fbdabe8a6973e1622efc85f06",
+              "url": "https://files.pythonhosted.org/packages/a6/e9/6e8be8df02b35d85e2b8809f7f1cfa290bdf5882b55127a539d049482db0/ast_serialize-0.8.0-cp39-abi3-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "cd5b91b9e6f2356ace3a556963b0cd783b395fbbb0bb17b4defc283415466e77",
-              "url": "https://files.pythonhosted.org/packages/82/04/78128bbb170071c2c72a210a181f1c00e11cc1cec60a8beef747b07f9201/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+              "hash": "3926fa117b5e65019853a2969966d11c7175af377a3425991f3fe73784412405",
+              "url": "https://files.pythonhosted.org/packages/b0/6a/3bae0af06f9b1bae3001c44d64215f5b567877e7aae9ffd45db11c3a7647/ast_serialize-0.8.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "c901adbd750029b9ac4ad3d6aa56853e0ad4875119fbf52b7b8298afc223828b",
-              "url": "https://files.pythonhosted.org/packages/a8/5a/e046f3899e2acba4677d7427b76431443a1aa1a0e583dfb05b55b69d55cf/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_armv7l.whl"
+              "hash": "252f883290d1cdb728eb7fe1d9a7221b88af5a329aae0bc91ddee4dafb820331",
+              "url": "https://files.pythonhosted.org/packages/bf/32/7f77ea87fa0836daab706ed5cb7f903bb25fa26a77439011aee626af11d8/ast_serialize-0.8.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "c4af9a1386166e40ed01464991806f89038a2d89782576c7774876fa77034e32",
-              "url": "https://files.pythonhosted.org/packages/b1/f2/13736d920ab3d49bbee80ef1a277dd7b7aaf3b3545efd9d2a8114fe05525/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_aarch64.whl"
+              "hash": "f359df4bd921918af8bebd142a376c77511d7151cc8ba852760b587b5a4a54f3",
+              "url": "https://files.pythonhosted.org/packages/cb/5b/9f14430f12fe830b656fb38f8e2e05ee13b02a88967660bef46af0ab22a8/ast_serialize-0.8.0-cp39-abi3-musllinux_1_2_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e61580a69faf47e3689795367ed211f2a10fd741478cc0f36a0f128793360aad",
-              "url": "https://files.pythonhosted.org/packages/c1/f6/ec7ec652c51db77c2f61d8573338e13e4704303265ccc658cb4031d9f354/ast_serialize-0.6.0-cp39-abi3-macosx_11_0_arm64.whl"
+              "hash": "4c38b915511e32bc718c49dbce98ff9af36bac0ad6a604f58000cd5e3aecdba7",
+              "url": "https://files.pythonhosted.org/packages/cb/88/287b9a5300c1f2f651d259f670931b63110adc265b7613c885b44c5bc53d/ast_serialize-0.8.0-cp39-abi3-musllinux_1_2_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "dcbed41e9386059fc0261d602445ede0976c2ecec2939688bcbcb9ed0b6f28b7",
-              "url": "https://files.pythonhosted.org/packages/ca/87/b4d6c38e0ccd5e85dc54cecdf933a152c60b28fe5d993a6d8a72fa6d5896/ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "54f95b486018d262bcb387a9afd96f0da74508b442762b80c769454a6fbb3ee3",
+              "url": "https://files.pythonhosted.org/packages/ce/73/ea84852096c2036c61cc0b2f97b90242207419f534dc671060ee1c8e05cb/ast_serialize-0.8.0-cp39-abi3-musllinux_1_2_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "3ae22a366b752ab4496191525b78b097b5b72d531752e3c1dd7e383a8f2c8a1a",
-              "url": "https://files.pythonhosted.org/packages/cc/c7/e42aaca7bb2d22a7c06d5a8c7930086c5a334e93d716e6fa5e6647a4515f/ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_i686.whl"
+              "hash": "e1bd223df0f6c96b396975fa604cb33bce53d9b4a0185490be4c4a289f7c9c87",
+              "url": "https://files.pythonhosted.org/packages/d9/e3/6142e920fec6ef7bccabd8c24ed8ed99f8bdc6cb8b065e1df7c6a3b2d667/ast_serialize-0.8.0-cp39-abi3-macosx_10_12_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "897ac47b5637be41c0c07061c8a912fafa967ef1dc73fa115e4bfa70882a093b",
-              "url": "https://files.pythonhosted.org/packages/f3/58/494ef8c4b4acb2f4a265ac934caf45f792a08fe27d6b853de35ad991941a/ast_serialize-0.6.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl"
+              "hash": "6c37c43e4004dfb42d321ddedc569dc17ff4259296f3af577c9ea46a809bc010",
+              "url": "https://files.pythonhosted.org/packages/e1/a9/11851c3e02a3fea2ddc9932d1fdc7d2edaeecc0d2e11bc5f2a7fde2b0934/ast_serialize-0.8.0.tar.gz"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "96abc072ad29db8d02194afd47d68987322622787daceae82398d7b69f3ba2e6",
+              "url": "https://files.pythonhosted.org/packages/eb/5a/75b82ad2725b5e8e8c742732f9e76c6738a292d0709e1f60d10a973730b4/ast_serialize-0.8.0-cp39-abi3-manylinux_2_31_riscv64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "9a2ef9cf12f2de4f1028c42c1dd7d775255e0fb3e5bb48896c97e35ef52366fe",
+              "url": "https://files.pythonhosted.org/packages/ee/f3/1bc3a79afcf0c2a8d2c37182d0d659d1545a9d7f7f6dc9cf3e63d6c17135/ast_serialize-0.8.0-cp39-abi3-musllinux_1_2_riscv64.whl"
             }
           ],
           "project_name": "ast-serialize",
           "requires_dists": [],
           "requires_python": ">=3.7",
-          "version": "0.6.0"
+          "version": "0.8.0"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "db327e7271e653c32040b85ae6188059c924b57d7e1e29f935523fa017cd4e82",
-              "url": "https://files.pythonhosted.org/packages/8c/f2/10946922503858a359492fa27f13e86228bde702116a740ac7b3cd185f24/librt-0.13.0-cp312-cp312-musllinux_1_2_x86_64.whl"
+              "hash": "1e47b8ba865d7ede071a91a7163073bbaeb72541f1ef8a07d512c45c7b5007f2",
+              "url": "https://files.pythonhosted.org/packages/c9/4c/cf9601c1b4c5f09280acd5d83abdb2e68527a2be8257136eb42304218622/librt-0.15.0-cp312-cp312-musllinux_1_2_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "cb8a1adce42d8b75485a5d56a9623a50bcab995b6079f1dac59fc44034dd93d9",
-              "url": "https://files.pythonhosted.org/packages/03/e7/a197e7bc72baf2c61ce7fdc6906a5054dc05bd8da0819aa894e4857bf87e/librt-0.13.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
+              "hash": "c802434092b769b1d613ed2e13fac15fbfce1934a74bd10283b03c0fae231cd1",
+              "url": "https://files.pythonhosted.org/packages/0c/db/3ad9c965c72f1e1d6beeec44ec10a54e17be8ae042fbb4baade16cbadced/librt-0.15.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "fadc63331f4388c3dc90090448f682a7e9feafc11481391c1e94f2f907a3976e",
-              "url": "https://files.pythonhosted.org/packages/36/11/69ac3b54766ffba5fd7e5acebfb048d66dbe1f9f2d14516c2b3edc59cf87/librt-0.13.0-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl"
+              "hash": "71599e011ac880e8e45d46047d714871894c7d4ab6f25626f8d4f89da21f368d",
+              "url": "https://files.pythonhosted.org/packages/14/43/f4b1bd1b2888798a1409808889a25ea1ba49eaabce7d681ed27734c2df9d/librt-0.15.0-cp312-cp312-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "70d9c62a4cffd9f23396cd5ef93fc5d11b31596b9b7d6306074abe3d5fcf09bd",
-              "url": "https://files.pythonhosted.org/packages/61/5f/d72f95fd444a926a3c14b4e24979474116988dd57a45be242077c45d3c22/librt-0.13.0-cp312-cp312-musllinux_1_2_aarch64.whl"
+              "hash": "cc30523e3f1a23fb7511cc659834a0d01a1042bb9de359bc1c131cc4ec6c9656",
+              "url": "https://files.pythonhosted.org/packages/26/60/03b3abb82b41714671b907bf6989b228e31e6a8af52dec82b5b0728dc250/librt-0.15.0-cp312-cp312-musllinux_1_2_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "93d24ebb82aa4420b1409c389e7857bc35bd0b668007ac8172427d5c73cc8cc5",
-              "url": "https://files.pythonhosted.org/packages/90/ef/db98f744ca50e6efc9c95c70ee49b77aefac31f6a3fc7c83754a42d6a74f/librt-0.13.0-cp312-cp312-macosx_11_0_arm64.whl"
+              "hash": "6ecfc32dfb46fb7b565bcd6abf9412acf978775a998273d22888a6d7953730dd",
+              "url": "https://files.pythonhosted.org/packages/29/39/ab57cc2f5b276156da02bb7f5a8921bada1cb1993ffec99acf811c602c23/librt-0.15.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b222493da6e7b6199db9bd79502436cf5a27da3c1f7fa83c7e285444fc93fd03",
-              "url": "https://files.pythonhosted.org/packages/94/f0/f2283385bb6b950b26a1410f4ce51ec27231e0b3a4b925c46366d218b198/librt-0.13.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+              "hash": "4e66cbe84437497d951b799d3e1551291b6fb3d643820a7014b3655d57a59162",
+              "url": "https://files.pythonhosted.org/packages/36/9b/356320fbae2ac8467e21c5e73e1389c80468e4998c62cc7d3536cc51b614/librt-0.15.0.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "ac04bcd3328eb91d99dfedf6a60d9c1f15d3434e6f6daf922f0420f7d90b85c7",
-              "url": "https://files.pythonhosted.org/packages/96/d5/6d9bb2f54e4109a956b7128836529653eb9d740f784bc47ed10a02c1000e/librt-0.13.0-cp312-cp312-musllinux_1_2_riscv64.whl"
+              "hash": "5500eeae393a184d14e1f35645962c27129d20c81afa4069e6ef826ebc2b3aaa",
+              "url": "https://files.pythonhosted.org/packages/4b/07/5888a6d76acd62ebce66c61b74d94e9370b9c32929f111e487bb6546f8ed/librt-0.15.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "66c0e7e6b02a155576df2c77ec933a70b72da726e248c494abf690923e624348",
-              "url": "https://files.pythonhosted.org/packages/c4/08/dcd9993ad192737a004ba263d549f8ea605b326b952e7d6205c7d4170b76/librt-0.13.0-cp312-cp312-musllinux_1_2_i686.whl"
+              "hash": "d5f51401d102c885b9ca509e62c79b1dbff286e1b9b047fde6f763780789356d",
+              "url": "https://files.pythonhosted.org/packages/93/26/473c2e4b6c104e9e58e27ce95fc8005c8bd4fc36cae4f254371125a92db8/librt-0.15.0-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1d2a610c14ac0d0750ee0a3ab8548e83155258387891caaca04def4bf7289781",
-              "url": "https://files.pythonhosted.org/packages/dc/2f/3908645ddddab7120b46295e541ead308109fa48dbec7d67d7a778870d60/librt-0.13.0.tar.gz"
+              "hash": "89cc46cfd15022e35084355478c9ac809d90b1152222706ac9a7655ec21df6fa",
+              "url": "https://files.pythonhosted.org/packages/a7/b9/bdbb0b648b5c2befb031f4c6f3b1dd857415e8fb492a25a3c764a6681e6c/librt-0.15.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "30536798f4504c0fad0885b1d371b0539abb081e4570c9d7c641cb51141b49f0",
-              "url": "https://files.pythonhosted.org/packages/f0/f4/b2933ddae222dac338476abb872641169a5cfed2c2bb5444a5b07b32b0c3/librt-0.13.0-cp312-cp312-macosx_10_13_x86_64.whl"
+              "hash": "e87bc679f86a99aa3b26e3c78eeb821a247c9a28eae48eaafcc32c3bf4c3bb9e",
+              "url": "https://files.pythonhosted.org/packages/ba/39/99c25030e782bdfb7a21be8c05254806a2e4bbb05c8d50c2a2130acbfa05/librt-0.15.0-cp312-cp312-macosx_10_13_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0763ca2ab66058174f9dee426dc64f5e0a89c24a7df8d3fe3f1836c04e25de4b",
-              "url": "https://files.pythonhosted.org/packages/f8/e7/7887712e27da7c1ab80fcabb1de6eb24243964f6557cae530d4b70706dbd/librt-0.13.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl"
+              "hash": "85ea21ec6730194d67156b0e0b5430ccb1d61f8b8b907e39b37f9812b74a13f0",
+              "url": "https://files.pythonhosted.org/packages/bc/95/2a2853c1ee014bf102116e7f897a04beeaeb2461b45b79af98bdfb95f1ef/librt-0.15.0-cp312-cp312-musllinux_1_2_riscv64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "5a6526a2a956bbb1e4ae3568c82e650fc99119c66bb011ea60715744955a2b4d",
+              "url": "https://files.pythonhosted.org/packages/dc/84/6937a280d461f7de6e031ffb02edc2b7c3c90d49d630565ce8ff27cbc5f2/librt-0.15.0-cp312-cp312-musllinux_1_2_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "59fe030d8ae4a57e3fb7756bf35a858de74e04066fc8555c53d0af979132af81",
+              "url": "https://files.pythonhosted.org/packages/f2/0e/9bb1f0a4affbd0a1888f4f79dc03ed2a299d9a2c26c59ab2a97dcbf11903/librt-0.15.0-cp312-cp312-musllinux_1_2_i686.whl"
             }
           ],
           "project_name": "librt",
           "requires_dists": [],
           "requires_python": ">=3.9",
-          "version": "0.13.0"
+          "version": "0.15.0"
         },
         {
           "artifacts": [

--- a/python-default.lock
+++ b/python-default.lock
@@ -18,7 +18,7 @@
 //     "fw-utils>=3",
 //     "hypothesis>=6.0.0",
 //     "moto[s3,ses,ssm]==5.1.14",
-//     "nacc_attribute_deriver @ https://github.com/naccdata/nacc-attribute-deriver/releases/download/v2.4.0/nacc_attribute_deriver-2.4.0-py3-none-any.whl",
+//     "nacc_attribute_deriver @ https://github.com/naccdata/nacc-attribute-deriver/releases/download/v2.4.1/nacc_attribute_deriver-2.4.1-py3-none-any.whl",
 //     "nacc_form_validator @ https://github.com/naccdata/nacc-form-validator/releases/download/v0.6.4/nacc_form_validator-0.6.4-py3-none-any.whl",
 //     "natsort",
 //     "pandas-stubs>=2.0.3",
@@ -152,42 +152,42 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "115ed9cac409d9b57e2437b52fdb4286660d12a2bd44a0f48d530e68623d09a7",
-              "url": "https://files.pythonhosted.org/packages/80/a4/2c4ee25556a997a81ea01073962cf8351da3707412c584d053b3861d09e8/boto3-1.43.57-py3-none-any.whl"
+              "hash": "082cf9df068168cb44028a1703822374c1eb7e48fa49470d7e8a76f0c977d0bc",
+              "url": "https://files.pythonhosted.org/packages/77/0f/b41f8968452dc6bf3b83f15f5e9f76a27fd93e246906aeb2e0555f494375/boto3-1.43.67-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "549c95e45f9b04cf0c69727632dbdda23b84dcd3d0ed7981c6aaff72ef9cb5af",
-              "url": "https://files.pythonhosted.org/packages/c7/30/324319a914752e4021358ccf8252c04364eb8358f9d41d9c3f021959b363/boto3-1.43.57.tar.gz"
+              "hash": "75fe983b70d39cfdc274dc51f9bb02b8a0a104bdad4fa073c1af85a35e707c91",
+              "url": "https://files.pythonhosted.org/packages/ad/bf/ef5de9b55523bc2141d072fbe6614627088e3e6f97b47850216e99de6a1c/boto3-1.43.67.tar.gz"
             }
           ],
           "project_name": "boto3",
           "requires_dists": [
-            "botocore<1.44.0,>=1.43.57",
+            "botocore<1.44.0,>=1.43.67",
             "botocore[crt]<2.0a0,>=1.21.0; extra == \"crt\"",
             "jmespath<2.0.0,>=0.7.1",
             "s3transfer<0.20.0,>=0.19.0"
           ],
           "requires_python": ">=3.10",
-          "version": "1.43.57"
+          "version": "1.43.67"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "36053e8243a8d45aab013f1f6e4176a86d3b9195872df87c97ef7c42ff04159e",
-              "url": "https://files.pythonhosted.org/packages/ca/db/45751b2ed0466b58b967a0e0058ebaf7f8608da0cd80e91247e13e3b6348/boto3_stubs-1.43.57-py3-none-any.whl"
+              "hash": "d1ba5022fad49869ec6c40b19fc08a45e9458689978376ed6754cbff7e732a4e",
+              "url": "https://files.pythonhosted.org/packages/b3/f0/462a2ce327b87f00e5bebb6f6e37180f19e492e38cc524333151173c29c2/boto3_stubs-1.43.67-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a957410d83b78c5abe4fd7778f4b2dcd7e8f0d92de69edb6cbae50390b333a6a",
-              "url": "https://files.pythonhosted.org/packages/68/9d/0a25b4b93aa0ae8e88adbf116117c8b5f705563f3122f5aa9b011bebf8db/boto3_stubs-1.43.57.tar.gz"
+              "hash": "f15696f567102d057e4d0d313a371dc644ca638e7bd07c490f362c2c64f7a4bc",
+              "url": "https://files.pythonhosted.org/packages/93/e0/4885861380b98e15b8031cae9575091cbadefeb5518bb62882c0435284b8/boto3_stubs-1.43.67.tar.gz"
             }
           ],
           "project_name": "boto3-stubs",
           "requires_dists": [
             "boto3-stubs-full<1.44.0,>=1.43.0; extra == \"full\"",
-            "boto3==1.43.57; extra == \"boto3\"",
+            "boto3==1.43.67; extra == \"boto3\"",
             "botocore-stubs",
             "mypy-boto3-accessanalyzer<1.44.0,>=1.43.0; extra == \"accessanalyzer\"",
             "mypy-boto3-accessanalyzer<1.44.0,>=1.43.0; extra == \"all\"",
@@ -197,6 +197,10 @@
             "mypy-boto3-acm-pca<1.44.0,>=1.43.0; extra == \"all\"",
             "mypy-boto3-acm<1.44.0,>=1.43.0; extra == \"acm\"",
             "mypy-boto3-acm<1.44.0,>=1.43.0; extra == \"all\"",
+            "mypy-boto3-agent-registry-control<1.44.0,>=1.43.0; extra == \"agent-registry-control\"",
+            "mypy-boto3-agent-registry-control<1.44.0,>=1.43.0; extra == \"all\"",
+            "mypy-boto3-agent-registry<1.44.0,>=1.43.0; extra == \"agent-registry\"",
+            "mypy-boto3-agent-registry<1.44.0,>=1.43.0; extra == \"all\"",
             "mypy-boto3-aiops<1.44.0,>=1.43.0; extra == \"aiops\"",
             "mypy-boto3-aiops<1.44.0,>=1.43.0; extra == \"all\"",
             "mypy-boto3-amp<1.44.0,>=1.43.0; extra == \"all\"",
@@ -807,6 +811,8 @@
             "mypy-boto3-pipes<1.44.0,>=1.43.0; extra == \"pipes\"",
             "mypy-boto3-polly<1.44.0,>=1.43.0; extra == \"all\"",
             "mypy-boto3-polly<1.44.0,>=1.43.0; extra == \"polly\"",
+            "mypy-boto3-pricing-plan-manager<1.44.0,>=1.43.0; extra == \"all\"",
+            "mypy-boto3-pricing-plan-manager<1.44.0,>=1.43.0; extra == \"pricing-plan-manager\"",
             "mypy-boto3-pricing<1.44.0,>=1.43.0; extra == \"all\"",
             "mypy-boto3-pricing<1.44.0,>=1.43.0; extra == \"pricing\"",
             "mypy-boto3-proton<1.44.0,>=1.43.0; extra == \"all\"",
@@ -1050,19 +1056,19 @@
             "typing-extensions>=4.1.0; python_version < \"3.12\""
           ],
           "requires_python": ">=3.9",
-          "version": "1.43.57"
+          "version": "1.43.67"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "319c6d79f66c3f3f2b538f7dcdc90e410a15a7bfced1db06479134947e629482",
-              "url": "https://files.pythonhosted.org/packages/41/7a/1cfe9c296df0fa6e0143c8622b10f21fa8fb9cce25450e9a8e5cf6523e4b/botocore-1.43.57-py3-none-any.whl"
+              "hash": "48ab8e9fac26fbc2a700d57010251003e6a5f731cf74d8540fb796bc8f3fc0ef",
+              "url": "https://files.pythonhosted.org/packages/21/be/38af8e96f3d200c9d34eab8e9f69a4468388ed6030ea04ff012974e5af5a/botocore-1.43.67-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "001a5653bebc03b862bde2da63bad4adb0b30072a3f247aba4daae5aa097b546",
-              "url": "https://files.pythonhosted.org/packages/0b/92/1f8a454cf90bcb0c0e32a25817441cb7f3702fdd76710d7018abad12a2fc/botocore-1.43.57.tar.gz"
+              "hash": "6fe5cfa0c8676ba809efe505b618ec00f30d1af2d014bf316a7aa4ee86accb20",
+              "url": "https://files.pythonhosted.org/packages/53/1c/3a75deae60e36bd0ee5c27d040384756b2ea1c90bd7c8c9658335a18b4f5/botocore-1.43.67.tar.gz"
             }
           ],
           "project_name": "botocore",
@@ -1073,7 +1079,7 @@
             "urllib3!=2.2.0,<3,>=1.25.4"
           ],
           "requires_python": ">=3.10",
-          "version": "1.43.57"
+          "version": "1.43.67"
         },
         {
           "artifacts": [
@@ -1138,53 +1144,53 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "379de10ce1ba048b1448599d1b37b24caee16309d1ac98d3982fc997f768700b",
-              "url": "https://files.pythonhosted.org/packages/79/99/0d0fd37f055224085f42bbb2c022d002e17dde4a97972822327b07d84101/cffi-2.1.0-cp312-cp312-musllinux_1_2_x86_64.whl"
+              "hash": "210019b6c7cf07f081b4c54635c8cf744377001350e29cc0f81c4377b4797735",
+              "url": "https://files.pythonhosted.org/packages/cb/52/3fa190537004dd7f0ab860a6dc7c0175b8667f68d1e618a46f5498d30250/cffi-2.1.1-cp312-cp312-musllinux_1_2_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b6422532152adf4e59b110cb2808cee7a033800952f5c036b4af047ee43199e7",
-              "url": "https://files.pythonhosted.org/packages/1b/dc/5620cf930688be01f2d673804291de757a934c90b946dbdc3d84130c2ea4/cffi-2.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
+              "hash": "c8c69575568085ba0b1b10c0249d779a214aea6f6522e949a0fc9fb0fcb449d0",
+              "url": "https://files.pythonhosted.org/packages/10/69/43965eccfdead3b9220015fd1320e117be8c6ed01a62ffab76eeb752f5d5/cffi-2.1.1-cp312-cp312-macosx_10_15_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "df2b82571a1b30f58a87bf4e5a9e78d2b1eff6c6ce8fd3aa3757221f93f0863f",
-              "url": "https://files.pythonhosted.org/packages/1e/85/990925db5df586ec90beb97529c853497e7f85ba0234830447faf41c3057/cffi-2.1.0-cp312-cp312-macosx_10_15_x86_64.whl"
+              "hash": "68e62fe11f30d5ca8289242866f0a5291402d8529ca2178ab8afc5c9694ae890",
+              "url": "https://files.pythonhosted.org/packages/44/de/f98430906df1545ffde0d543dd124a7a439bc2cd32b36b9c53f805df7333/cffi-2.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "78474632761faa0fb96f30b1c928c84ebcf68713cbb80d15bab09dfe61640fde",
-              "url": "https://files.pythonhosted.org/packages/4b/92/e7bb136ad6b5352603732cf907ef862ca103f20f2031c1735a46300c20c9/cffi-2.1.0-cp312-cp312-macosx_11_0_arm64.whl"
+              "hash": "f81b3b8f3d4e343550fa4baa0e479bba9f2d29ce9c2e9b51d1ce1718d7442fcf",
+              "url": "https://files.pythonhosted.org/packages/54/7d/16e5a096677b5e313ca80cd5e5170efa3ea44624a82bb111925522da64b1/cffi-2.1.1-cp312-cp312-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "46b1c8db8f6122420f32d02fffb924c2fe9bc772d228c7c711748fff56aabb2b",
-              "url": "https://files.pythonhosted.org/packages/4b/a4/77b53abbf7a1e0beb9637edbef2a94d15f9c822f591e85d439ffd91519a6/cffi-2.1.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl"
+              "hash": "811bd1e21d32de12efca32393a0ab3f5133b54fce9bd44b8bd77ab07da14bf6a",
+              "url": "https://files.pythonhosted.org/packages/56/e6/8941622732edec876dd17d0453dce07317ae96db34f2ec1436c9d3785986/cffi-2.1.1-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "efc1cdd798b1aaf39b4610bba7aad28c9bea9b910f25c784ccf9ec1fa719d1f9",
-              "url": "https://files.pythonhosted.org/packages/57/5f/ff100cae70ebe9d8df1c01a00e510e45d9adb5c1fdda84791b199141de97/cffi-2.1.0.tar.gz"
+              "hash": "3143d81e29e1e20a9ce10901ec369012947876596f75a222235965f2b7ae832e",
+              "url": "https://files.pythonhosted.org/packages/64/b3/f8aa4f3e34986c7e4ec45072d1b1b9dd295b6b18007b45518d79726dd725/cffi-2.1.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d9fafc5aa2e2a39aaf7f8cc0c1f044a9b07fca12e558dca53a3cc5c654ad67a7",
-              "url": "https://files.pythonhosted.org/packages/58/0c/f528df19cc94b675087324d4760d9e6d5bfae97d6217aa4fac43de4f5fcc/cffi-2.1.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl"
+              "hash": "4a7c934f7360e8cd64fe9efadcbd10c7c6364f531e432b9a4bf5ccbc9e0e8b50",
+              "url": "https://files.pythonhosted.org/packages/6a/5b/717f1526b9957b34456313c31645c5b82b8fb5c3fe9e4752999be7128bfc/cffi-2.1.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1e9f50d192a3e525b15a75ab5114e442d83d657b7ec29182a991bc9a88fd3a66",
-              "url": "https://files.pythonhosted.org/packages/62/f2/c9522a81c32132799a1972c39f5c5f8b4c8b9f00488a23feaa6c06f07741/cffi-2.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
+              "hash": "dd31f52ea1086513bb9df30f8fcee9b8918323ae067a3d5b78bc826a000712be",
+              "url": "https://files.pythonhosted.org/packages/9e/ef/008a1939e372c06329a3fce4279c02f328488f3526744906eeec3da7ad5f/cffi-2.1.1.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "98fff996e983a36d3aa2eca83af40c5821202e7e6f32d13ae94e3d2286f10cfe",
-              "url": "https://files.pythonhosted.org/packages/6e/28/bd53988b9833e8f8ad539d26f4c07a6b3f6bcb1e9e02e7ca038250b3428d/cffi-2.1.0-cp312-cp312-musllinux_1_2_aarch64.whl"
+              "hash": "208f941bb9d18e768138677f0a6d2ce01f590df56043dda1df1535ac57c88517",
+              "url": "https://files.pythonhosted.org/packages/a0/d2/6cd24ae3be000a634109c247d1475d62e5616d0dc78c82770942ec384248/cffi-2.1.1-cp312-cp312-musllinux_1_2_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5972433ad71a9e46516584ef60a0fda12d9dc459938d1539c3ddecf9bdc1368d",
-              "url": "https://files.pythonhosted.org/packages/c3/c0/d1ec30ffb370f748f2fb54425972bfef9871e0132e82fb589c46b6676049/cffi-2.1.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl"
+              "hash": "c1453022f490d2459a11819d83ad1d586e9ff65a12ac3e705ffebd46d3685dcf",
+              "url": "https://files.pythonhosted.org/packages/b1/db/dceb9dd5b231e1da801793f8acc9f3c52a7e1afe40bb1aae37e02b0faad5/cffi-2.1.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
             }
           ],
           "project_name": "cffi",
@@ -1192,7 +1198,7 @@
             "pycparser; implementation_name != \"PyPy\""
           ],
           "requires_python": ">=3.10",
-          "version": "2.1.0"
+          "version": "2.1.1"
         },
         {
           "artifacts": [
@@ -1266,128 +1272,128 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b",
-              "url": "https://files.pythonhosted.org/packages/93/77/8df9eb486495979bccecd1062e2eaf435250e84437040295b57d09048b0b/cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl"
+              "hash": "65c2c3add92b45fd0709db8594536aea39c2a67af0e27ffcf049c498501140b7",
+              "url": "https://files.pythonhosted.org/packages/d2/1a/efcfb02f91407149a0dacffffab791f7e19bf6385f63b3666dc8b5e5c9c8/cryptography-50.0.0-cp39-abi3-musllinux_1_2_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db",
-              "url": "https://files.pythonhosted.org/packages/09/41/3797cfaf69cae04a13ee78ebd83f0678d9c02b4779d21ce24445326f1a69/cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
+              "hash": "ccdc4a71a4dabae05de219404f9f4abc38e3b58422177ff93d0da05967dafa07",
+              "url": "https://files.pythonhosted.org/packages/03/37/73d005be173aff344af30e9fd2a576575cb2391a7101d9cd3842e1fa8cce/cryptography-50.0.0-cp39-abi3-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ec5e529fb80935c94fe7b729f9972b50e351a0e6b50aa294fd5cabb109fcc29a",
-              "url": "https://files.pythonhosted.org/packages/19/2a/5bb823f5bedcf80718cea7fbc95ec5515cca3769633c4b01a32be7f30e7c/cryptography-49.0.0-cp39-abi3-macosx_11_0_arm64.whl"
+              "hash": "8d89f3976b10b4ce31118de72329025f70d2c6ead14a8217c5514dd2c6d5a78f",
+              "url": "https://files.pythonhosted.org/packages/06/1e/63a1027cb7fec360a182208e1b7767d5aa1fe57be3d6aa856e69a321edc0/cryptography-50.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493",
-              "url": "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz"
+              "hash": "900131fafd8aead39ac7dd3a7e833be754c17a95cfd91221636949fe4eb0aa8a",
+              "url": "https://files.pythonhosted.org/packages/15/37/36a9c479bbe49acea2636c7fd3360d20f7b7e079c300352011c44850b181/cryptography-50.0.0-cp311-abi3-manylinux_2_31_armv7l.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6",
-              "url": "https://files.pythonhosted.org/packages/20/2c/0622f20ff02b2ef32558733443805dc82fd4c275be01b2d19d14676f3a1b/cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl"
+              "hash": "d764dcf130c428ef66786f866dd750f53182bc608813489915e9fc106bb0c82f",
+              "url": "https://files.pythonhosted.org/packages/1d/dd/7c77d26285cc7f6991efce64a0f5b4f9383bfa5dd8c5033003eaf7db4cdb/cryptography-50.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64",
-              "url": "https://files.pythonhosted.org/packages/24/01/186c825898477d77e2324d5360fefe622ff1d8d1963ec0554e2cada8ec77/cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl"
+              "hash": "f89831ef99dd7dd169ab06d63a831adb9e20a87aac6d380266bbda5823349169",
+              "url": "https://files.pythonhosted.org/packages/22/f6/ec13b470172126464a86bf54d2294a46d29837fc51ba3e45d4047946fb5e/cryptography-50.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18",
-              "url": "https://files.pythonhosted.org/packages/2c/99/2d13299eb3dd27b02dcfaafcc91d6b5cb3329f7cbd6d8f51921acd566c1a/cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
+              "hash": "7cec5b856506da6defb290f30c9ee687d5f5e8cb0bd3f6459dde43b0b4fa40ef",
+              "url": "https://files.pythonhosted.org/packages/27/20/c930314a2ab476d15dec966ec87e2e9637bb02b06106b12c0396c57bb603/cryptography-50.0.0-cp311-abi3-musllinux_1_2_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4",
-              "url": "https://files.pythonhosted.org/packages/3d/df/40577043ca124e17012f408ddddaeb213b856336ac82ddb3bc915f39e29f/cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
+              "hash": "07949c449a1abcf60d1ee6e88956d89404c7df3c8258f46589e912988e551987",
+              "url": "https://files.pythonhosted.org/packages/32/98/8a151d64367204cbc63ec65d37502f1d9c53cf4bfc6ec3c532614dbec60d/cryptography-50.0.0-cp311-abi3-manylinux_2_34_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2",
-              "url": "https://files.pythonhosted.org/packages/4a/91/01ce7303a4579e6d3a6abef01bd322848e9ea7a219adcabc5048b9033571/cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl"
+              "hash": "105110f43a471dbd0060b9c9516cb8a6a79233631a04cc2ba16f28323ac6e025",
+              "url": "https://files.pythonhosted.org/packages/46/c9/f60aed34c013f317f92817b6c171c2d22a78270fa41109bd4b08af26b194/cryptography-50.0.0-cp39-abi3-manylinux_2_28_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f",
-              "url": "https://files.pythonhosted.org/packages/4f/01/339573cf1023163a400b0b5d16f6d507de413b9f60be6fd1b77feeaf6737/cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl"
+              "hash": "fd9192b7b70c573d7f214eb1ae35e00d359f6f5e4b27c7e21e30de1fc6204645",
+              "url": "https://files.pythonhosted.org/packages/57/ef/8f2df13c7216bcad3e1c74e07f6e193d93e998e114f524a53877c9af27ad/cryptography-50.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b",
-              "url": "https://files.pythonhosted.org/packages/62/99/a2c95cf8293f07491e9e27c20cc4dcd18176d944e674679adeb1d0173fd6/cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl"
+              "hash": "c87f62a3d3b9888ed0fdde100ec06aa61ca9cd44bad9057d1dff9a516b5f5bb9",
+              "url": "https://files.pythonhosted.org/packages/64/a2/4615c8f7d81a00b1d6e6afe19f694e1543582349fb5f4076f6cb5dc36485/cryptography-50.0.0-cp39-abi3-musllinux_1_2_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8",
-              "url": "https://files.pythonhosted.org/packages/67/d0/a5fcd3515f0bae49a7b6d0413cc1bdccdcc1fc0047037a0d480642cdc5d6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl"
+              "hash": "6e7d61120573a7f2cd94cc095f9e81f6967c61ccdf194285aa143ecec8e0b708",
+              "url": "https://files.pythonhosted.org/packages/6b/16/d3008eff98c764979865834c3d386d4fd041b5f52e7f34fc29ac1a5eb515/cryptography-50.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9",
-              "url": "https://files.pythonhosted.org/packages/6c/72/3e798c064bc39e471008075d0f9bc9daf77a80879c092e4a8e170c585ed4/cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl"
+              "hash": "b42a28c1844fd9de8f3f7d540e36b66f3a9c83fceac7170ebc7a6a19edd9dcae",
+              "url": "https://files.pythonhosted.org/packages/6b/72/a1116d683a6d7ece94590013882515de087edf9ef0e6292aae615a44df73/cryptography-50.0.0-cp311-abi3-manylinux_2_28_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e",
-              "url": "https://files.pythonhosted.org/packages/6c/a0/db537264e234f7273a73ec020873d6d6b39dfd8a53db78b550ca8320440e/cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl"
+              "hash": "a1b30560f2acc95aa8b2e06e716a13dbfc97314747b80d9707e307f77b40d6b3",
+              "url": "https://files.pythonhosted.org/packages/7d/ff/b6ce0954962e7f7b969f850a883744197bb3910bdfd7b6da162eab7d9f68/cryptography-50.0.0-cp311-abi3-manylinux_2_28_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7",
-              "url": "https://files.pythonhosted.org/packages/6d/88/05563c7fe2e914e87d1a536d06fe83e66b4e1d95cb593e05aea375531da8/cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl"
+              "hash": "a91296cb61e8df6f86d0c19cc4068228da256bf59bf86049fbd821084565327f",
+              "url": "https://files.pythonhosted.org/packages/85/4f/0fa8c2f4428198f15d9ff8d63400e27afbf94ce833f6108da1eb3753f945/cryptography-50.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459",
-              "url": "https://files.pythonhosted.org/packages/71/fd/577302e213a1be9468f92d1afef66fcf1ef83d516819d9992ca547f592bd/cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl"
+              "hash": "37fdb0d0111f1e2ff07139dfb79f1b49531f8e213c46f1163dd7642979b58c47",
+              "url": "https://files.pythonhosted.org/packages/9c/f8/d97f9603efda3888187bfdb893f26c41be4735c10631d05d284ee6b047c4/cryptography-50.0.0-cp39-abi3-manylinux_2_34_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "966fe0e9c67490071f14c0d2b1cb2dfb3023c5ce39457343931415f08382f2db",
-              "url": "https://files.pythonhosted.org/packages/9b/22/adf66990e63584a68dfb50c24f48a125c07b1699899381c8151e63ed458c/cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl"
+              "hash": "828743d939e9629bc267b8e2d08d8bb67cd4319c771a33d4b18b22dd8fb7440a",
+              "url": "https://files.pythonhosted.org/packages/be/f3/f9a0173b139372c3a48ed98154b45cc6b9de17c789d5ab552e621c293609/cryptography-50.0.0-cp39-abi3-manylinux_2_31_armv7l.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36",
-              "url": "https://files.pythonhosted.org/packages/a0/84/84fe36f19caf857d61cb7fc9c63035a47ffabd84ea12d1d393148efa3615/cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl"
+              "hash": "031e2d5dd4bb9caa3ca9c82e5a197fd8ae680232cee62603d1a813f3f07e3d03",
+              "url": "https://files.pythonhosted.org/packages/c5/5c/59086b4aac5e879d38ddbcf74e4be7ade89cebc3eb199a55da998c3bb46a/cryptography-50.0.0-cp311-abi3-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c",
-              "url": "https://files.pythonhosted.org/packages/a3/5b/c5246635d5fd3b64e0d45ae10e99fd32fe9676a79915ccfe5a61ba9af1a5/cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl"
+              "hash": "1489e263a8048bb8b6a8bac662eb2d402ea5d2b7b4699b72f385f1e2772db105",
+              "url": "https://files.pythonhosted.org/packages/ca/dc/bd72b26be8953f80625f63151efd38eee71c76ca6cf591c08ff34615a79e/cryptography-50.0.0-cp311-abi3-musllinux_1_2_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69",
-              "url": "https://files.pythonhosted.org/packages/a5/4d/9c0cd02f95e2602dd5e563da149ee0830abef3537be8b34dc56281ebe27a/cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl"
+              "hash": "e722f16708d854fe924790e051061f6704a472c3bac347b6fd88033ea8dd0dc5",
+              "url": "https://files.pythonhosted.org/packages/d1/63/54dd723490ba2dc09b299682c10b38db38f159728bcaae8c591b8af2f22d/cryptography-50.0.0-cp39-abi3-manylinux_2_28_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9",
-              "url": "https://files.pythonhosted.org/packages/a9/3c/f3ad17eecc1a57b0ba236dc01f90e783c51f4a2f35f64777cc4f47a184b2/cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl"
+              "hash": "2a8183b489dc1f7f80f135780fadc1108f14b31b8a40411c7a5b17425f65f28b",
+              "url": "https://files.pythonhosted.org/packages/d8/36/83bb81f6e569bc38e1e4a7bc80f29b46bb9601920bc455fc8e888f5d5742/cryptography-50.0.0-cp39-abi3-manylinux_2_34_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21",
-              "url": "https://files.pythonhosted.org/packages/b8/7b/62cbbab75d0659865bf0273790031544a0b16c8072d258f9428dcd8190dc/cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl"
+              "hash": "06a32a980526a6ab9a4b9bf8f7385800791e2bb960903cb6b530e4817509a3b7",
+              "url": "https://files.pythonhosted.org/packages/d9/41/029086c34d91052fc3b88bcc8056f709a7c915c7a23b235a54eb800b1c97/cryptography-50.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68",
-              "url": "https://files.pythonhosted.org/packages/c4/b6/d7696e4e890d6ae1469935164c9e5215c557671cb78d6e3f458ccceaa632/cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl"
+              "hash": "82148ec5bddac30b51a5b3c1945075f896fa022cb93f8e4a01e9f6ee95292c5f",
+              "url": "https://files.pythonhosted.org/packages/da/3a/f05e32c99d440c9bb891ea0e36c9091891e36be5a9a87ab2ee6ea20729f6/cryptography-50.0.0-cp311-abi3-manylinux_2_34_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325",
-              "url": "https://files.pythonhosted.org/packages/e6/8b/43011f7ebe515a8aa20d61f290a326cd890c2e738e16e59eaff8d9c3a412/cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
+              "hash": "eeac2acb5a20ed25e0ad6d1df9891a520b78b404266b6d11778f25d5d691a6c9",
+              "url": "https://files.pythonhosted.org/packages/de/41/6cbdcf9142d00fe82836fbb51e503e58088575cf7a0fe1dbff6695bf0840/cryptography-50.0.0.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc",
-              "url": "https://files.pythonhosted.org/packages/f0/ee/6fca21d1ac73e06f8bef71940abfd4d2f6472b4bca284d770f32bd4086f6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl"
+              "hash": "910e1d2668e7de9648f2bcee30e180db2a6b15c30f887d7c4c93ddf96e3992e3",
+              "url": "https://files.pythonhosted.org/packages/ff/c6/7a6202a534e32103a285b7834a120869557fe198d51d7cfe59754c8bda9c/cryptography-50.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
             }
           ],
           "project_name": "cryptography",
@@ -1397,7 +1403,7 @@
             "typing-extensions>=4.13.2; python_full_version < \"3.11\""
           ],
           "requires_python": "!=3.9.0,!=3.9.1,>=3.9",
-          "version": "49.0.0"
+          "version": "50.0.0"
         },
         {
           "artifacts": [
@@ -1441,8 +1447,8 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "14badd576efcfef3b23f1f33f065d40c89b3e802d45f1f863cff75c74c0011d8",
-              "url": "https://files.pythonhosted.org/packages/7b/c2/221aff2da8afb06911eb8c3b854d7c70fd2401bd2c7a6ceb30fc721fc171/fw_client-2.3.2-py3-none-any.whl"
+              "hash": "3e798d2ad8a13553d165d416e9b2d063d1f926fdbc62790d9d6c7e739e04a21b",
+              "url": "https://files.pythonhosted.org/packages/fd/dd/5c1923d75d9b5eefc4b16c445d60fde62782d948a069dd7b82e7fd8a6663/fw_client-2.3.4-py3-none-any.whl"
             }
           ],
           "project_name": "fw-client",
@@ -1453,7 +1459,7 @@
             "packaging>=23"
           ],
           "requires_python": "<4,>=3.10",
-          "version": "2.3.2"
+          "version": "2.3.4"
         },
         {
           "artifacts": [
@@ -1597,93 +1603,93 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "b9b9e69ae32b4a1854f69edfceb0c2f69300108b367ad99bfd6fe1044ca0fa8f",
-              "url": "https://files.pythonhosted.org/packages/3f/1a/c709ecb4c082e413d464d9d67f8b74612b7518397b7511430cee491c4503/hypothesis-6.161.8-cp312-cp312-musllinux_1_2_x86_64.whl"
+              "hash": "50d50e313dfff2e79c754b92a4c88c479dd9e102a56c60caa5b3d6263caa1b02",
+              "url": "https://files.pythonhosted.org/packages/b9/00/e285e7987e96d74e229fcb94c58dd8e85290966fc2040fbac4b081fc49c9/hypothesis-6.165.2-cp312-cp312-musllinux_1_2_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "89df776cae9ed73819134c52a3826f351bcb8aadcf7ef69fbe04b1e9306d7a5d",
-              "url": "https://files.pythonhosted.org/packages/0c/17/89d48ec82acc56d4894f41ff395258ff0b34539413f205379c7ed4682cb0/hypothesis-6.161.8-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+              "hash": "21668cb5a8a694d45ff4c43f20a8fc577a47467b5102c680a43638b027136368",
+              "url": "https://files.pythonhosted.org/packages/0f/91/7bb502379a8dcc43f2538530c05cf16fd4e386afa587d65cc289484425cf/hypothesis-6.165.2-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "4338436e20c0d5e494c905288364600783edbabeeb19ab5b50746ce631980cd9",
-              "url": "https://files.pythonhosted.org/packages/15/23/50e1224bcb1683633beb9ee36c21f59531fa86ccb3c9ef0d65732f5ac035/hypothesis-6.161.8-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "0a6add02d9b3b73b59f4d69f5b15abbc07113cd335cc140815cec2877e6b496c",
+              "url": "https://files.pythonhosted.org/packages/49/de/b074d899f4a04fa8b99a5bbd66f209c1c02bc21f9f87404539b28b99aff0/hypothesis-6.165.2-cp310-abi3-manylinux_2_31_riscv64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d4063bbef8f704a68a1c1406ba4496d3373c8d60cdaf261660f2422e3257033a",
-              "url": "https://files.pythonhosted.org/packages/26/4d/5e828d3bc3956509cbc5de404e511650cd48473c608a9de0c65952c27994/hypothesis-6.161.8-cp310-abi3-manylinux_2_31_riscv64.whl"
+              "hash": "d726513b32cc6407667ac0812fa3517408f933b89b16b6b84f296335eec18432",
+              "url": "https://files.pythonhosted.org/packages/54/f1/de30869d83f00137a664319a4acb0ba8b1a9e2c879afdc12abb1b4c703f7/hypothesis-6.165.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ad8042c20cfaf4d4a679d45725289d639c171bc2d6473238457879d9cfd6a1d6",
-              "url": "https://files.pythonhosted.org/packages/29/16/6fc009137435bc88d3189ca0ba616727ea46a3efc76afba7e98a4f6a38c1/hypothesis-6.161.8-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "33a7303566e660664f3f02ea1df85f7b966cd6723165c696996cfd8630913b3a",
+              "url": "https://files.pythonhosted.org/packages/5c/63/46c9908fe7bd5ffa5002fa88fe289dfe6d3cea3fad1ab8942fe11f1c8a2b/hypothesis-6.165.2-cp310-abi3-macosx_10_12_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7eff53a5d0ef11db420e467c836229b7c07afee183d69adf3aa9c2bca6ba1365",
-              "url": "https://files.pythonhosted.org/packages/33/63/f6c610567c0eff8c434fdbded63a80f1af60d634b8c13e53670b97887f72/hypothesis-6.161.8-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "96d02928d1a0b7d59e39fd8ada75f0b7d0377ff29f91c94109f92fc2dab9af74",
+              "url": "https://files.pythonhosted.org/packages/6e/fa/2820bdbe0660394544b9e120b03ea7020702d7fa5c76236166de6ababc9d/hypothesis-6.165.2-cp310-abi3-musllinux_1_2_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "37dfb915fb24626d8b4f8a99e50d7bdfd7cae044fca170d99e699cdca1dc5421",
-              "url": "https://files.pythonhosted.org/packages/3a/88/1f769673b066df75825c30e9c14d177288cff6ec0af3c74b4880a1590fdc/hypothesis-6.161.8-cp310-abi3-musllinux_1_2_armv7l.whl"
+              "hash": "4ceabc69a95e761f381663c6452537fde12a2a6e0275e095b6822c0e0f3b1364",
+              "url": "https://files.pythonhosted.org/packages/88/c7/08cf7930d8bec7f1df971c948af2ccb5a402d5b8b19b306af655a603b180/hypothesis-6.165.2-cp310-abi3-musllinux_1_2_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5b575502ffacd5ac5d3f4a777f0d22b5188693904af876dd46614c12476b4fde",
-              "url": "https://files.pythonhosted.org/packages/49/1e/bdf7091f82974a26a92850a5539aba20c348e0ffcd4ee48f0f2d020cc3de/hypothesis-6.161.8-cp310-abi3-macosx_10_12_x86_64.whl"
+              "hash": "306763ce7186e08ee30dba409b320873d1afc54adf76b44c6bf83b5867d17359",
+              "url": "https://files.pythonhosted.org/packages/8d/e5/120642320291d8d117a83491d93527149ddbd15e56399274741fc4bd3a9a/hypothesis-6.165.2-cp312-cp312-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d37360094e6203473b15e3cad7ecfb2e08fbd8acaabd8c730dc126cb597fde1c",
-              "url": "https://files.pythonhosted.org/packages/59/2f/1a67b70064587eb05fddf59964de2a7dedf4135786b4b150ff18dc16a8db/hypothesis-6.161.8.tar.gz"
+              "hash": "b24f1b238deb97fda828a939931de3210f5cef21e87fe0b941fafbeb55ead676",
+              "url": "https://files.pythonhosted.org/packages/98/81/a9039e7eee38523e2ad13e9e4e70c508f25d4205fb4c6ceb98632547ca82/hypothesis-6.165.2-cp312-cp312-macosx_10_12_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "775f65cde6caa1392a1be122dea02cb091650f9dd85d412abe9151931c2c91ba",
-              "url": "https://files.pythonhosted.org/packages/5b/4e/712bf26800cbc6a0628c24ecc7ba950a7f0c7b25556bd67a582aa56bed0b/hypothesis-6.161.8-cp310-abi3-musllinux_1_2_riscv64.whl"
+              "hash": "de2e3f6a6f75c876be481138c6c0802ebe10deef9f13ce1cdd6e0ed21d8e1e28",
+              "url": "https://files.pythonhosted.org/packages/9e/c8/39cd922bf3e1ec84977b768d4e8be31ae051e3a6b400b4fdd7ebcddb1eed/hypothesis-6.165.2-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "12847e53cc26f7d58d84c32156c6d0ac52458c26e5ab99f6d423d43124a18680",
-              "url": "https://files.pythonhosted.org/packages/77/a8/6b345a74e54b2eb90b729fb98e0fc13356598d27dd64bd896e99a8222868/hypothesis-6.161.8-cp310-abi3-musllinux_1_2_x86_64.whl"
+              "hash": "9f878ebc5c33e4e8e8a90bd3d7ccc3f3a7370847aa22243536e673047f0f4c37",
+              "url": "https://files.pythonhosted.org/packages/b5/ef/251607eb2446fb44e8faa83e30aa1b6cc281b6eca5d0ecaabe7527e3395d/hypothesis-6.165.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "eb3dd046c8ab7efaeaa5416f4ad1778544ca798f8091284543c814fc73312fad",
-              "url": "https://files.pythonhosted.org/packages/9a/21/4b0718501b1bd05a7be4711277eef8684d1cb7cfb1d4e41554ce47789933/hypothesis-6.161.8-cp310-abi3-macosx_11_0_arm64.whl"
+              "hash": "06d8fe4c82a935f67e610c99848360f5caeb04f547c7d7a830a5c74fb96f053a",
+              "url": "https://files.pythonhosted.org/packages/c5/7f/fdce62542a514f6b33c4fc0a760e6d17bb57602b28cb079b78e55b8ea32d/hypothesis-6.165.2-cp310-abi3-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7a26b54b04579edc8e647dbc0745a0deff96e15a7fa28148ffe7f52f006da57a",
-              "url": "https://files.pythonhosted.org/packages/a0/ae/b166d504748b7ac014587d14a8aa624a17cb9266219bf48d7859747a0ab9/hypothesis-6.161.8-cp310-abi3-musllinux_1_2_aarch64.whl"
+              "hash": "11e1ce261765ffa6acbaf540358426519ca4a5e46b825cf39b429c77c1895689",
+              "url": "https://files.pythonhosted.org/packages/c5/91/c9ebb7da3b6e06c47aecceb959cf7df6af75025663af543373c5692f97ac/hypothesis-6.165.2-cp310-abi3-musllinux_1_2_armv7l.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8f3679076ef3e9efd7cfa7ea1c997f9687725e628ebdeef69d385ef3164b6269",
-              "url": "https://files.pythonhosted.org/packages/ab/1b/2569623d32daecd0b35f5686691e7375bedbbb85bc5aa49f6f742ce7dee0/hypothesis-6.161.8-cp312-cp312-macosx_10_12_x86_64.whl"
+              "hash": "eea4ab5cfdd6c6a23a60777559ea06c34868234fff6542ff6125c0250429348e",
+              "url": "https://files.pythonhosted.org/packages/e5/04/4ce8ae1bf78d09d7543ab7037a3beedc7f3d963c7aa04e82842415284689/hypothesis-6.165.2-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5a61fd3a9288d5d5543a54c0b363ba2c600815314d89a7eb8a6b3983ac89e255",
-              "url": "https://files.pythonhosted.org/packages/b8/d4/beb843943e50e85fc505d618cf914fd646e9864219992d26c1ad4043f1ae/hypothesis-6.161.8-cp310-abi3-manylinux_2_5_i686.manylinux1_i686.whl"
+              "hash": "11013896b6a2ed497079558cb9f89e8b3b564f8859782b38f72cfc1dbeca66ad",
+              "url": "https://files.pythonhosted.org/packages/e8/38/5a8514683a181f82a8ad9f6d084b704fea7a97c9814033939fc493b55fca/hypothesis-6.165.2-cp310-abi3-manylinux_2_5_i686.manylinux1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1ea8de981d40a68cb739f67053df2aab6c2e23c337f08da3c3e9ad31f356bfcf",
-              "url": "https://files.pythonhosted.org/packages/bf/0a/d22fa179497e45456a6e97f150dc8b00f0b4ead67a4d09c892b2907a1fc7/hypothesis-6.161.8-cp312-cp312-macosx_11_0_arm64.whl"
+              "hash": "680a1adf523ac792b46064f425b112ce6c08a7a8f50e65d08e029de6aa11df95",
+              "url": "https://files.pythonhosted.org/packages/ea/73/fc3743243603dc49911a1ec073a3a524ea8e1c7d48218d3c2a3faa9a8709/hypothesis-6.165.2.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "88d0850723b7c7afe2a0b1372217bf398da2d7ce232907e2debe0075be579fe4",
-              "url": "https://files.pythonhosted.org/packages/c8/b6/d7f4848df0d470aa2cdfb3aee7e5261ab494ce18b6e4410f45ef3ff86f58/hypothesis-6.161.8-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "b0250099b2e55d72872319918aacc501110a182938a3d56bcae4a999bee5db08",
+              "url": "https://files.pythonhosted.org/packages/ed/24/13c2fd9f253ba3a92d4aaa61ae45a8b130df57ab5bd6fc481e2aae520e36/hypothesis-6.165.2-cp310-abi3-musllinux_1_2_riscv64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "3827fd23cd9447bbbd86a307cd1d8e7c545ca6a0f180ffa3f0e3985d8f8e3c8a",
-              "url": "https://files.pythonhosted.org/packages/dd/30/2b0eeea1ff97a97726cd29e93b0a576fece7b7878ef8d3b2ea1f5dbb3acf/hypothesis-6.161.8-cp312-cp312-musllinux_1_2_aarch64.whl"
+              "hash": "a700c0e193707e3b6f1b23f1d5f534896dd9f79bb2a2340582579bad5f5b59a4",
+              "url": "https://files.pythonhosted.org/packages/fa/2c/8925c2bddf6e105d947a04511cd5d536eabc8d4ed926518a0d1672ede007/hypothesis-6.165.2-cp312-cp312-musllinux_1_2_aarch64.whl"
             }
           ],
           "project_name": "hypothesis",
@@ -1727,7 +1733,7 @@
             "watchdog>=4.0.0; extra == \"watchdog\""
           ],
           "requires_python": ">=3.10",
-          "version": "6.161.8"
+          "version": "6.165.2"
         },
         {
           "artifacts": [
@@ -2038,8 +2044,8 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "855a51526623ca3599385b70b7aaa91f6a826db782463a2f8bdfb05daf6af82b",
-              "url": "https://github.com/naccdata/nacc-attribute-deriver/releases/download/v2.4.0/nacc_attribute_deriver-2.4.0-py3-none-any.whl"
+              "hash": "69fe6e018998518360ded7d41f3266b94d55b8f181ad2ed56c24cd11b430d7fa",
+              "url": "https://github.com/naccdata/nacc-attribute-deriver/releases/download/v2.4.1/nacc_attribute_deriver-2.4.1-py3-none-any.whl"
             }
           ],
           "project_name": "nacc-attribute-deriver",
@@ -2047,7 +2053,7 @@
             "pydantic>=2.10.6"
           ],
           "requires_python": "==3.12.*",
-          "version": "2.4.0"
+          "version": "2.4.1"
         },
         {
           "artifacts": [
@@ -2167,19 +2173,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e",
-              "url": "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl"
+              "hash": "d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c",
+              "url": "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661",
-              "url": "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz"
+              "hash": "94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79",
+              "url": "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz"
             }
           ],
           "project_name": "packaging",
           "requires_dists": [],
-          "requires_python": ">=3.8",
-          "version": "26.2"
+          "requires_python": ">=3.9",
+          "version": "26.3"
         },
         {
           "artifacts": [
@@ -2313,13 +2319,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "a6277eb1c8cebf48d9b2413fcd2e9a6b4ff479c934a223c29eacbc3058c4cb55",
-              "url": "https://files.pythonhosted.org/packages/0b/e0/99ec5b02203c4e9ce878bc63d8caa06ac1f891e4d63bded9a5ced70fcb4f/pandas_stubs-3.0.3.260530-py3-none-any.whl"
+              "hash": "60e90e3e1eda6937e337e243cbe6217e151c11137cd7eddf832af537c7310bfd",
+              "url": "https://files.pythonhosted.org/packages/60/c2/959caec5c46f484b5f8bb6def4b0cf7a45ba6acda26f12b75142d98cc5ae/pandas_stubs-3.0.5.260730-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d1efe47b2e5a312c047d7feabec5cb7a55365747983420077e9fcbe9ab74f714",
-              "url": "https://files.pythonhosted.org/packages/3d/aa/c41a8a0ff86fd85dbb3ec0c1f3fa488ca64a8b5f82654ae1b07d84acefe5/pandas_stubs-3.0.3.260530.tar.gz"
+              "hash": "f70a232c57d93a5a2c81f8a53953e10891a5374bc92652277deb325e2e4d0ff3",
+              "url": "https://files.pythonhosted.org/packages/c2/d2/dea4a3a56b7b5f69c5fbca9f14625fcf28e1a39a657e9833d4a10bcac593/pandas_stubs-3.0.5.260730.tar.gz"
             }
           ],
           "project_name": "pandas-stubs",
@@ -2327,7 +2333,7 @@
             "numpy>=1.23.5"
           ],
           "requires_python": ">=3.11",
-          "version": "3.0.3.260530"
+          "version": "3.0.5.260730"
         },
         {
           "artifacts": [
@@ -3175,19 +3181,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "1ae41d51a5c5f6bbeeb7f1f34df7086d55ff1605cf88d2ed71a7a276e1a7794e",
-              "url": "https://files.pythonhosted.org/packages/16/85/cff97326a81e7e8877803e78e3ea56c840b85bb811934b9c936f7c40f185/types_python_dateutil-2.9.0.20260716-py3-none-any.whl"
+              "hash": "54aa3707350ed7a9cc0776fd2f6739679d6967d11b40150985e81edcb86df4db",
+              "url": "https://files.pythonhosted.org/packages/e4/5e/3715867caea2f4cea56ccb04c851cde23ed063449c3b004c7a047f20dd48/types_python_dateutil-2.9.0.20260807-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1d55d1c3024bdb4861bb6a6622c9ec800c433d87bdc5b16fb84cdd0eed4ef2cb",
-              "url": "https://files.pythonhosted.org/packages/df/9a/aefb9f80ff79641d36149352afe66ca835c5e6894deb518418f786f4b8ad/types_python_dateutil-2.9.0.20260716.tar.gz"
+              "hash": "e0b8a90d464c8684c66b7b8e4556d9074afdddcc56ca45323f0987134f9e7034",
+              "url": "https://files.pythonhosted.org/packages/c8/4e/b3fa538f9cb38dfece0d6ccf6d3d0d925bdedb144fb9c8129dfc007cd003/types_python_dateutil-2.9.0.20260807.tar.gz"
             }
           ],
           "project_name": "types-python-dateutil",
           "requires_dists": [],
           "requires_python": ">=3.10",
-          "version": "2.9.0.20260716"
+          "version": "2.9.0.20260807"
         },
         {
           "artifacts": [
@@ -3434,7 +3440,7 @@
     "fw-utils>=3",
     "hypothesis>=6.0.0",
     "moto[s3,ses,ssm]==5.1.14",
-    "nacc_attribute_deriver @ https://github.com/naccdata/nacc-attribute-deriver/releases/download/v2.4.0/nacc_attribute_deriver-2.4.0-py3-none-any.whl",
+    "nacc_attribute_deriver @ https://github.com/naccdata/nacc-attribute-deriver/releases/download/v2.4.1/nacc_attribute_deriver-2.4.1-py3-none-any.whl",
     "nacc_form_validator @ https://github.com/naccdata/nacc-form-validator/releases/download/v0.6.4/nacc_form_validator-0.6.4-py3-none-any.whl",
     "natsort",
     "pandas-stubs>=2.0.3",

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,4 +31,4 @@ ratelimit>=2.2.1
 ratelimit-types>=0.0.1
 redcap_api@ https://github.com/naccdata/redcap-api/releases/download/v0.3.0/redcap_api-0.3.0-py3-none-any.whl
 nacc_form_validator@ https://github.com/naccdata/nacc-form-validator/releases/download/v0.6.4/nacc_form_validator-0.6.4-py3-none-any.whl
-nacc_attribute_deriver@ https://github.com/naccdata/nacc-attribute-deriver/releases/download/v2.4.0/nacc_attribute_deriver-2.4.0-py3-none-any.whl
+nacc_attribute_deriver@ https://github.com/naccdata/nacc-attribute-deriver/releases/download/v2.4.1/nacc_attribute_deriver-2.4.1-py3-none-any.whl


### PR DESCRIPTION
Updated dependencies:

```
                                                                  
Lockfile diff: python-default.lock [python-default]
                                                                  
==                    Upgraded dependencies                     ==

  boto3                          1.43.57      -->   1.43.67
  boto3-stubs                    1.43.57      -->   1.43.67
  botocore                       1.43.57      -->   1.43.67
  cffi                           2.1.0        -->   2.1.1
  cryptography                   49.0.0       -->   50.0.0
  fw-client                      2.3.2        -->   2.3.4
  hypothesis                     6.161.8      -->   6.165.2
  nacc-attribute-deriver         2.4.0        -->   2.4.1
  packaging                      26.2         -->   26.3
  pandas-stubs                   3.0.3.260530   -->   3.0.5.260730
  types-python-dateutil          2.9.0.20260716   -->   2.9.0.20260807
                                                                  
Lockfile diff: mypy.lock [mypy]
                                                                  
==                    Upgraded dependencies                     ==

  ast-serialize                  0.6.0        -->   0.8.0
  librt                          0.13.0       -->   0.15.0
```