### PR TITLE
Capture duplicate-submit events in form-transformer

### DIFF
--- a/.kiro/specs/duplicate-submit-event-capture/.config.kiro
+++ b/.kiro/specs/duplicate-submit-event-capture/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "88359a72-bfc4-4e11-9c73-07dc84f9eda4", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/duplicate-submit-event-capture/design.md
+++ b/.kiro/specs/duplicate-submit-event-capture/design.md
@@ -1,0 +1,535 @@
+# Design Document: Duplicate Submit Event Capture
+
+## Overview
+
+This feature adds a `"duplicate-submit"` event type to the NACC transaction log system and integrates it into the form-transformer gear. When form-transformer detects that a CSV row is an identical resubmission (via `FormPreprocessor.is_existing_visit()`), it captures a `"duplicate-submit"` VisitEvent to S3. This gives downstream reporting deterministic signal to distinguish orphaned submit events (duplicates that were intentionally dropped) from legitimately unfinalized submissions still in progress.
+
+The change touches three layers:
+1. **Event model** — extend `VisitEventType` with the new action literal
+2. **Gear manifest** — add optional S3 configuration to form-transformer
+3. **Gear logic** — wire `VisitEventCapture` into form-transformer and emit events at the duplicate detection point
+
+No changes are needed to `VisitEvent` model validation, `VisitEventCapture.capture_event()`, or the S3 filename generation — these are generic over the action string.
+
+## Architecture
+
+```mermaid
+sequenceDiagram
+    participant CSV as Input CSV
+    participant FT as form-transformer
+    participant PP as FormPreprocessor
+    participant VEC as VisitEventCapture
+    participant S3 as S3 Transaction Log
+
+    CSV->>FT: visit_row(row, line_num)
+    FT->>FT: transform(row)
+    FT->>PP: is_existing_visit(transformed_row)
+    PP-->>FT: True (duplicate)
+    FT->>FT: Build DataIdentification from transformed_row
+    FT->>VEC: capture_event(VisitEvent(action="duplicate-submit", ...))
+    VEC->>S3: PUT log-duplicate-submit-{ts}-{adcid}-{project}-{ptid}-{date}.json
+    FT->>FT: Add to __existing_visits (existing behavior continues)
+```
+
+### Deployment Topology
+
+```mermaid
+graph TD
+    subgraph "Flywheel Gear Runtime"
+        RT[form-transformer run.py]
+        M[main.py / CSVTransformVisitor]
+    end
+    subgraph "Shared Libraries (common/)"
+        VE[visit_events.py]
+        EC[event_capture.py]
+        S3B[s3_bucket.py]
+    end
+    subgraph "AWS"
+        S3[S3 Transaction Log Bucket]
+    end
+
+    RT -->|creates| EC
+    RT -->|passes to| M
+    M -->|calls| EC
+    EC -->|uses| VE
+    EC -->|writes via| S3B
+    S3B -->|PUT| S3
+```
+
+### Design Rationale
+
+- **Event at detection point, not during batch processing**: The event is captured in `visit_row()` immediately when `is_existing_visit()` returns True. This ensures exactly one event per duplicate row regardless of what happens later (metadata copy success/failure, re-addition to batch).
+- **Optional configuration**: Event capture is gated behind manifest config options. When not configured, the gear behaves identically to before — zero behavioral change for existing deployments.
+- **Failure isolation**: Event capture is wrapped in try/except. S3 failures do not affect the gear's processing outcome. The existing `@retry_with_backoff` handles transient issues; only after retries are exhausted does the exception propagate to the catch block.
+
+## Components and Interfaces
+
+### Modified Components
+
+#### 1. `common/src/python/event_capture/visit_events.py`
+
+**Change**: Extend `VisitEventType` literal and add constant.
+
+```python
+# Before
+VisitEventType = Literal["submit", "delete", "not-pass-qc", "pass-qc"]
+
+# After
+VisitEventType = Literal["submit", "delete", "not-pass-qc", "pass-qc", "duplicate-submit"]
+
+# New constant
+ACTION_DUPLICATE_SUBMIT: VisitEventType = "duplicate-submit"
+```
+
+No changes to `VisitEvent` model, serializer, or validator. The `validate_datatype_consistency` validator already handles `datatype="form"` with `FormIdentification`, which is all that `"duplicate-submit"` events will use.
+
+#### 2. `gear/form_transformer/src/docker/manifest.json`
+
+**Change**: Add two optional config fields.
+
+```json
+{
+  "config": {
+    "event_bucket": {
+      "description": "S3 bucket for visit event transaction log",
+      "type": "string",
+      "optional": true
+    },
+    "event_environment": {
+      "description": "Environment prefix for event log files (prod or dev)",
+      "type": "string",
+      "optional": true,
+      "enum": ["prod", "dev"]
+    }
+  }
+}
+```
+
+#### 3. `gear/form_transformer/src/python/form_csv_app/run.py`
+
+**Change**: Create `VisitEventCapture` from config and pass to `run()`.
+
+```python
+# In FormCSVtoJSONTransformer.run():
+
+# After getting gear_name and before calling run()
+event_capture: Optional[VisitEventCapture] = None
+event_bucket = context.config.opts.get("event_bucket", "")
+event_environment = context.config.opts.get("event_environment", "")
+
+if event_bucket and event_environment:
+    try:
+        s3_bucket = S3BucketInterface.create_from_environment(event_bucket)
+        event_capture = VisitEventCapture(
+            s3_bucket=s3_bucket, environment=event_environment
+        )
+        log.info(
+            "Visit event capture initialized for environment "
+            f"'{event_environment}' with bucket '{event_bucket}'"
+        )
+    except (S3InterfaceError, ClientError) as error:
+        raise GearExecutionError(
+            f"Failed to initialize visit event capture: "
+            f"Unable to access S3 bucket '{event_bucket}'. Error: {error}"
+        ) from error
+elif event_bucket or event_environment:
+    log.warning(
+        "Both event_bucket and event_environment are required for event capture. "
+        f"Got event_bucket='{event_bucket}', event_environment='{event_environment}'. "
+        "Event capture will be disabled."
+    )
+
+# Pass to run() along with file timestamp and project context
+file_entry = self.__file_input.file_entry(context)
+timestamp = file_entry.created
+
+success = run(
+    input_file=csv_file,
+    ...,  # existing params
+    event_capture=event_capture,
+    center_label=prj_adaptor.group,
+    project_label=prj_adaptor.label,
+    timestamp=timestamp,
+)
+```
+
+#### 4. `gear/form_transformer/src/python/form_csv_app/main.py`
+
+**Changes**:
+- `run()` function gains `event_capture`, `center_label`, `project_label`, `timestamp` parameters
+- `CSVTransformVisitor.__init__()` gains those parameters
+- `visit_row()` captures event after `is_existing_visit()` returns True
+
+##### `run()` function signature change:
+
+```python
+def run(
+    *,
+    input_file: TextIO,
+    id_column: str,
+    module: str,
+    destination: ProjectAdaptor,
+    transformer_factory: TransformerFactory,
+    preprocessor: FormPreprocessor,
+    module_configs: ModuleConfigs,
+    error_writer: ListErrorWriter,
+    gear_name: str,
+    downstream_gears: Optional[List[str]] = None,
+    # New parameters
+    event_capture: Optional[VisitEventCapture] = None,
+    center_label: str = "",
+    project_label: str = "",
+    timestamp: Optional[datetime] = None,
+) -> bool:
+```
+
+##### `CSVTransformVisitor.__init__()` additions:
+
+```python
+def __init__(
+    self,
+    *,
+    # ... existing params ...
+    event_capture: Optional[VisitEventCapture] = None,
+    center_label: str = "",
+    project_label: str = "",
+    timestamp: Optional[datetime] = None,
+) -> None:
+    # ... existing assignments ...
+    self.__event_capture = event_capture
+    self.__center_label = center_label
+    self.__project_label = project_label
+    self.__timestamp = timestamp
+```
+
+##### Event capture in `visit_row()`:
+
+```python
+# In visit_row(), after is_existing_visit() returns True:
+if (
+    self.__module_configs.preprocess_checks
+    and PreprocessingChecks.DUPLICATE_RECORD
+    in self.__module_configs.preprocess_checks
+    and self.__preprocessor.is_existing_visit(input_record=transformed_row)
+):
+    # Capture duplicate-submit event BEFORE adding to existing_visits
+    self.__capture_duplicate_event(transformed_row)
+    
+    transformed_row["linenumber"] = line_num
+    self.__existing_visits[subject_lbl].append(transformed_row)
+    return True
+```
+
+##### New private method for event capture:
+
+```python
+def __capture_duplicate_event(self, transformed_row: Dict[str, Any]) -> None:
+    """Capture a duplicate-submit event for the given row.
+    
+    Failures are logged as warnings and do not interrupt processing.
+    """
+    if not self.__event_capture or not self.__timestamp:
+        return
+
+    try:
+        data_id = DataIdentification.from_form_record(
+            transformed_row, self.__date_field
+        )
+    except (EmptyFieldError, InvalidDateError, ValidationError) as error:
+        ptid = transformed_row.get(FieldNames.PTID, "unknown")
+        date = transformed_row.get(self.__date_field, "unknown")
+        log.warning(
+            f"Cannot construct DataIdentification for duplicate event "
+            f"(ptid={ptid}, date={date}): {error}. Skipping event capture."
+        )
+        return
+
+    event = VisitEvent(
+        action=ACTION_DUPLICATE_SUBMIT,
+        project_label=self.__project_label,
+        center_label=self.__center_label,
+        gear_name=self.__gear_name,
+        data_identification=data_id,
+        datatype="form",
+        timestamp=self.__timestamp,
+    )
+
+    try:
+        self.__event_capture.capture_event(event)
+    except Exception as error:
+        ptid = transformed_row.get(FieldNames.PTID, "unknown")
+        date = transformed_row.get(self.__date_field, "unknown")
+        log.warning(
+            f"Failed to capture duplicate-submit event for "
+            f"ptid={ptid}, date={date}: {error}. Continuing processing."
+        )
+```
+
+### Unchanged Components
+
+- **`event_capture.py` (`VisitEventCapture`)**: No changes. `create_event_filename()` interpolates the action string directly into the filename, so `"duplicate-submit"` naturally produces `log-duplicate-submit-...` filenames. The `capture_event()` method is action-agnostic.
+- **`csv_capture_visitor.py`**: Not modified. identifier-lookup continues to emit `"submit"` events as before.
+- **`preprocessor.py` (`FormPreprocessor`)**: Not modified. `is_existing_visit()` is called exactly as before.
+
+## Data Models
+
+### VisitEventType (extended)
+
+```python
+VisitEventType = Literal["submit", "delete", "not-pass-qc", "pass-qc", "duplicate-submit"]
+```
+
+### VisitEvent (unchanged structure)
+
+A `"duplicate-submit"` event uses the existing model with:
+
+| Field | Source |
+|-------|--------|
+| `action` | `"duplicate-submit"` (constant) |
+| `study` | `"adrc"` (default) |
+| `project_label` | From `ProjectAdaptor.label` |
+| `center_label` | From `ProjectAdaptor.group` |
+| `gear_name` | `"form-transformer"` (from manifest) |
+| `data_identification` | Constructed from transformed CSV row via `DataIdentification.from_form_record()` |
+| `datatype` | `"form"` (constant) |
+| `timestamp` | Input file's `created` timestamp (same as identifier-lookup's source) |
+
+### Serialized Event JSON (example)
+
+```json
+{
+  "action": "duplicate-submit",
+  "study": "adrc",
+  "project_label": "ingest-form",
+  "center_label": "adrc42",
+  "gear_name": "form-transformer",
+  "ptid": "110001",
+  "naccid": "NACC000001",
+  "pipeline_adcid": 42,
+  "visit_number": "2",
+  "visit_date": "2024-03-15",
+  "module": "UDS",
+  "packet": "F",
+  "datatype": "form",
+  "timestamp": "2024-03-15T11:00:00Z"
+}
+```
+
+### S3 Filename
+
+```
+prod/log-duplicate-submit-20240315-110000-42-ingest-form-110001-2024-03-15.json
+```
+
+Generated by existing `create_event_filename()` — no special handling needed.
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Prework Analysis
+
+**Acceptance Criteria Testing Prework:**
+
+1.1 THE VisitEventType literal SHALL include "duplicate-submit" as a valid action value
+  Thoughts: This is a static type definition. We can test that creating a VisitEvent with action="duplicate-submit" succeeds.
+  Classification: EXAMPLE
+  Test Strategy: Create a VisitEvent with action="duplicate-submit" and verify it validates.
+
+1.2 THE visit_events module SHALL export an ACTION_DUPLICATE_SUBMIT constant
+  Thoughts: This is a simple constant definition check.
+  Classification: EXAMPLE
+  Test Strategy: Import and assert the constant value.
+
+1.3 WHEN a VisitEvent is created with action "duplicate-submit", it SHALL accept the same required fields and apply validate_datatype_consistency
+  Thoughts: This tests model validation behavior across different inputs. We can generate random valid DataIdentification objects and verify the model validates them correctly with datatype="form".
+  Classification: PROPERTY
+  Test Strategy: Generate random valid DataIdentification with FormIdentification data, create VisitEvent with action="duplicate-submit" and datatype="form", verify it passes validation.
+
+1.4 WHEN a VisitEvent with action "duplicate-submit" is serialized, it SHALL produce the same flattened structure
+  Thoughts: This is a serialization property. We can generate random VisitEvents with action="duplicate-submit" and verify the serialized output contains renamed fields and flattened data_identification. This is a round-trip-adjacent property.
+  Classification: PROPERTY
+  Test Strategy: Generate random valid VisitEvents with "duplicate-submit" action, serialize them, verify output contains pipeline_adcid, visit_date, visit_number and all pass-through fields.
+
+2.1 WHEN is_existing_visit() returns True, THE Form_Transformer SHALL capture a "duplicate-submit" VisitEvent
+  Thoughts: This tests behavior that varies with input — different CSV rows may or may not be duplicates. We can mock the preprocessor and event capture, generate random transformed rows, and verify that when is_existing_visit returns True, capture_event is called exactly once.
+  Classification: PROPERTY
+  Test Strategy: Generate random transformed rows, mock is_existing_visit to return True, verify capture_event is called with action="duplicate-submit".
+
+2.2 THE captured event SHALL contain DataIdentification from the transformed record
+  Thoughts: This is about correct data flow. We can verify that the data_identification in the captured event matches what from_form_record would produce from the same row.
+  Classification: PROPERTY
+  Test Strategy: Generate random transformed rows with valid dates/modules, verify the captured event's data_identification matches DataIdentification.from_form_record(row, date_field).
+
+2.3-2.6 THE captured event SHALL use "form" datatype, gear name, timestamp, project/center labels
+  Thoughts: These are specific field value checks that should hold for all captured events.
+  Classification: PROPERTY (combined with 2.1/2.2)
+  Test Strategy: Verify all fields in captured event match expected constants.
+
+2.7 IF DataIdentification cannot be constructed, THEN skip event capture and log warning
+  Thoughts: This is an error handling case. We can generate rows with missing/invalid date fields.
+  Classification: EDGE_CASE
+  Test Strategy: Provide rows with empty date fields, verify no event is captured and processing continues.
+
+2.8 WHEN duplicate-submit event is captured, continue existing behavior
+  Thoughts: This verifies the event capture doesn't interfere with existing logic.
+  Classification: PROPERTY
+  Test Strategy: Verify that after event capture, the row is still added to __existing_visits.
+
+3.1-3.4 VisitEventCapture dependency injection (config handling)
+  Thoughts: These test config parsing and initialization. The behavior varies with config combinations.
+  Classification: EXAMPLE (config parsing is a finite set of cases)
+  Test Strategy: Test the 4 config states: both present, only bucket, only env, neither.
+
+4.1-4.3 Filename pattern for duplicate-submit
+  Thoughts: The filename generation is a pure function of the VisitEvent fields. We can generate random events and verify the filename matches the expected pattern.
+  Classification: PROPERTY
+  Test Strategy: Generate random VisitEvents with action="duplicate-submit", verify create_event_filename produces filenames matching the expected regex pattern.
+
+5.1-5.4 Manifest configuration
+  Thoughts: These are static configuration checks.
+  Classification: EXAMPLE
+  Test Strategy: Parse manifest.json and verify config options exist with correct types.
+
+6.1 Exactly one event per duplicate row at detection point
+  Thoughts: This is a cardinality property. For any duplicate row, exactly one event should be captured. We can mock and count calls.
+  Classification: PROPERTY
+  Test Strategy: Process multiple duplicate rows, verify capture_event call count equals duplicate row count.
+
+6.2 No events for non-duplicate rows
+  Thoughts: This is the complement of 6.1.
+  Classification: PROPERTY
+  Test Strategy: Process non-duplicate rows, verify capture_event is never called.
+
+6.3 No second event during batch reprocessing
+  Thoughts: When metadata copy fails and row is re-added to batch, no second event should fire.
+  Classification: EXAMPLE
+  Test Strategy: Mock metadata copy failure, verify event count remains 1.
+
+7.1-7.3 Event capture failure isolation
+  Thoughts: When capture_event raises, processing continues unchanged.
+  Classification: PROPERTY
+  Test Strategy: Mock capture_event to raise, verify visit_row still returns True and row is added to __existing_visits.
+
+### Reflection on Properties
+
+Reviewing the identified properties for redundancy:
+
+- Properties 2.1, 2.2, 2.3-2.6, and 2.8 all test aspects of the same operation (event capture on duplicate detection). They can be consolidated: "For any valid duplicate row, the captured event has correct fields AND processing continues." However, the field correctness (2.2) and the continuation guarantee (2.8) test distinct behaviors. I'll combine 2.1 + 2.3-2.6 into one property about field correctness, keep 2.2 as a separate property about DataIdentification round-trip, and keep 2.8 as a separate property about non-interference.
+
+- Properties 6.1 and 6.2 are two sides of the same coin (events for duplicates, no events for non-duplicates). These can be combined: "The number of captured events equals the number of duplicate rows."
+
+- Property 4.1-4.3 (filename pattern) is already covered by the existing `create_event_filename` tests — the function is action-agnostic. However, it's worth a property test to confirm the hyphenated action passes through correctly.
+
+**Final consolidated properties:**
+
+1. VisitEvent serialization with "duplicate-submit" (from 1.3 + 1.4)
+2. DataIdentification round-trip in captured event (from 2.2)
+3. Captured event field correctness (from 2.1 + 2.3-2.6)
+4. Event count equals duplicate count (from 6.1 + 6.2)
+5. Event capture failure does not alter processing (from 7.1-7.3 + 2.8)
+6. Filename pattern for duplicate-submit action (from 4.1-4.3)
+
+### Property 1: VisitEvent serialization round-trip for duplicate-submit
+
+*For any* valid `DataIdentification` containing `FormIdentification` data with a non-None module, creating a `VisitEvent` with `action="duplicate-submit"` and `datatype="form"` SHALL produce a valid model that serializes to a flat dictionary containing `pipeline_adcid`, `visit_date`, `visit_number`, `module`, and `ptid` fields with values matching the input DataIdentification.
+
+**Validates: Requirements 1.3, 1.4**
+
+### Property 2: DataIdentification construction from transformed row
+
+*For any* dictionary containing valid `ptid`, `adcid`, `visitnum`, `module`, `packet`, and a valid date string in a given `date_field`, calling `DataIdentification.from_form_record(row, date_field)` SHALL produce a `DataIdentification` whose participant, visit, and form fields match the input dictionary values.
+
+**Validates: Requirements 2.2**
+
+### Property 3: Captured event contains correct metadata
+
+*For any* transformed CSV row where `is_existing_visit()` returns True, the captured `VisitEvent` SHALL have `action="duplicate-submit"`, `datatype="form"`, the configured `gear_name`, the file's `created` timestamp, and `project_label`/`center_label` matching the destination project.
+
+**Validates: Requirements 2.1, 2.3, 2.4, 2.5, 2.6**
+
+### Property 4: Event count equals duplicate row count
+
+*For any* input CSV containing N rows where `is_existing_visit()` returns True and M rows where it returns False, the total number of `capture_event()` calls SHALL equal N (one per duplicate row, zero for non-duplicates).
+
+**Validates: Requirements 6.1, 6.2**
+
+### Property 5: Event capture failure does not alter processing outcome
+
+*For any* transformed CSV row where `is_existing_visit()` returns True and `capture_event()` raises an exception, `visit_row()` SHALL still return True and the row SHALL be added to the existing-visits collection, preserving identical behavior to when event capture is not configured.
+
+**Validates: Requirements 7.1, 7.2, 7.3, 2.8**
+
+### Property 6: Filename generation for hyphenated actions
+
+*For any* `VisitEvent` with action `"duplicate-submit"`, `create_event_filename()` SHALL produce a filename matching the regex pattern `^.*/log-duplicate-submit-\d{8}-\d{6}-\d+-[^/]+-[^/]+-\d{4}-\d{2}-\d{2}\.json$`.
+
+**Validates: Requirements 4.1, 4.2, 4.3**
+
+## Error Handling
+
+### Event Capture Failures
+
+| Failure Mode | Handling | Impact |
+|---|---|---|
+| S3 bucket inaccessible at startup | `GearExecutionError` raised in `run.py` | Gear fails to start (fail-fast) |
+| S3 write failure during processing | `@retry_with_backoff` retries 3 times with exponential backoff. If still fails, exception caught in `__capture_duplicate_event()`, logged as warning | Processing continues, event is lost |
+| `DataIdentification` construction fails (missing/invalid date) | Caught in `__capture_duplicate_event()`, logged as warning | Event skipped, duplicate still processed normally |
+| `VisitEvent` validation error (shouldn't occur with valid data) | Caught by the outer try/except in `__capture_duplicate_event()` | Event skipped, processing continues |
+
+### Configuration Edge Cases
+
+| Config State | Behavior |
+|---|---|
+| Both `event_bucket` and `event_environment` provided | Event capture enabled |
+| Neither provided | Event capture disabled silently (backward-compatible) |
+| Only one provided | Warning logged, event capture disabled |
+| `event_bucket` is invalid S3 bucket | `GearExecutionError` raised at startup |
+
+### Idempotency Considerations
+
+Each duplicate resubmission produces a unique S3 event file (because `timestamp` comes from the file's `created` time). This is intentional — it mirrors how identifier-lookup produces unique submit events. The downstream lambda uses `timestamp` as part of the identity key, so multiple `"duplicate-submit"` events for the same visit are treated as distinct records if they occur at different times.
+
+## Testing Strategy
+
+### Unit Tests (example-based)
+
+- **visit_events.py**: Verify `ACTION_DUPLICATE_SUBMIT` constant exists and equals `"duplicate-submit"`. Verify `VisitEvent` accepts the new action with valid form data.
+- **manifest.json**: Parse and verify `event_bucket` and `event_environment` config options are present with correct types and constraints.
+- **run.py config handling**: Test the four config states (both, neither, only bucket, only environment).
+- **Edge case**: Row with missing date field does not capture event and does not raise.
+- **Edge case**: Metadata copy failure does not trigger a second event capture.
+
+### Property-Based Tests (hypothesis)
+
+Property-based testing is appropriate here because:
+- `VisitEvent` serialization/validation is a pure function with clear input/output
+- `DataIdentification.from_form_record()` is a pure function with structured inputs
+- Event capture behavior varies with row content (duplicate vs. non-duplicate)
+- The input space (CSV rows with various field combinations) is large
+
+**Library**: `hypothesis` (already used in this project)
+
+**Configuration**: Minimum 100 iterations per property test.
+
+Each property test references its design document property:
+- **Feature: duplicate-submit-event-capture, Property 1**: VisitEvent serialization for duplicate-submit
+- **Feature: duplicate-submit-event-capture, Property 2**: DataIdentification construction round-trip
+- **Feature: duplicate-submit-event-capture, Property 3**: Captured event metadata correctness
+- **Feature: duplicate-submit-event-capture, Property 4**: Event count equals duplicate count
+- **Feature: duplicate-submit-event-capture, Property 5**: Failure isolation
+- **Feature: duplicate-submit-event-capture, Property 6**: Filename pattern for hyphenated actions
+
+### Integration Tests
+
+- End-to-end test with mocked S3: process a CSV with a mix of duplicate and non-duplicate rows, verify the correct number of events are written with correct content.
+- Test with `VisitEventCapture` set to None (event capture disabled): verify gear processes CSV identically to current behavior.
+
+### Test File Organization
+
+```
+common/test/python/event_capture_test/
+├── test_visit_events_duplicate_submit.py     # Property 1, 6 + unit tests
+gear/form_transformer/test/python/
+├── test_duplicate_event_capture.py           # Properties 2, 3, 4, 5 + unit tests
+```

--- a/.kiro/specs/duplicate-submit-event-capture/requirements.md
+++ b/.kiro/specs/duplicate-submit-event-capture/requirements.md
@@ -1,0 +1,100 @@
+# Requirements Document
+
+## Introduction
+
+When a center resubmits a visit packet without changes, the submission pipeline creates orphaned "submit" events in the transaction log. The identifier-lookup gear logs a "submit" event unconditionally, but form-transformer silently drops duplicates without logging any event. This leaves no signal to distinguish a duplicate resubmission from a legitimate submission still in progress.
+
+This feature adds a "duplicate-submit" event type that form-transformer logs when it detects an existing visit (an identical resubmission). This gives downstream reporting an explicit signal to pair with and dismiss the orphaned "submit" event.
+
+## Glossary
+
+- **Form_Transformer**: The Flywheel gear (`form-transformer`) that transforms CSV visit records into JSON, detects duplicate submissions, and uploads results. It is the authoritative source for duplicate detection.
+- **VisitEventCapture**: The component (`event_capture.event_capture.VisitEventCapture`) responsible for writing `VisitEvent` objects as JSON files to an S3 transaction log bucket.
+- **VisitEvent**: The Pydantic model (`event_capture.visit_events.VisitEvent`) representing a transactional event for a participant visit. Contains action, data_identification, timestamps, and gear metadata.
+- **VisitEventType**: The type literal defining valid event actions. Currently `"submit" | "delete" | "not-pass-qc" | "pass-qc"`.
+- **FormPreprocessor**: The component (`preprocess.preprocessor.FormPreprocessor`) that performs preprocessing checks on visit records, including duplicate detection via `is_existing_visit()`.
+- **CSVTransformVisitor**: The visitor class in form-transformer's `main.py` that processes CSV rows, accumulates existing (duplicate) visits, and manages the transformation batch.
+- **DataIdentification**: The model (`nacc_common.data_identification.DataIdentification`) that encapsulates participant, visit, and data-type-specific identification fields.
+- **Transaction_Log**: The S3 bucket storing event JSON files with naming pattern `{env}/log-{action}-{timestamp}-{adcid}-{project}-{ptid}-{visit_date}.json`.
+- **S3BucketInterface**: The abstraction (`s3.s3_bucket.S3BucketInterface`) used by VisitEventCapture to write files to S3.
+
+## Requirements
+
+### Requirement 1: Extend VisitEventType with duplicate-submit action
+
+**User Story:** As a reporting system consumer, I want a distinct event type for duplicate submissions, so that I can deterministically distinguish orphaned submits from legitimately unfinalized visits.
+
+#### Acceptance Criteria
+
+1. THE VisitEventType literal SHALL include `"duplicate-submit"` as a valid action value alongside the existing `"submit"`, `"delete"`, `"not-pass-qc"`, and `"pass-qc"` values.
+2. THE `visit_events` module SHALL export an `ACTION_DUPLICATE_SUBMIT` constant of type `VisitEventType` with the value `"duplicate-submit"`.
+3. WHEN a VisitEvent is created with action `"duplicate-submit"`, THE VisitEvent model SHALL accept the same required fields as any other action (study, project_label, center_label, gear_name, data_identification, datatype, timestamp) and apply the existing `validate_datatype_consistency` rules to the datatype and data_identification pairing.
+4. WHEN a VisitEvent with action `"duplicate-submit"` is serialized, THE VisitEvent model SHALL produce the same flattened dictionary structure as other event types, including the renamed fields (`pipeline_adcid`, `visit_date`, `visit_number`) and all pass-through fields from data_identification.
+
+### Requirement 2: Form-transformer logs duplicate-submit events
+
+**User Story:** As a reporting system consumer, I want form-transformer to log a "duplicate-submit" event when it detects a duplicate submission, so that the transaction log contains explicit signal for each dropped duplicate.
+
+#### Acceptance Criteria
+
+1. WHEN `FormPreprocessor.is_existing_visit()` returns True for a visit record, THE Form_Transformer SHALL capture a `"duplicate-submit"` VisitEvent for that record.
+2. THE captured `"duplicate-submit"` event SHALL contain a `DataIdentification` constructed from the transformed record (the post-transformation row passed to `is_existing_visit()`) using the module's configured `date_field`, including ptid, visit_date, module, visitnum, packet, naccid, and adcid as available in that record.
+3. THE captured `"duplicate-submit"` event SHALL use `"form"` as the datatype value.
+4. THE captured `"duplicate-submit"` event SHALL use the gear name `"form-transformer"` as the `gear_name` field.
+5. THE captured `"duplicate-submit"` event SHALL use the Flywheel input file entry's `created` timestamp (the same source used by identifier-lookup for submit events) as the `timestamp` field.
+6. THE captured `"duplicate-submit"` event SHALL use the destination project's label as the `project_label` field and the center identifier (ADCID-based label) as the `center_label` field, consistent with the values used for submit events on the same project.
+7. IF `DataIdentification` cannot be constructed from the transformed record (due to missing or invalid fields), THEN THE Form_Transformer SHALL skip event capture for that record and SHALL log a warning without interrupting processing of the duplicate visit.
+8. WHEN a duplicate-submit event is captured, THE Form_Transformer SHALL continue its existing behavior of copying downstream metadata for the duplicate visit (the event capture does not replace existing duplicate-handling logic).
+
+### Requirement 3: VisitEventCapture dependency injection into form-transformer
+
+**User Story:** As a developer, I want the form-transformer gear to receive a properly configured VisitEventCapture instance, so that it can write events to S3 without duplicating infrastructure setup logic.
+
+#### Acceptance Criteria
+
+1. THE Form_Transformer gear's manifest.json SHALL declare `event_bucket` (type: string, default: empty string) and `event_environment` (type: string, default: empty string) configuration options for specifying the S3 transaction log destination.
+2. WHEN `event_bucket` and `event_environment` are both provided as non-empty strings, THE Form_Transformer gear's `run.py` SHALL create a `VisitEventCapture` instance using `S3BucketInterface.create_from_environment(event_bucket)` with the `event_environment` value, and pass it to the `run()` function in `main.py`.
+3. IF `S3BucketInterface.create_from_environment()` raises an `S3InterfaceError` or `ClientError` during `VisitEventCapture` initialization, THEN THE Form_Transformer gear SHALL raise a `GearExecutionError` with a message indicating the S3 bucket could not be accessed.
+4. IF `event_bucket` or `event_environment` is empty or not provided, THEN THE Form_Transformer gear SHALL pass `None` as the event capture parameter, and CSV processing SHALL continue normally without logging events and without raising an error.
+5. THE `run()` function in `main.py` SHALL accept an `Optional[VisitEventCapture]` parameter and pass it to the `CSVTransformVisitor` constructor, making it available at the point where duplicate detection occurs in `visit_row`.
+
+### Requirement 4: Duplicate-submit event S3 file naming
+
+**User Story:** As a reporting pipeline operator, I want duplicate-submit event files to follow the same naming convention as other events, so that the existing S3 retrieval infrastructure can discover them.
+
+#### Acceptance Criteria
+
+1. WHEN a `"duplicate-submit"` event is written to S3, THE VisitEventCapture SHALL produce a filename matching the pattern `{env}/log-duplicate-submit-{YYYYMMDD-HHMMSS}-{adcid}-{project}-{ptid}-{visit_date}.json` where `{YYYYMMDD-HHMMSS}` is the event timestamp formatted identically to other actions.
+2. THE filename for a `"duplicate-submit"` event SHALL be generated by the existing `create_event_filename()` method, which produces the same result for any event action value (the action string is interpolated directly into the filename).
+3. THE hyphenated action value `"duplicate-submit"` SHALL pass through the filename generation unsanitized (the existing sanitization only applies to the project label's `/` and `\` characters), ensuring the resulting filename is compatible with downstream S3 retrieval patterns.
+
+### Requirement 5: Form-transformer manifest configuration
+
+**User Story:** As a platform administrator, I want to configure form-transformer with event capture settings through the gear manifest, so that the feature can be enabled per deployment without code changes.
+
+#### Acceptance Criteria
+
+1. THE form-transformer `manifest.json` SHALL include an `event_bucket` configuration option of type `string` that is optional and has no default value.
+2. THE form-transformer `manifest.json` SHALL include an `event_environment` configuration option of type `string` that is optional, constrained to the enum values `["prod", "dev"]`, and has no default value.
+3. WHEN both `event_bucket` and `event_environment` are omitted from the gear configuration, THE Form_Transformer SHALL operate identically to its behavior prior to the event capture feature (no S3 event writes, no errors raised due to missing event configuration).
+4. IF only one of `event_bucket` or `event_environment` is provided while the other is omitted, THEN THE Form_Transformer SHALL skip event capture and log a warning message indicating that both options are required for event capture to be active.
+
+### Requirement 6: One duplicate-submit event per duplicate visit record
+
+**User Story:** As a reporting system consumer, I want exactly one duplicate-submit event per duplicate row in the input file, so that event counts accurately reflect submission volume.
+
+#### Acceptance Criteria
+
+1. WHEN `FormPreprocessor.is_existing_visit()` returns True for a row during `visit_row()` processing, THE Form_Transformer SHALL capture exactly one `"duplicate-submit"` event for that row at the point of detection (before adding the row to the existing-visits collection).
+2. WHEN a single input CSV file contains both duplicate and non-duplicate rows, THE Form_Transformer SHALL capture `"duplicate-submit"` events only for the rows where `is_existing_visit()` returns True and SHALL NOT capture events for rows that proceed to the current batch as non-duplicates.
+3. WHEN `is_existing_visit()` returns True but the downstream metadata copy later fails (causing the visit to be re-added to the current batch for reprocessing), THE Form_Transformer SHALL NOT capture a second `"duplicate-submit"` event during batch reprocessing — the single event captured at initial detection is the only event for that row.
+
+### Requirement 7: Event capture failure does not block processing
+
+**User Story:** As a platform operator, I want form-transformer to continue processing even if event capture fails, so that a transient S3 issue does not block legitimate data processing.
+
+#### Acceptance Criteria
+
+1. IF the `VisitEventCapture.capture_event()` call raises an exception after exhausting its retry logic, THEN THE Form_Transformer SHALL log a warning that identifies the affected record (subject and visit date) and continue processing the remaining records without altering the gear's overall success or failure exit status.
+2. IF event capture fails for a duplicate record, THEN THE Form_Transformer SHALL still perform its existing behavior (copying downstream metadata or re-adding to batch) for that record.
+3. IF event capture fails for one or more records in a batch, THEN THE Form_Transformer SHALL complete processing of all remaining records in the batch and SHALL NOT re-raise the event capture exception.

--- a/.kiro/specs/duplicate-submit-event-capture/tasks.md
+++ b/.kiro/specs/duplicate-submit-event-capture/tasks.md
@@ -1,0 +1,148 @@
+# Implementation Plan: Duplicate Submit Event Capture
+
+## Overview
+
+This plan implements the `"duplicate-submit"` event type in the NACC transaction log system and integrates it into the form-transformer gear. The implementation proceeds bottom-up: event model extension, manifest config, gear wiring (run.py and main.py), then tests.
+
+## Tasks
+
+- [x] 1. Extend VisitEventType with duplicate-submit action
+  - [x] 1.1 Add "duplicate-submit" to VisitEventType literal and ACTION_DUPLICATE_SUBMIT constant
+    - Modify `common/src/python/event_capture/visit_events.py`
+    - Add `"duplicate-submit"` to the `VisitEventType` Literal type
+    - Add `ACTION_DUPLICATE_SUBMIT: VisitEventType = "duplicate-submit"` constant below existing action constants
+    - No changes needed to VisitEvent model, serializer, or validator (they are action-agnostic)
+    - _Requirements: 1.1, 1.2, 1.3, 1.4_
+
+- [x] 2. Add event capture configuration to form-transformer manifest
+  - [x] 2.1 Add event_bucket and event_environment config options to manifest.json
+    - Modify `gear/form_transformer/src/docker/manifest.json`
+    - Add `event_bucket` config: type string, optional, description for S3 transaction log bucket
+    - Add `event_environment` config: type string, optional, enum `["prod", "dev"]`, description for environment prefix
+    - Both fields must be optional with no default value
+    - _Requirements: 5.1, 5.2, 5.3_
+
+- [x] 3. Integrate VisitEventCapture into form-transformer
+  - [x] 3.1 Add event_capture, center_label, project_label, timestamp parameters to run() and CSVTransformVisitor
+    - Modify `gear/form_transformer/src/python/form_csv_app/main.py`
+    - Add `event_capture: Optional[VisitEventCapture] = None` parameter to `run()` function
+    - Add `center_label: str = ""` parameter to `run()` function
+    - Add `project_label: str = ""` parameter to `run()` function
+    - Add `timestamp: Optional[datetime] = None` parameter to `run()` function
+    - Add same parameters to `CSVTransformVisitor.__init__()` and store as instance attributes
+    - Pass parameters through from `run()` to the `CSVTransformVisitor` constructor
+    - Add required imports: `from datetime import datetime`, `from event_capture.event_capture import VisitEventCapture`, `from event_capture.visit_events import ACTION_DUPLICATE_SUBMIT, VisitEvent`
+    - _Requirements: 3.5, 2.1_
+
+  - [x] 3.2 Implement __capture_duplicate_event() method in CSVTransformVisitor
+    - Add private method `__capture_duplicate_event(self, transformed_row: Dict[str, Any]) -> None`
+    - Return early if `self.__event_capture` or `self.__timestamp` is None
+    - Try constructing `DataIdentification.from_form_record(transformed_row, self.__date_field)`
+    - On `EmptyFieldError`, `InvalidDateError`, or `ValidationError`: log warning with ptid/date and return (skip event)
+    - Create `VisitEvent` with action=ACTION_DUPLICATE_SUBMIT, datatype="form", and the stored project_label, center_label, gear_name, timestamp
+    - Call `self.__event_capture.capture_event(event)` wrapped in try/except that catches any Exception, logs warning, and continues
+    - Add import for `EmptyFieldError`, `InvalidDateError` from `nacc_common.data_identification`
+    - _Requirements: 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 7.1, 7.2, 7.3_
+
+  - [x] 3.3 Call __capture_duplicate_event in visit_row() at the duplicate detection point
+    - In `visit_row()`, after `is_existing_visit()` returns True and BEFORE `self.__existing_visits[subject_lbl].append(transformed_row)`
+    - Insert call: `self.__capture_duplicate_event(transformed_row)`
+    - This ensures exactly one event per duplicate row at detection time, not during batch reprocessing
+    - _Requirements: 6.1, 6.2, 6.3_
+
+  - [x] 3.4 Wire VisitEventCapture creation and passing in run.py
+    - Modify `gear/form_transformer/src/python/form_csv_app/run.py`
+    - Add imports: `from botocore.exceptions import ClientError`, `from event_capture.event_capture import VisitEventCapture`, `from s3.s3_bucket import S3BucketInterface, S3InterfaceError`
+    - In `FormCSVtoJSONTransformer.run()`, after getting `gear_name`:
+      - Read `event_bucket` and `event_environment` from `context.config.opts`
+      - If both are non-empty strings: create `S3BucketInterface.create_from_environment(event_bucket)` and `VisitEventCapture`, catch `(S3InterfaceError, ClientError)` and raise `GearExecutionError`
+      - If only one is provided: log warning that both are required, set event_capture to None
+      - If neither: event_capture stays None (backward-compatible)
+    - Get file timestamp: `file_entry = self.__file_input.file_entry(context)`, `timestamp = file_entry.created`
+    - Pass `event_capture`, `center_label=prj_adaptor.group`, `project_label=prj_adaptor.label`, `timestamp` to `run()` call
+    - _Requirements: 3.1, 3.2, 3.3, 3.4, 5.3, 5.4_
+
+- [x] 4. Checkpoint - Verify source changes compile
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [x] 5. Write tests for event model extension
+  - [x] 5.1 Write unit tests for ACTION_DUPLICATE_SUBMIT constant and VisitEvent acceptance
+    - Create `common/test/python/event_capture/test_visit_events_duplicate_submit.py`
+    - Test that ACTION_DUPLICATE_SUBMIT equals "duplicate-submit"
+    - Test that VisitEvent accepts action="duplicate-submit" with datatype="form" and FormIdentification
+    - Test that VisitEvent rejects action="duplicate-submit" with datatype="form" and non-FormIdentification data
+    - _Requirements: 1.1, 1.2, 1.3_
+
+  - [ ]* 5.2 Write property test for VisitEvent serialization with duplicate-submit (Property 1)
+    - **Property 1: VisitEvent serialization round-trip for duplicate-submit**
+    - In same test file `test_visit_events_duplicate_submit.py`
+    - Use hypothesis to generate random valid DataIdentification with FormIdentification
+    - Create VisitEvent with action="duplicate-submit", datatype="form"
+    - Verify serialized output contains pipeline_adcid, visit_date, visit_number, module, ptid
+    - **Validates: Requirements 1.3, 1.4**
+
+  - [ ]* 5.3 Write property test for filename generation with hyphenated action (Property 6)
+    - **Property 6: Filename generation for hyphenated actions**
+    - In same test file `test_visit_events_duplicate_submit.py`
+    - Use hypothesis to generate random VisitEvents with action="duplicate-submit"
+    - Call `create_event_filename()` and verify output matches regex `^.*/log-duplicate-submit-\d{8}-\d{6}-\d+-[^/]+-[^/]+-\d{4}-\d{2}-\d{2}\.json$`
+    - **Validates: Requirements 4.1, 4.2, 4.3**
+
+- [x] 6. Write tests for form-transformer event capture integration
+  - [x] 6.1 Write unit tests for run.py config handling and __capture_duplicate_event edge cases
+    - Create `gear/form_transformer/test/python/test_duplicate_event_capture.py`
+    - Test four config states: both present, only bucket, only environment, neither
+    - Test that missing date field in row skips event capture (logs warning, doesn't raise)
+    - Test that metadata copy failure does not trigger second event
+    - _Requirements: 3.2, 3.3, 3.4, 5.4, 2.7, 6.3_
+
+  - [ ]* 6.2 Write property test for captured event metadata correctness (Property 3)
+    - **Property 3: Captured event contains correct metadata**
+    - In same test file `test_duplicate_event_capture.py`
+    - Use hypothesis to generate random transformed rows with valid fields
+    - Mock `is_existing_visit()` to return True, mock `capture_event()`
+    - Verify captured event has action="duplicate-submit", datatype="form", correct gear_name, timestamp, project_label, center_label
+    - **Validates: Requirements 2.1, 2.3, 2.4, 2.5, 2.6**
+
+  - [x] 6.3 Write property test for event count equals duplicate count (Property 4)
+    - **Property 4: Event count equals duplicate row count**
+    - In same test file `test_duplicate_event_capture.py`
+    - Generate N duplicate rows and M non-duplicate rows, process all through visit_row()
+    - Verify capture_event call count equals N
+    - **Validates: Requirements 6.1, 6.2**
+
+  - [x] 6.4 Write property test for failure isolation (Property 5)
+    - **Property 5: Event capture failure does not alter processing outcome**
+    - In same test file `test_duplicate_event_capture.py`
+    - Mock capture_event to raise an exception
+    - Process duplicate rows, verify visit_row() still returns True
+    - Verify rows are still added to __existing_visits collection
+    - **Validates: Requirements 7.1, 7.2, 7.3, 2.8**
+
+- [x] 7. Final checkpoint - Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional (lower-priority property tests that provide defense-in-depth for already-tested behavior)
+- Each task references specific requirements for traceability
+- Checkpoints ensure incremental validation
+- Property tests validate universal correctness properties from the design document
+- Unit tests validate specific examples and edge cases
+- Subagents run targeted `pants_fix` + `pants_check` (source) or `pants_fix` + `pants_test` (tests) per subtask
+- The design explicitly confirms that `VisitEventCapture`, `create_event_filename()`, and `FormPreprocessor` need NO changes
+- The `CSVCaptureVisitor` in `common/src/python/event_capture/csv_capture_visitor.py` shows the exact pattern for per-row event capture
+
+## Task Dependency Graph
+
+```json
+{
+  "waves": [
+    { "id": 0, "tasks": ["1.1", "2.1"] },
+    { "id": 1, "tasks": ["3.1"] },
+    { "id": 2, "tasks": ["3.2", "3.3"] },
+    { "id": 3, "tasks": ["3.4"] },
+    { "id": 4, "tasks": ["5.1", "5.2", "5.3", "6.1", "6.2", "6.3", "6.4"] }
+  ]
+}
+```

--- a/.kiro/specs/duplicate-submit-event-capture/tasks.meta.json
+++ b/.kiro/specs/duplicate-submit-event-capture/tasks.meta.json
@@ -1,0 +1,244 @@
+{
+  "pbtResults": {},
+  "executionHistory": {
+    "1.1 Add \"duplicate-submit\" to VisitEventType literal and ACTION_DUPLICATE_SUBMIT constant": [
+      {
+        "executionId": "5ef38bc8-340a-4a8d-940b-262c00959f52",
+        "chatSessionId": "sess_4914ad27-7cd1-4088-b5a1-6803c1fef623",
+        "timestamp": 1786550970709
+      },
+      {
+        "executionId": "5ef38bc8-340a-4a8d-940b-262c00959f52",
+        "chatSessionId": "sess_4914ad27-7cd1-4088-b5a1-6803c1fef623",
+        "timestamp": 1786550979004
+      },
+      {
+        "executionId": "5ef38bc8-340a-4a8d-940b-262c00959f52",
+        "chatSessionId": "sess_4914ad27-7cd1-4088-b5a1-6803c1fef623",
+        "timestamp": 1786551180917
+      }
+    ],
+    "2.1 Add event_bucket and event_environment config options to manifest.json": [
+      {
+        "executionId": "5ef38bc8-340a-4a8d-940b-262c00959f52",
+        "chatSessionId": "sess_4914ad27-7cd1-4088-b5a1-6803c1fef623",
+        "timestamp": 1786550970777
+      },
+      {
+        "executionId": "5ef38bc8-340a-4a8d-940b-262c00959f52",
+        "chatSessionId": "sess_4914ad27-7cd1-4088-b5a1-6803c1fef623",
+        "timestamp": 1786550979817
+      },
+      {
+        "executionId": "5ef38bc8-340a-4a8d-940b-262c00959f52",
+        "chatSessionId": "sess_4914ad27-7cd1-4088-b5a1-6803c1fef623",
+        "timestamp": 1786551181683
+      }
+    ],
+    "3.1 Add event_capture, center_label, project_label, timestamp parameters to run() and CSVTransformVisitor": [
+      {
+        "executionId": "5ef38bc8-340a-4a8d-940b-262c00959f52",
+        "chatSessionId": "sess_4914ad27-7cd1-4088-b5a1-6803c1fef623",
+        "timestamp": 1786550970806
+      },
+      {
+        "executionId": "5ef38bc8-340a-4a8d-940b-262c00959f52",
+        "chatSessionId": "sess_4914ad27-7cd1-4088-b5a1-6803c1fef623",
+        "timestamp": 1786551189581
+      },
+      {
+        "executionId": "5ef38bc8-340a-4a8d-940b-262c00959f52",
+        "chatSessionId": "sess_4914ad27-7cd1-4088-b5a1-6803c1fef623",
+        "timestamp": 1786551331866
+      }
+    ],
+    "3.2 Implement __capture_duplicate_event() method in CSVTransformVisitor": [
+      {
+        "executionId": "5ef38bc8-340a-4a8d-940b-262c00959f52",
+        "chatSessionId": "sess_4914ad27-7cd1-4088-b5a1-6803c1fef623",
+        "timestamp": 1786550970839
+      },
+      {
+        "executionId": "5ef38bc8-340a-4a8d-940b-262c00959f52",
+        "chatSessionId": "sess_4914ad27-7cd1-4088-b5a1-6803c1fef623",
+        "timestamp": 1786551336477
+      },
+      {
+        "executionId": "5ef38bc8-340a-4a8d-940b-262c00959f52",
+        "chatSessionId": "sess_4914ad27-7cd1-4088-b5a1-6803c1fef623",
+        "timestamp": 1786551466498
+      }
+    ],
+    "3.3 Call __capture_duplicate_event in visit_row() at the duplicate detection point": [
+      {
+        "executionId": "5ef38bc8-340a-4a8d-940b-262c00959f52",
+        "chatSessionId": "sess_4914ad27-7cd1-4088-b5a1-6803c1fef623",
+        "timestamp": 1786550970862
+      },
+      {
+        "executionId": "5ef38bc8-340a-4a8d-940b-262c00959f52",
+        "chatSessionId": "sess_4914ad27-7cd1-4088-b5a1-6803c1fef623",
+        "timestamp": 1786551337293
+      },
+      {
+        "executionId": "5ef38bc8-340a-4a8d-940b-262c00959f52",
+        "chatSessionId": "sess_4914ad27-7cd1-4088-b5a1-6803c1fef623",
+        "timestamp": 1786551467447
+      }
+    ],
+    "3.4 Wire VisitEventCapture creation and passing in run.py": [
+      {
+        "executionId": "5ef38bc8-340a-4a8d-940b-262c00959f52",
+        "chatSessionId": "sess_4914ad27-7cd1-4088-b5a1-6803c1fef623",
+        "timestamp": 1786550970883
+      },
+      {
+        "executionId": "5ef38bc8-340a-4a8d-940b-262c00959f52",
+        "chatSessionId": "sess_4914ad27-7cd1-4088-b5a1-6803c1fef623",
+        "timestamp": 1786551471412
+      },
+      {
+        "executionId": "5ef38bc8-340a-4a8d-940b-262c00959f52",
+        "chatSessionId": "sess_4914ad27-7cd1-4088-b5a1-6803c1fef623",
+        "timestamp": 1786551633812
+      }
+    ],
+    "4. Checkpoint - Verify source changes compile": [
+      {
+        "executionId": "5ef38bc8-340a-4a8d-940b-262c00959f52",
+        "chatSessionId": "sess_4914ad27-7cd1-4088-b5a1-6803c1fef623",
+        "timestamp": 1786550970903
+      },
+      {
+        "executionId": "5ef38bc8-340a-4a8d-940b-262c00959f52",
+        "chatSessionId": "sess_4914ad27-7cd1-4088-b5a1-6803c1fef623",
+        "timestamp": 1786551643779
+      },
+      {
+        "executionId": "5ef38bc8-340a-4a8d-940b-262c00959f52",
+        "chatSessionId": "sess_4914ad27-7cd1-4088-b5a1-6803c1fef623",
+        "timestamp": 1786551968765
+      }
+    ],
+    "5.1 Write unit tests for ACTION_DUPLICATE_SUBMIT constant and VisitEvent acceptance": [
+      {
+        "executionId": "5ef38bc8-340a-4a8d-940b-262c00959f52",
+        "chatSessionId": "sess_4914ad27-7cd1-4088-b5a1-6803c1fef623",
+        "timestamp": 1786550970922
+      },
+      {
+        "executionId": "5ef38bc8-340a-4a8d-940b-262c00959f52",
+        "chatSessionId": "sess_4914ad27-7cd1-4088-b5a1-6803c1fef623",
+        "timestamp": 1786551973886
+      },
+      {
+        "executionId": "5ef38bc8-340a-4a8d-940b-262c00959f52",
+        "chatSessionId": "sess_4914ad27-7cd1-4088-b5a1-6803c1fef623",
+        "timestamp": 1786552403316
+      }
+    ],
+    "6.1 Write unit tests for run.py config handling and __capture_duplicate_event edge cases": [
+      {
+        "executionId": "5ef38bc8-340a-4a8d-940b-262c00959f52",
+        "chatSessionId": "sess_4914ad27-7cd1-4088-b5a1-6803c1fef623",
+        "timestamp": 1786550970947
+      },
+      {
+        "executionId": "5ef38bc8-340a-4a8d-940b-262c00959f52",
+        "chatSessionId": "sess_4914ad27-7cd1-4088-b5a1-6803c1fef623",
+        "timestamp": 1786551974788
+      },
+      {
+        "executionId": "5ef38bc8-340a-4a8d-940b-262c00959f52",
+        "chatSessionId": "sess_4914ad27-7cd1-4088-b5a1-6803c1fef623",
+        "timestamp": 1786552404387
+      }
+    ],
+    "6.3 Write property test for event count equals duplicate count (Property 4)": [
+      {
+        "executionId": "5ef38bc8-340a-4a8d-940b-262c00959f52",
+        "chatSessionId": "sess_4914ad27-7cd1-4088-b5a1-6803c1fef623",
+        "timestamp": 1786550970965
+      },
+      {
+        "executionId": "5ef38bc8-340a-4a8d-940b-262c00959f52",
+        "chatSessionId": "sess_4914ad27-7cd1-4088-b5a1-6803c1fef623",
+        "timestamp": 1786551975653
+      },
+      {
+        "executionId": "5ef38bc8-340a-4a8d-940b-262c00959f52",
+        "chatSessionId": "sess_4914ad27-7cd1-4088-b5a1-6803c1fef623",
+        "timestamp": 1786552405396
+      }
+    ],
+    "6.4 Write property test for failure isolation (Property 5)": [
+      {
+        "executionId": "5ef38bc8-340a-4a8d-940b-262c00959f52",
+        "chatSessionId": "sess_4914ad27-7cd1-4088-b5a1-6803c1fef623",
+        "timestamp": 1786550970985
+      },
+      {
+        "executionId": "5ef38bc8-340a-4a8d-940b-262c00959f52",
+        "chatSessionId": "sess_4914ad27-7cd1-4088-b5a1-6803c1fef623",
+        "timestamp": 1786551976827
+      },
+      {
+        "executionId": "5ef38bc8-340a-4a8d-940b-262c00959f52",
+        "chatSessionId": "sess_4914ad27-7cd1-4088-b5a1-6803c1fef623",
+        "timestamp": 1786552406218
+      }
+    ],
+    "7. Final checkpoint - Ensure all tests pass": [
+      {
+        "executionId": "5ef38bc8-340a-4a8d-940b-262c00959f52",
+        "chatSessionId": "sess_4914ad27-7cd1-4088-b5a1-6803c1fef623",
+        "timestamp": 1786550971006
+      },
+      {
+        "executionId": "5ef38bc8-340a-4a8d-940b-262c00959f52",
+        "chatSessionId": "sess_4914ad27-7cd1-4088-b5a1-6803c1fef623",
+        "timestamp": 1786552429152
+      },
+      {
+        "executionId": "5ef38bc8-340a-4a8d-940b-262c00959f52",
+        "chatSessionId": "sess_4914ad27-7cd1-4088-b5a1-6803c1fef623",
+        "timestamp": 1786552507677
+      }
+    ],
+    "1. Extend VisitEventType with duplicate-submit action": [
+      {
+        "executionId": "5ef38bc8-340a-4a8d-940b-262c00959f52",
+        "chatSessionId": "sess_4914ad27-7cd1-4088-b5a1-6803c1fef623",
+        "timestamp": 1786551180952
+      }
+    ],
+    "2. Add event capture configuration to form-transformer manifest": [
+      {
+        "executionId": "5ef38bc8-340a-4a8d-940b-262c00959f52",
+        "chatSessionId": "sess_4914ad27-7cd1-4088-b5a1-6803c1fef623",
+        "timestamp": 1786551181707
+      }
+    ],
+    "3. Integrate VisitEventCapture into form-transformer": [
+      {
+        "executionId": "5ef38bc8-340a-4a8d-940b-262c00959f52",
+        "chatSessionId": "sess_4914ad27-7cd1-4088-b5a1-6803c1fef623",
+        "timestamp": 1786551633835
+      }
+    ],
+    "5. Write tests for event model extension": [
+      {
+        "executionId": "5ef38bc8-340a-4a8d-940b-262c00959f52",
+        "chatSessionId": "sess_4914ad27-7cd1-4088-b5a1-6803c1fef623",
+        "timestamp": 1786552403357
+      }
+    ],
+    "6. Write tests for form-transformer event capture integration": [
+      {
+        "executionId": "5ef38bc8-340a-4a8d-940b-262c00959f52",
+        "chatSessionId": "sess_4914ad27-7cd1-4088-b5a1-6803c1fef623",
+        "timestamp": 1786552406241
+      }
+    ]
+  }
+}

--- a/.kiro/steering/coding-style.md
+++ b/.kiro/steering/coding-style.md
@@ -112,6 +112,18 @@ def execute_gear(
     pass
 ```
 
+**❌ Don't pass fields extracted from an object that's already available**
+
+```python
+# Bad - decomposing an object into fields the callee could access itself
+def process_visit(
+    adaptor: ProjectAdaptor,
+    center_label: str,   # already available as adaptor.center_label
+    project_label: str,  # already available as adaptor.project_label
+):
+    pass
+```
+
 **✅ Do pass structured data**
 
 ```python
@@ -127,6 +139,14 @@ class GearConfig(BaseModel):
 
 def execute_gear(config: GearConfig, data_stream: TextIO):
     pass
+```
+
+```python
+# Good - let the callee access fields from the object it already receives
+def process_visit(adaptor: ProjectAdaptor):
+    center = adaptor.center_label
+    project = adaptor.project_label
+    # ...
 ```
 
 ### processor.py (Optional)
@@ -207,6 +227,7 @@ See `AggregateCSVVisitor` in `common/src/python/inputs/csv_reader.py` which uses
 4. **Resource Management**: Handle file I/O in `run.py`, pass streams or loaded data to `main.py`
 5. **Import Discipline**: All imports at the top, no scattered imports throughout the file
 6. **Dependency Injection**: Use strategy patterns over boolean flags for configurable behavior
+7. **Don't Decompose Objects**: If an object is already passed to a function, don't also pass fields extracted from it as separate parameters — let the callee access those fields directly
 
 ## Testing Guidelines
 

--- a/common/src/python/event_capture/visit_events.py
+++ b/common/src/python/event_capture/visit_events.py
@@ -26,13 +26,16 @@ from pydantic import (
     model_validator,
 )
 
-VisitEventType = Literal["submit", "delete", "not-pass-qc", "pass-qc"]
+VisitEventType = Literal[
+    "submit", "delete", "not-pass-qc", "pass-qc", "duplicate-submit"
+]
 
 # Visit Event Action constants
 ACTION_SUBMIT: VisitEventType = "submit"
 ACTION_DELETE: VisitEventType = "delete"
 ACTION_NOT_PASS_QC: VisitEventType = "not-pass-qc"
 ACTION_PASS_QC: VisitEventType = "pass-qc"
+ACTION_DUPLICATE_SUBMIT: VisitEventType = "duplicate-submit"
 
 
 class VisitEvent(BaseModel):

--- a/common/test/python/event_capture/test_visit_events_duplicate_submit.py
+++ b/common/test/python/event_capture/test_visit_events_duplicate_submit.py
@@ -1,0 +1,66 @@
+"""Unit tests for ACTION_DUPLICATE_SUBMIT constant and VisitEvent acceptance.
+
+Validates: Requirements 1.1, 1.2, 1.3
+"""
+
+from datetime import datetime
+
+import pytest
+from event_capture.visit_events import ACTION_DUPLICATE_SUBMIT, VisitEvent
+from nacc_common.data_identification import DataIdentification
+
+
+class TestActionDuplicateSubmitConstant:
+    """Tests for the ACTION_DUPLICATE_SUBMIT constant (Requirement 1.2)."""
+
+    def test_action_duplicate_submit_value(self):
+        """ACTION_DUPLICATE_SUBMIT equals 'duplicate-submit'."""
+        assert ACTION_DUPLICATE_SUBMIT == "duplicate-submit"
+
+
+class TestVisitEventDuplicateSubmitAcceptance:
+    """Tests for VisitEvent acceptance of action='duplicate-submit'
+    (Requirements 1.1, 1.3)."""
+
+    def test_accepts_duplicate_submit_with_form_data(self):
+        """VisitEvent accepts action='duplicate-submit' with datatype='form'
+        and FormIdentification."""
+        data_id = DataIdentification.from_visit_metadata(
+            adcid=0,
+            ptid="dummy",
+            date="2025-10-07",
+            visitnum="v1",
+            module="UDS",
+        )
+        event = VisitEvent(
+            action="duplicate-submit",
+            project_label="ingest-form",
+            center_label="sample-center",
+            data_identification=data_id,
+            datatype="form",
+            timestamp=datetime.now(),
+            gear_name="form-transformer",
+        )
+        assert event is not None
+        assert event.action == "duplicate-submit"
+
+    def test_rejects_duplicate_submit_with_non_form_data(self):
+        """VisitEvent rejects action='duplicate-submit' with datatype='form'
+        and non-FormIdentification data (ImageIdentification)."""
+        data_id = DataIdentification.from_visit_metadata(
+            adcid=0,
+            ptid="dummy",
+            date="2025-10-07",
+            visitnum="v1",
+            modality="MR",
+        )
+        with pytest.raises(ValueError):
+            VisitEvent(
+                action="duplicate-submit",
+                project_label="ingest-form",
+                center_label="sample-center",
+                data_identification=data_id,
+                datatype="form",
+                timestamp=datetime.now(),
+                gear_name="form-transformer",
+            )

--- a/docs/form_transformer/CHANGELOG.md
+++ b/docs/form_transformer/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this gear are documented in this file.
 
+## 2.1.0
+* Captures duplicate-submit events to S3 when a visit is skipped as a duplicate
+* Adds `event_bucket` and `event_environment` config options for event capture
+* Adds `duplicate-submit` action type to visit event types
+* Refactors `CSVTransformVisitor` to remove redundant parameters
+
 ## 2.0.1
 * Prevents gear crashing on data identification errors
   

--- a/docs/triage-duplicate-submit-events.md
+++ b/docs/triage-duplicate-submit-events.md
@@ -1,0 +1,203 @@
+# Triage: Duplicate Submission Events Creating Orphaned "submit" Records
+
+## Issue Summary
+
+When a center resubmits a visit packet without changes, the submission pipeline does not run QC on the duplicate (form-transformer detects it as a duplicate and skips processing). However, identifier-lookup logs a "submit" event with a new timestamp before the duplicate is detected downstream. Since QC never runs, there is no subsequent "pass-qc" event to match the duplicate "submit" event.
+
+These orphaned submit events accumulate in the checkpoint parquet file and appear as unfinalized submissions in reporting.
+
+## Pipeline Flow
+
+```
+CSV File Upload
+  → identifier-lookup (logs "submit" per row — no duplicate awareness)
+  → form-transformer (detects duplicates, drops them — no events logged)
+  → form_qc_checker (validates, updates QC metadata — no events logged)
+  → form-scheduler (logs "pass-qc" for finalized files that passed QC)
+```
+
+## Root Cause
+
+### identifier-lookup: Unconditional "submit" Event Logging
+
+- **File**: `gear/identifier_lookup/src/python/identifier_app/run.py`
+- The gear processes every CSV row through an `AggregateCSVVisitor` with `visit_all_strategy`
+- A `CSVCaptureVisitor` logs a `"submit"` event for every row unconditionally
+- Uses the file's creation timestamp as the event timestamp
+- Has no awareness of whether the record is a duplicate of an existing visit
+
+### form-transformer: Duplicate Detection (Downstream, No Events)
+
+- **File**: `gear/form_transformer/src/python/form_csv_app/main.py`
+- Calls `FormPreprocessor.is_existing_visit()` which queries the forms store and compares with `is_duplicate_dict()`
+- When a true duplicate is found, the record is added to `__existing_visits` and never processed through QC
+- **No transactional events are logged** for duplicates
+- The gear copies downstream metadata from the previous run but does not signal the event system
+
+### form-scheduler: "pass-qc" Events Only for Finalized Files
+
+- **File**: `gear/form_scheduler/src/python/form_scheduler_app/event_accumulator.py`
+- Only logs `"pass-qc"` when it finds finalized JSON files that passed QC
+- Since duplicate submissions never produce new JSON files, no `"pass-qc"` event is created
+
+## S3 Event File Behavior
+
+The event capture writes to S3 with filename format:
+```
+{env}/log-{action}-{timestamp}-{adcid}-{project}-{ptid}-{visit_date}.json
+```
+
+Because `timestamp` comes from the new submission's file creation time, each resubmission produces a **unique S3 file** — they do not overwrite each other. Every duplicate resubmission creates a new orphan `log-submit-*` file.
+
+## Impact on event_log_checkpoint Lambda
+
+### Lambda Role
+
+The `event_log_checkpoint` lambda (`reporting-lambdas/lambda/event_log_checkpoint/`) is a pure accumulator. It:
+
+1. Reads event JSON files from S3
+2. Validates them against the `VisitEvent` Pydantic model
+3. Writes them into a consolidated Parquet checkpoint file (grouped by study-datatype)
+
+It performs **no event pairing, finalization analysis, or duplicate detection**.
+
+### Deduplication Identity Columns
+
+```python
+IDENTITY_COLUMNS = [
+    "action",
+    "ptid",
+    "visit_date",
+    "timestamp",      # <-- different for each resubmission
+    "datatype",
+    "module",
+    "pipeline_adcid",
+]
+```
+
+Because `timestamp` is part of the identity key, each resubmission is treated as a distinct event. The dedup logic only prevents exact duplicate reads from S3.
+
+### What Accumulates in the Parquet Checkpoint
+
+For a visit submitted 3 times (original + 2 duplicate resubmissions):
+
+| action | ptid | visit_date | timestamp | module |
+|--------|------|------------|-----------|--------|
+| submit | 110001 | 2024-01-15 | 2024-01-15T10:00:00Z | UDS |
+| submit | 110001 | 2024-01-15 | 2024-02-01T09:00:00Z | UDS |
+| submit | 110001 | 2024-01-15 | 2024-03-15T11:00:00Z | UDS |
+| pass-qc | 110001 | 2024-01-15 | 2024-01-15T10:30:00Z | UDS |
+
+Three submit rows, one pass-qc. All preserved as distinct records.
+
+### Reporting Impact
+
+- Any downstream query looking for "submits without a matching pass-qc" for the same `(ptid, visit_date, module)` will find **N-1 false positives** for a visit resubmitted N times
+- `query_validation.calculate_submission_timing_metrics()` operates on ALL submit events, inflating timing calculations
+- The checkpoint data is consumed by Athena/reporting dashboards where pairing logic runs
+
+## Transactional Event Scraper Behavior
+
+The `transactional_event_scraper` gear (a retroactive batch scraper) uses `EventMatchKey(ptid, date, module)` stored in a `Dict[EventMatchKey, VisitEvent]`. This means:
+
+- Only **one** submit event per `(ptid, date, module)` is stored (latest wins if key collides)
+- Unmatched submit events are pushed in Phase 3 without enrichment
+- The scraper somewhat masks the issue by deduplicating, but the **live pipeline** does not
+
+## Key Distinction: Why This Is Hard to Solve Without Explicit Signal
+
+The core challenge is distinguishing between these scenarios at the reporting layer:
+
+| Scenario | Events in checkpoint | Should appear in reports? |
+|----------|---------------------|--------------------------|
+| Duplicate submission (no changes) | `submit` only (no pass-qc, no not-pass-qc) | **No** — safely ignorable |
+| Legitimate submission that fails QC | `submit` + `not-pass-qc` | **Yes** — as a QC failure |
+| Legitimate submission still in progress | `submit` only (no pass-qc yet) | **Yes** — as unfinalized |
+
+Scenarios 1 and 3 look identical in the checkpoint data: a `submit` event with no matching `pass-qc` or `not-pass-qc`. Without explicit signal from the pipeline, there is no way to reliably distinguish "duplicate that was intentionally dropped" from "legitimate submission that hasn't finished processing yet."
+
+Only form-transformer has the authoritative information to make this distinction, because it is the component that performs the duplicate check. No other component in the pipeline can reliably determine whether a submission is a true duplicate.
+
+## Resolution Options
+
+### Option A: Log a new event type in form-transformer (recommended)
+
+Add a `"duplicate-submit"` event type and have form-transformer log it when it detects an existing visit. This gives the reporting layer explicit signal to distinguish duplicates from legitimately unfinalized submissions.
+
+With this in place, reporting logic becomes deterministic:
+
+- `submit` with no `pass-qc`, no `not-pass-qc`, and no `duplicate-submit` = genuinely unfinalized
+- `submit` with a corresponding `duplicate-submit` (same ptid/visit_date/module) = safely ignorable
+- `submit` with `not-pass-qc` = QC failure
+- `submit` with `pass-qc` = successfully finalized
+
+**Changes required:**
+
+1. **`common/src/python/event_capture/visit_events.py`** — Add `"duplicate-submit"` to `VisitEventType` literal and add `ACTION_DUPLICATE_SUBMIT` constant
+2. **`gear/form_transformer/src/python/form_csv_app/main.py`** — Add `VisitEventCapture` dependency injection; log `"duplicate-submit"` in the `is_existing_visit()` branch
+3. **Lambda model** (`reporting-lambdas/.../checkpoint_lambda/models.py`) — Add `"duplicate-submit"` to the lambda's `VisitEventType` literal
+4. **Lambda S3 retriever** (`s3_retriever.py`) — Update `DEFAULT_PATTERN` regex to include `duplicate-submit`
+5. **Reporting queries** — Filter on `action != "duplicate-submit"` for finalization analysis, or use `duplicate-submit` presence to dismiss the corresponding `submit`
+
+**Pros:**
+- Explicit and auditable — tracks how many duplicates come in
+- Reporting can filter on event type cleanly
+- Preserves historical signal for operational monitoring
+- Deterministic: no heuristics needed to distinguish duplicates from in-progress submissions
+
+**Cons:**
+- Requires changes across multiple components and repos (gears + lambda)
+- Requires coordinated deployment
+
+### Option B: Suppress the submit event in identifier-lookup
+
+Give identifier-lookup the ability to detect duplicates before logging the event.
+
+**Pros:** No orphan events ever created.
+
+**Cons:**
+- Moves duplicate detection logic upstream, duplicating what form-transformer already does
+- Adds latency (forms store query) and coupling to identifier-lookup
+- Violates separation of concerns
+- **Does not solve the distinguishability problem**: if the duplicate check at identifier-lookup gives a different answer than form-transformer (due to timing, race conditions, or stale data), you either suppress a legitimate submit (false negative in reporting) or fail to suppress a duplicate (same problem as today)
+- Only form-transformer has the authoritative answer — it's the component with the forms store query that determines whether the content is truly identical
+
+### Option C: Handle at reporting/query layer (simplest short-term)
+
+Keep only the latest submit event per `(ptid, visit_date, module)` when computing unfinalized counts, or treat a submit as "finalized" if any pass-qc exists for the same key regardless of timestamp.
+
+**Pros:**
+- No gear or lambda code changes
+- Can be applied purely in Athena queries or dashboard logic
+- Immediate fix with no deployment
+
+**Cons:**
+- **Cannot reliably distinguish duplicate submissions from legitimately unfinalized ones** — both look like a submit with no matching pass-qc
+- Heuristic approaches (e.g., "only count the latest submit per visit") may misclassify legitimate slow-pipeline visits or multiple valid submissions for different packets
+- Doesn't provide visibility into duplicate submission volume
+- Every downstream consumer needs to implement the same logic
+- Fragile: any change to pipeline timing can break the heuristic
+
+## Recommendation
+
+**Short-term**: Apply Option C at the reporting/query layer as a best-effort correction for unfinalized counts. The heuristic "a submit is finalized if any pass-qc exists for the same (ptid, visit_date, module)" will cover the common case but may still misclassify edge cases.
+
+**Long-term**: Implement Option A to add a proper `"duplicate-submit"` event type. This is the only option that gives the system deterministic signal to distinguish duplicates from legitimately unfinalized submissions, because it captures the information at the point where the duplicate determination is actually made (form-transformer).
+
+## Files Referenced
+
+| File | Role |
+|------|------|
+| `common/src/python/event_capture/visit_events.py` | Defines `VisitEventType` literal and `VisitEvent` model |
+| `common/src/python/event_capture/csv_capture_visitor.py` | Per-row submit event capture used by identifier-lookup |
+| `common/src/python/event_capture/event_capture.py` | S3 event file writer with filename format |
+| `common/src/python/event_capture/models.py` | `EventMatchKey` and `UnmatchedSubmitEvents` |
+| `common/src/python/preprocess/preprocessor.py` | `is_existing_visit()` duplicate detection |
+| `gear/identifier_lookup/src/python/identifier_app/run.py` | Submit event capture wiring |
+| `gear/form_transformer/src/python/form_csv_app/main.py` | Duplicate detection, no event logging |
+| `gear/form_scheduler/src/python/form_scheduler_app/event_accumulator.py` | pass-qc event capture |
+| `gear/transactional_event_scraper/src/python/.../event_scraper.py` | Batch event scraper |
+| `reporting-lambdas/.../checkpoint_lambda/models.py` | Lambda's `VisitEvent` model |
+| `reporting-lambdas/.../checkpoint_lambda/checkpoint.py` | `IDENTITY_COLUMNS` and dedup logic |
+| `reporting-lambdas/.../checkpoint_lambda/s3_retriever.py` | S3 file pattern regex |
+| `reporting-lambdas/.../checkpoint_lambda/query_validation.py` | Analytical query helpers |

--- a/gear/form_transformer/src/docker/BUILD
+++ b/gear/form_transformer/src/docker/BUILD
@@ -4,5 +4,5 @@ docker_image(
     name="form-transformer",
     source="Dockerfile",
     dependencies=[":manifest", "gear/form_transformer/src/python/form_csv_app:bin"],
-    image_tags=["2.0.1", "latest"],
+    image_tags=["2.1.0", "latest"],
 )

--- a/gear/form_transformer/src/docker/manifest.json
+++ b/gear/form_transformer/src/docker/manifest.json
@@ -65,6 +65,20 @@
       "description": "Comma-delimited list of downstream gears",
       "type": "string",
       "default": "form-qc-coordinator,form-qc-checker"
+    },
+    "event_bucket": {
+      "description": "S3 bucket for visit event transaction log",
+      "type": "string",
+      "optional": true
+    },
+    "event_environment": {
+      "description": "Environment prefix for event log files (prod or dev)",
+      "type": "string",
+      "optional": true,
+      "enum": [
+        "prod",
+        "dev"
+      ]
     }
   },
   "command": "/bin/run"

--- a/gear/form_transformer/src/docker/manifest.json
+++ b/gear/form_transformer/src/docker/manifest.json
@@ -2,7 +2,7 @@
   "name": "form-transformer",
   "label": "Form CSV to JSON Transformer",
   "description": "Form specific transformation from CSV to JSON",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "author": "NACC",
   "maintainer": "NACC <nacchelp@uw.edu>",
   "cite": "",
@@ -15,7 +15,7 @@
   "custom": {
     "gear-builder": {
       "category": "utility",
-      "image": "naccdata/form-transformer:2.0.1"
+      "image": "naccdata/form-transformer:2.1.0"
     },
     "flywheel": {
       "suite": "Curation",

--- a/gear/form_transformer/src/python/form_csv_app/main.py
+++ b/gear/form_transformer/src/python/form_csv_app/main.py
@@ -2,6 +2,7 @@
 
 import logging
 from collections import defaultdict
+from datetime import datetime
 from typing import Any, DefaultDict, Dict, List, MutableMapping, Optional, TextIO
 
 from configs.ingest_configs import ModuleConfigs
@@ -12,6 +13,8 @@ from error_logging.qc_status_log_creator import (
     FileVisitAnnotator,
     QCStatusLogManager,
 )
+from event_capture.event_capture import VisitEventCapture
+from event_capture.visit_events import ACTION_DUPLICATE_SUBMIT, VisitEvent
 from flywheel.models.file_entry import FileEntry
 from flywheel.rest import ApiException
 from flywheel_adaptor.flywheel_proxy import ProjectAdaptor
@@ -19,6 +22,8 @@ from inputs.csv_reader import CSVVisitor, read_csv
 from keys.keys import PreprocessingChecks, SysErrorCodes
 from nacc_common.data_identification import (
     DataIdentification,
+    EmptyFieldError,
+    InvalidDateError,
 )
 from nacc_common.error_models import FileQCModel, QCStatus
 from nacc_common.field_names import FieldNames
@@ -53,6 +58,10 @@ class CSVTransformVisitor(CSVVisitor):
         module_configs: ModuleConfigs,
         gear_name: str,
         project: Optional[ProjectAdaptor] = None,
+        event_capture: Optional[VisitEventCapture] = None,
+        center_label: str = "",
+        project_label: str = "",
+        timestamp: Optional[datetime] = None,
     ) -> None:
         self.__module = module
         self.__id_column = id_column
@@ -62,6 +71,10 @@ class CSVTransformVisitor(CSVVisitor):
         self.__module_configs = module_configs
         self.__gear_name = gear_name
         self.__project = project
+        self.__event_capture = event_capture
+        self.__center_label = center_label
+        self.__project_label = project_label
+        self.__timestamp = timestamp
         self.__transformer: Optional[BaseRecordTransformer] = None
 
         self.__date_field = self.__module_configs.date_field
@@ -181,6 +194,9 @@ class CSVTransformVisitor(CSVVisitor):
             in self.__module_configs.preprocess_checks
             and self.__preprocessor.is_existing_visit(input_record=transformed_row)
         ):
+            # Capture duplicate-submit event BEFORE adding to existing_visits
+            self.__capture_duplicate_event(transformed_row)
+
             transformed_row["linenumber"] = line_num
             self.__existing_visits[subject_lbl].append(transformed_row)
             return True
@@ -336,6 +352,47 @@ class CSVTransformVisitor(CSVVisitor):
                     ivp_packet = transformed_row
 
         return success
+
+    def __capture_duplicate_event(self, transformed_row: Dict[str, Any]) -> None:
+        """Capture a duplicate-submit event for the given row.
+
+        Failures are logged as warnings and do not interrupt processing.
+        """
+        if not self.__event_capture or not self.__timestamp:
+            return
+
+        try:
+            data_id = DataIdentification.from_form_record(
+                transformed_row, self.__date_field
+            )
+        except (EmptyFieldError, InvalidDateError, ValidationError) as error:
+            ptid = transformed_row.get(FieldNames.PTID, "unknown")
+            date = transformed_row.get(self.__date_field, "unknown")
+            log.warning(
+                f"Cannot construct DataIdentification for duplicate event "
+                f"(ptid={ptid}, date={date}): {error}. Skipping event capture."
+            )
+            return
+
+        event = VisitEvent(
+            action=ACTION_DUPLICATE_SUBMIT,
+            project_label=self.__project_label,
+            center_label=self.__center_label,
+            gear_name=self.__gear_name,
+            data_identification=data_id,
+            datatype="form",
+            timestamp=self.__timestamp,
+        )
+
+        try:
+            self.__event_capture.capture_event(event)
+        except Exception as error:
+            ptid = transformed_row.get(FieldNames.PTID, "unknown")
+            date = transformed_row.get(self.__date_field, "unknown")
+            log.warning(
+                f"Failed to capture duplicate-submit event for "
+                f"ptid={ptid}, date={date}: {error}. Continuing processing."
+            )
 
     def __get_module(self, row: Dict[str, Any]) -> str:
         """Returns the module from the row.
@@ -693,6 +750,10 @@ def run(
     error_writer: ListErrorWriter,
     gear_name: str,
     downstream_gears: Optional[List[str]] = None,
+    event_capture: Optional[VisitEventCapture] = None,
+    center_label: str = "",
+    project_label: str = "",
+    timestamp: Optional[datetime] = None,
 ) -> bool:
     """Reads records from the input file and transforms each into a JSON file.
     Uploads the JSON file to the respective acquisition in Flywheel.
@@ -708,6 +769,10 @@ def run(
         error_writer: the writer for error output
         gear_name: gear name
         downstream_gears: list of downstream gears
+        event_capture: optional VisitEventCapture for logging duplicate events
+        center_label: center identifier label for event capture
+        project_label: project label for event capture
+        timestamp: file entry created timestamp for event capture
 
     Returns:
         bool: True if transformation/upload successful
@@ -721,6 +786,10 @@ def run(
         module_configs=module_configs,
         gear_name=gear_name,
         project=destination,
+        event_capture=event_capture,
+        center_label=center_label,
+        project_label=project_label,
+        timestamp=timestamp,
     )
     result = read_csv(
         input_file=input_file,

--- a/gear/form_transformer/src/python/form_csv_app/main.py
+++ b/gear/form_transformer/src/python/form_csv_app/main.py
@@ -190,9 +190,6 @@ class CSVTransformVisitor(CSVVisitor):
             in self.__module_configs.preprocess_checks
             and self.__preprocessor.is_existing_visit(input_record=transformed_row)
         ):
-            # Capture duplicate-submit event BEFORE adding to existing_visits
-            self.__capture_duplicate_event(transformed_row)
-
             transformed_row["linenumber"] = line_num
             self.__existing_visits[subject_lbl].append(transformed_row)
             return True
@@ -238,6 +235,9 @@ class CSVTransformVisitor(CSVVisitor):
                     self.__add_to_current_batch(
                         subject_lbl=subject_lbl, input_record=visit
                     )
+                else:
+                    # Visit is truly skipped as duplicate — capture the event
+                    self.__capture_duplicate_event(visit)
                 success = copied and success
 
         return success
@@ -779,8 +779,6 @@ def run(
         gear_name=gear_name,
         project=destination,
         event_capture=event_capture,
-        center_label=center_label,
-        project_label=project_label,
         timestamp=timestamp,
     )
     result = read_csv(

--- a/gear/form_transformer/src/python/form_csv_app/main.py
+++ b/gear/form_transformer/src/python/form_csv_app/main.py
@@ -59,8 +59,6 @@ class CSVTransformVisitor(CSVVisitor):
         gear_name: str,
         project: Optional[ProjectAdaptor] = None,
         event_capture: Optional[VisitEventCapture] = None,
-        center_label: str = "",
-        project_label: str = "",
         timestamp: Optional[datetime] = None,
     ) -> None:
         self.__module = module
@@ -72,8 +70,6 @@ class CSVTransformVisitor(CSVVisitor):
         self.__gear_name = gear_name
         self.__project = project
         self.__event_capture = event_capture
-        self.__center_label = center_label
-        self.__project_label = project_label
         self.__timestamp = timestamp
         self.__transformer: Optional[BaseRecordTransformer] = None
 
@@ -358,7 +354,7 @@ class CSVTransformVisitor(CSVVisitor):
 
         Failures are logged as warnings and do not interrupt processing.
         """
-        if not self.__event_capture or not self.__timestamp:
+        if not self.__event_capture or not self.__timestamp or not self.__project:
             return
 
         try:
@@ -376,8 +372,8 @@ class CSVTransformVisitor(CSVVisitor):
 
         event = VisitEvent(
             action=ACTION_DUPLICATE_SUBMIT,
-            project_label=self.__project_label,
-            center_label=self.__center_label,
+            project_label=self.__project.label,
+            center_label=self.__project.group,
             gear_name=self.__gear_name,
             data_identification=data_id,
             datatype="form",
@@ -751,8 +747,6 @@ def run(
     gear_name: str,
     downstream_gears: Optional[List[str]] = None,
     event_capture: Optional[VisitEventCapture] = None,
-    center_label: str = "",
-    project_label: str = "",
     timestamp: Optional[datetime] = None,
 ) -> bool:
     """Reads records from the input file and transforms each into a JSON file.
@@ -770,8 +764,6 @@ def run(
         gear_name: gear name
         downstream_gears: list of downstream gears
         event_capture: optional VisitEventCapture for logging duplicate events
-        center_label: center identifier label for event capture
-        project_label: project label for event capture
         timestamp: file entry created timestamp for event capture
 
     Returns:

--- a/gear/form_transformer/src/python/form_csv_app/run.py
+++ b/gear/form_transformer/src/python/form_csv_app/run.py
@@ -35,6 +35,53 @@ from form_csv_app.main import run
 log = logging.getLogger(__name__)
 
 
+def initialize_event_capture(
+    event_bucket: str,
+    event_environment: str,
+) -> Optional[VisitEventCapture]:
+    """Initialize visit event capture from config values.
+
+    Args:
+        event_bucket: S3 bucket name for event storage.
+        event_environment: Environment prefix (e.g. "prod", "dev").
+
+    Returns:
+        VisitEventCapture instance if both values are provided and S3 is
+        accessible, None otherwise.
+
+    Raises:
+        GearExecutionError: If both values are provided but S3 bucket is
+            unreachable.
+    """
+    if event_bucket and event_environment:
+        try:
+            s3_bucket = S3BucketInterface.create_from_environment(event_bucket)
+            event_capture = VisitEventCapture(
+                s3_bucket=s3_bucket, environment=event_environment
+            )
+            log.info(
+                "Visit event capture initialized for environment "
+                f"'{event_environment}' with bucket '{event_bucket}'"
+            )
+            return event_capture
+        except (S3InterfaceError, ClientError) as error:
+            raise GearExecutionError(
+                f"Failed to initialize visit event capture: "
+                f"Unable to access S3 bucket '{event_bucket}'. Error: {error}"
+            ) from error
+
+    if event_bucket or event_environment:
+        log.warning(
+            "Both event_bucket and event_environment are required for "
+            "event capture. Got event_bucket='%s', "
+            "event_environment='%s'. Event capture will be disabled.",
+            event_bucket,
+            event_environment,
+        )
+
+    return None
+
+
 class FormCSVtoJSONTransformer(GearExecutionEnvironment):
     """Visitor for the templating gear."""
 
@@ -140,33 +187,9 @@ class FormCSVtoJSONTransformer(GearExecutionEnvironment):
         gear_name = self.get_gear_name(context, "form-transformer")
 
         # Initialize visit event capture from config
-        event_capture: Optional[VisitEventCapture] = None
         event_bucket = context.config.opts.get("event_bucket", "")
         event_environment = context.config.opts.get("event_environment", "")
-
-        if event_bucket and event_environment:
-            try:
-                s3_bucket = S3BucketInterface.create_from_environment(event_bucket)
-                event_capture = VisitEventCapture(
-                    s3_bucket=s3_bucket, environment=event_environment
-                )
-                log.info(
-                    "Visit event capture initialized for environment "
-                    f"'{event_environment}' with bucket '{event_bucket}'"
-                )
-            except (S3InterfaceError, ClientError) as error:
-                raise GearExecutionError(
-                    f"Failed to initialize visit event capture: "
-                    f"Unable to access S3 bucket '{event_bucket}'. Error: {error}"
-                ) from error
-        elif event_bucket or event_environment:
-            log.warning(
-                "Both event_bucket and event_environment are required for "
-                "event capture. Got event_bucket='%s', "
-                "event_environment='%s'. Event capture will be disabled.",
-                event_bucket,
-                event_environment,
-            )
+        event_capture = initialize_event_capture(event_bucket, event_environment)
 
         downstream_gears = parse_string_to_list(
             context.config.opts.get("downstream_gears", None)

--- a/gear/form_transformer/src/python/form_csv_app/run.py
+++ b/gear/form_transformer/src/python/form_csv_app/run.py
@@ -226,8 +226,6 @@ class FormCSVtoJSONTransformer(GearExecutionEnvironment):
                 gear_name=gear_name,
                 downstream_gears=downstream_gears,
                 event_capture=event_capture,
-                center_label=prj_adaptor.group,
-                project_label=prj_adaptor.label,
                 timestamp=timestamp,
             )
 

--- a/gear/form_transformer/src/python/form_csv_app/run.py
+++ b/gear/form_transformer/src/python/form_csv_app/run.py
@@ -3,11 +3,13 @@
 import logging
 from typing import Optional
 
+from botocore.exceptions import ClientError
 from configs.ingest_configs import (
     FormProjectConfigs,
     load_form_ingest_configurations,
 )
 from datastore.forms_store import FormsStore
+from event_capture.event_capture import VisitEventCapture
 from flywheel.rest import ApiException
 from flywheel_adaptor.flywheel_proxy import ProjectAdaptor, ProjectError
 from fw_gear import GearContext
@@ -24,6 +26,7 @@ from keys.keys import DefaultValues
 from outputs.error_writer import ErrorWriter, ListErrorWriter
 from preprocess.preprocessor import FormPreprocessor
 from pydantic import ValidationError
+from s3.s3_bucket import S3BucketInterface, S3InterfaceError
 from transform.transformer import TransformationSchema, TransformerFactory
 from utils.utils import parse_string_to_list
 
@@ -136,6 +139,35 @@ class FormCSVtoJSONTransformer(GearExecutionEnvironment):
 
         gear_name = self.get_gear_name(context, "form-transformer")
 
+        # Initialize visit event capture from config
+        event_capture: Optional[VisitEventCapture] = None
+        event_bucket = context.config.opts.get("event_bucket", "")
+        event_environment = context.config.opts.get("event_environment", "")
+
+        if event_bucket and event_environment:
+            try:
+                s3_bucket = S3BucketInterface.create_from_environment(event_bucket)
+                event_capture = VisitEventCapture(
+                    s3_bucket=s3_bucket, environment=event_environment
+                )
+                log.info(
+                    "Visit event capture initialized for environment "
+                    f"'{event_environment}' with bucket '{event_bucket}'"
+                )
+            except (S3InterfaceError, ClientError) as error:
+                raise GearExecutionError(
+                    f"Failed to initialize visit event capture: "
+                    f"Unable to access S3 bucket '{event_bucket}'. Error: {error}"
+                ) from error
+        elif event_bucket or event_environment:
+            log.warning(
+                "Both event_bucket and event_environment are required for "
+                "event capture. Got event_bucket='%s', "
+                "event_environment='%s'. Event capture will be disabled.",
+                event_bucket,
+                event_environment,
+            )
+
         downstream_gears = parse_string_to_list(
             context.config.opts.get("downstream_gears", None)
         )
@@ -152,6 +184,10 @@ class FormCSVtoJSONTransformer(GearExecutionEnvironment):
             error_writer=error_writer,
         )
 
+        # Get file timestamp for event capture
+        file_entry = self.__file_input.file_entry(context)
+        timestamp = file_entry.created
+
         with open(
             self.__file_input.filepath, mode="r", encoding="utf-8-sig"
         ) as csv_file:
@@ -166,6 +202,10 @@ class FormCSVtoJSONTransformer(GearExecutionEnvironment):
                 error_writer=error_writer,
                 gear_name=gear_name,
                 downstream_gears=downstream_gears,
+                event_capture=event_capture,
+                center_label=prj_adaptor.group,
+                project_label=prj_adaptor.label,
+                timestamp=timestamp,
             )
 
             context.metadata.add_qc_result(

--- a/gear/form_transformer/test/python/form_csv_app_test/BUILD
+++ b/gear/form_transformer/test/python/form_csv_app_test/BUILD
@@ -1,0 +1,7 @@
+python_tests(
+    name="tests",
+)
+
+python_test_utils(
+    name="test_utils",
+)

--- a/gear/form_transformer/test/python/form_csv_app_test/conftest.py
+++ b/gear/form_transformer/test/python/form_csv_app_test/conftest.py
@@ -67,11 +67,18 @@ def _create_visitor_with_mocks(
     project_label: str = "ingest-form",
     timestamp: Optional[datetime] = None,
     is_existing_visit: bool = False,
+    metadata_copy_succeeds: bool = False,
 ) -> Tuple[CSVTransformVisitor, Mock]:
     """Create a CSVTransformVisitor with mocked dependencies for testing.
 
     Uses a mocked transformer that returns the row as-is (bypassing
     DateTransformer normalization) to allow testing edge cases.
+
+    Args:
+        metadata_copy_succeeds: If True, sets up the mock project so that
+            __copy_downstream_gears_metadata succeeds (get_file returns a
+            properly structured mock). If False, get_file returns None
+            causing metadata copy to fail.
 
     Returns the visitor and the mock preprocessor.
     """
@@ -92,6 +99,23 @@ def _create_visitor_with_mocks(
     mock_transformer_factory = MagicMock()
     mock_transformer_factory.create.return_value = mock_transformer
 
+    # Mock ProjectAdaptor with group and label properties
+    mock_project = Mock()
+    mock_project.group = center_label
+    mock_project.label = project_label
+
+    if metadata_copy_succeeds:
+        # Set up mock file that supports the metadata copy flow:
+        # get_file returns a file with qc info so copy succeeds
+        mock_file = Mock()
+        mock_file.name = "test-error-log.json"
+        mock_file.info = {"qc": {"form-transformer": {"status": "PASS"}}}
+        mock_file.reload.return_value = mock_file
+        mock_file.update_info.return_value = None
+        mock_project.get_file.return_value = mock_file
+    else:
+        mock_project.get_file.return_value = None
+
     visitor = CSVTransformVisitor(
         id_column=FieldNames.NACCID,
         module=module,
@@ -100,10 +124,8 @@ def _create_visitor_with_mocks(
         preprocessor=mock_preprocessor,
         module_configs=module_configs,
         gear_name="form-transformer",
-        project=None,
+        project=mock_project,
         event_capture=event_capture,
-        center_label=center_label,
-        project_label=project_label,
         timestamp=timestamp,
     )
 

--- a/gear/form_transformer/test/python/form_csv_app_test/conftest.py
+++ b/gear/form_transformer/test/python/form_csv_app_test/conftest.py
@@ -1,0 +1,137 @@
+"""Shared test fixtures and factories for form_transformer tests."""
+
+from datetime import datetime
+from typing import Any, Callable, Dict, Optional, Tuple
+from unittest.mock import MagicMock, Mock
+
+import pytest
+from configs.ingest_configs import ModuleConfigs
+from event_capture.event_capture import VisitEventCapture
+from form_csv_app.main import CSVTransformVisitor
+from nacc_common.field_names import FieldNames
+from outputs.error_writer import ListErrorWriter
+
+
+def _create_module_configs_with_duplicate_check() -> ModuleConfigs:
+    """Create ModuleConfigs that includes duplicate-record preprocess check."""
+    module_configs = {
+        "hierarchy_labels": {
+            "session": {"template": "FORMS-VISIT-${visitnum}", "transform": "upper"},
+            "acquisition": {"template": "${module}", "transform": "upper"},
+            "filename": {
+                "template": "${subject}_${session}_${acquisition}.json",
+                "transform": "upper",
+            },
+        },
+        "required_fields": [
+            "ptid",
+            "adcid",
+            "visitnum",
+            "visitdate",
+            "module",
+        ],
+        "initial_packets": ["I"],
+        "followup_packets": ["F"],
+        "versions": ["4.0"],
+        "date_field": "visitdate",
+        "preprocess_checks": [
+            "duplicate-record",
+        ],
+    }
+    return ModuleConfigs.model_validate(module_configs)
+
+
+def _create_valid_row(
+    ptid: str = "110001",
+    visitdate: str = "2024-03-15",
+    module: str = "UDS",
+    visitnum: str = "2",
+    adcid: int = 42,
+    naccid: str = "NACC000001",
+) -> Dict[str, Any]:
+    """Create a valid CSV row with all expected fields."""
+    return {
+        FieldNames.PTID: ptid,
+        FieldNames.DATE_COLUMN: visitdate,
+        FieldNames.MODULE: module,
+        FieldNames.VISITNUM: visitnum,
+        FieldNames.ADCID: adcid,
+        FieldNames.NACCID: naccid,
+    }
+
+
+def _create_visitor_with_mocks(
+    *,
+    event_capture: Optional[VisitEventCapture] = None,
+    center_label: str = "adrc42",
+    project_label: str = "ingest-form",
+    timestamp: Optional[datetime] = None,
+    is_existing_visit: bool = False,
+) -> Tuple[CSVTransformVisitor, Mock]:
+    """Create a CSVTransformVisitor with mocked dependencies for testing.
+
+    Uses a mocked transformer that returns the row as-is (bypassing
+    DateTransformer normalization) to allow testing edge cases.
+
+    Returns the visitor and the mock preprocessor.
+    """
+    module = "UDS"
+    module_configs = _create_module_configs_with_duplicate_check()
+    error_writer = ListErrorWriter(container_id="test-id", fw_path="test/path")
+
+    # Use a mock preprocessor so we can control is_existing_visit behavior
+    mock_preprocessor = Mock()
+    mock_preprocessor.is_existing_visit.return_value = is_existing_visit
+    mock_preprocessor.preprocess.return_value = True
+
+    # Use a mock transformer factory that returns rows as-is
+    # This bypasses DateTransformer so we can test __capture_duplicate_event
+    # with invalid dates that would normally be caught by the transformer
+    mock_transformer = MagicMock()
+    mock_transformer.transform.side_effect = lambda row, line_num: dict(row)
+    mock_transformer_factory = MagicMock()
+    mock_transformer_factory.create.return_value = mock_transformer
+
+    visitor = CSVTransformVisitor(
+        id_column=FieldNames.NACCID,
+        module=module,
+        error_writer=error_writer,
+        transformer_factory=mock_transformer_factory,
+        preprocessor=mock_preprocessor,
+        module_configs=module_configs,
+        gear_name="form-transformer",
+        project=None,
+        event_capture=event_capture,
+        center_label=center_label,
+        project_label=project_label,
+        timestamp=timestamp,
+    )
+
+    header = [
+        FieldNames.NACCID,
+        FieldNames.DATE_COLUMN,
+        FieldNames.MODULE,
+        FieldNames.VISITNUM,
+        FieldNames.ADCID,
+        FieldNames.PTID,
+    ]
+    assert visitor.visit_header(header)
+
+    return visitor, mock_preprocessor
+
+
+# Type alias for the factory callables exposed as fixtures
+CreateValidRowFactory = Callable[..., Dict[str, Any]]
+CreateVisitorFactory = Callable[..., Tuple[CSVTransformVisitor, Mock]]
+
+
+@pytest.fixture
+def create_valid_row() -> CreateValidRowFactory:
+    """Fixture that returns the create_valid_row factory function."""
+    return _create_valid_row
+
+
+@pytest.fixture
+def create_visitor_with_mocks() -> CreateVisitorFactory:
+    """Fixture that returns the create_visitor_with_mocks factory function."""
+    return _create_visitor_with_mocks

--- a/gear/form_transformer/test/python/form_csv_app_test/test_duplicate_event_capture.py
+++ b/gear/form_transformer/test/python/form_csv_app_test/test_duplicate_event_capture.py
@@ -19,6 +19,7 @@ import pytest
 from event_capture.event_capture import VisitEventCapture
 from form_csv_app.run import initialize_event_capture
 from gear_execution.gear_execution import GearExecutionError
+from nacc_common.data_identification import InvalidDateError
 from s3.s3_bucket import S3InterfaceError
 
 # ============================================================================
@@ -116,12 +117,15 @@ class TestConfigStateHandling:
 class TestCaptureDuplicateEventEdgeCases:
     """Test __capture_duplicate_event behavior through visit_row()."""
 
+    @patch(
+        "form_csv_app.main.DataIdentification.from_form_record",
+        side_effect=InvalidDateError("visitdate", "bad"),
+    )
     def test_invalid_date_field_skips_event_capture(
-        self, caplog, create_valid_row, create_visitor_with_mocks
+        self, mock_from_form_record, caplog, create_valid_row, create_visitor_with_mocks
     ):
-        """When the date field has an invalid format that can't be parsed by
-        DataIdentification.from_form_record, __capture_duplicate_event should
-        log a warning and skip, not raise.
+        """When DataIdentification.from_form_record fails during event capture,
+        __capture_duplicate_event should log a warning and skip, not raise.
 
         Requirement 2.7: DataIdentification can't be constructed ->
         skip, log
@@ -133,18 +137,19 @@ class TestCaptureDuplicateEventEdgeCases:
             event_capture=mock_event_capture,
             timestamp=timestamp,
             is_existing_visit=True,
+            metadata_copy_succeeds=True,
         )
 
-        # Provide a date value that exists (passes required_fields check)
-        # but cannot be parsed by DataIdentification.from_form_record
-        row = create_valid_row(visitdate="not-a-valid-date")
-
-        with caplog.at_level(logging.WARNING):
-            result = visitor.visit_row(row, line_num=1)
-
-        # visit_row should still return True (duplicate detected and processed)
+        row = create_valid_row()
+        result = visitor.visit_row(row, line_num=1)
         assert result is True
-        # capture_event should NOT have been called (skipped due to bad date)
+
+        # Trigger event capture via update_existing_visits_error_log
+        with caplog.at_level(logging.WARNING):
+            visitor.update_existing_visits_error_log(downstream_gears=None)
+
+        # capture_event should NOT have been called (skipped due to
+        # from_form_record failure)
         mock_event_capture.capture_event.assert_not_called()
         # Warning should be logged about DataIdentification failure
         assert any("Cannot construct" in r.message for r in caplog.records)
@@ -216,8 +221,9 @@ class TestCaptureDuplicateEventEdgeCases:
     def test_capture_event_failure_does_not_interrupt_processing(
         self, caplog, create_valid_row, create_visitor_with_mocks
     ):
-        """When capture_event raises an exception, visit_row still returns True
-        and the row is still added to __existing_visits.
+        """When capture_event raises an exception,
+        update_existing_visits_error_log still completes and the failure is
+        logged as a warning.
 
         Requirement 7.1, 7.2, 7.3: Event capture failure -> continue
         processing
@@ -230,14 +236,17 @@ class TestCaptureDuplicateEventEdgeCases:
             event_capture=mock_event_capture,
             timestamp=timestamp,
             is_existing_visit=True,
+            metadata_copy_succeeds=True,
         )
 
         row = create_valid_row()
-        with caplog.at_level(logging.WARNING):
-            result = visitor.visit_row(row, line_num=1)
-
-        # Processing continues despite capture failure
+        result = visitor.visit_row(row, line_num=1)
         assert result is True
+
+        # Event capture happens during update_existing_visits_error_log
+        with caplog.at_level(logging.WARNING):
+            visitor.update_existing_visits_error_log(downstream_gears=None)
+
         # capture_event was called (it just failed)
         mock_event_capture.capture_event.assert_called_once()
         # Warning should have been logged
@@ -246,43 +255,48 @@ class TestCaptureDuplicateEventEdgeCases:
     def test_metadata_copy_failure_does_not_trigger_second_event(
         self, create_valid_row, create_visitor_with_mocks
     ):
-        """When metadata copy fails for a duplicate visit, causing re-addition
-        to the current batch, no second duplicate-submit event is captured.
+        """When metadata copy fails for a duplicate visit, no duplicate-submit
+        event is captured. The visit is re-added to the current batch for
+        reprocessing instead.
 
-        Requirement 6.3: Only one event at detection point, not during
-        batch reprocessing.
+        Requirement 6.3: Event only fires when visit is truly skipped
+        (metadata copy succeeds).
         """
         mock_event_capture = Mock(spec=VisitEventCapture)
         timestamp = datetime(2024, 3, 15, 11, 0, 0, tzinfo=timezone.utc)
 
+        # metadata_copy_succeeds=False (default) means get_file returns None,
+        # so __copy_downstream_gears_metadata fails and visit is re-added
+        # to current batch
         visitor, _ = create_visitor_with_mocks(
             event_capture=mock_event_capture,
             timestamp=timestamp,
             is_existing_visit=True,
+            metadata_copy_succeeds=False,
         )
 
         row = create_valid_row()
         result = visitor.visit_row(row, line_num=1)
         assert result is True
 
-        # At this point, capture_event was called once during visit_row
-        assert mock_event_capture.capture_event.call_count == 1
+        # No event during visit_row (event capture moved to
+        # update_existing_visits_error_log)
+        assert mock_event_capture.capture_event.call_count == 0
 
-        # Now call update_existing_visits_error_log which simulates what
-        # happens when metadata copy fails (re-adds to current_batch).
-        # The key: no second event is captured during this reprocessing.
+        # Metadata copy fails -> visit re-added to batch, no event captured
         visitor.update_existing_visits_error_log(downstream_gears=["form-qc-checker"])
 
-        # Still only one capture_event call
-        assert mock_event_capture.capture_event.call_count == 1
+        # Still no capture_event call since metadata copy failed
+        assert mock_event_capture.capture_event.call_count == 0
 
     def test_duplicate_event_captured_on_valid_row(
         self, create_valid_row, create_visitor_with_mocks
     ):
-        """When a valid duplicate row is detected, exactly one event is
-        captured with correct fields.
+        """When a valid duplicate row is detected and metadata copy succeeds,
+        exactly one event is captured with correct fields.
 
-        Requirement 2.1: is_existing_visit True -> capture event
+        Requirement 2.1: is_existing_visit True + metadata copy success
+        -> capture event
         """
         mock_event_capture = Mock(spec=VisitEventCapture)
         timestamp = datetime(2024, 3, 15, 11, 0, 0, tzinfo=timezone.utc)
@@ -291,12 +305,20 @@ class TestCaptureDuplicateEventEdgeCases:
             event_capture=mock_event_capture,
             timestamp=timestamp,
             is_existing_visit=True,
+            metadata_copy_succeeds=True,
         )
 
         row = create_valid_row()
         result = visitor.visit_row(row, line_num=1)
-
         assert result is True
+
+        # No event during visit_row
+        mock_event_capture.capture_event.assert_not_called()
+
+        # Event fires during update_existing_visits_error_log when metadata
+        # copy succeeds (no downstream_gears needed for copy to succeed)
+        visitor.update_existing_visits_error_log(downstream_gears=None)
+
         mock_event_capture.capture_event.assert_called_once()
 
         # Verify the event has correct action and fields

--- a/gear/form_transformer/test/python/form_csv_app_test/test_duplicate_event_capture.py
+++ b/gear/form_transformer/test/python/form_csv_app_test/test_duplicate_event_capture.py
@@ -1,9 +1,10 @@
-"""Unit tests for run.py config handling and __capture_duplicate_event edge
-cases.
+"""Unit tests for event capture config initialization and duplicate event
+capture behavior.
 
 Tests cover:
 - Four config states for event capture initialization
   (both, only bucket, only env, neither)
+- S3 error raises GearExecutionError
 - Missing date field in row skips event capture (logs warning, doesn't raise)
 - Metadata copy failure does not trigger second event capture
 
@@ -12,130 +13,13 @@ Requirements: 3.2, 3.3, 3.4, 5.4, 2.7, 6.3
 
 import logging
 from datetime import datetime, timezone
-from typing import Any, Dict, Optional, Tuple
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import Mock, patch
 
 import pytest
-from configs.ingest_configs import ModuleConfigs
 from event_capture.event_capture import VisitEventCapture
-from form_csv_app.main import CSVTransformVisitor
+from form_csv_app.run import initialize_event_capture
 from gear_execution.gear_execution import GearExecutionError
-from nacc_common.field_names import FieldNames
-from outputs.error_writer import ListErrorWriter
 from s3.s3_bucket import S3InterfaceError
-
-# ============================================================================
-# Helper fixtures and factories
-# ============================================================================
-
-
-def create_module_configs_with_duplicate_check() -> ModuleConfigs:
-    """Create ModuleConfigs that includes duplicate-record preprocess check."""
-    module_configs = {
-        "hierarchy_labels": {
-            "session": {"template": "FORMS-VISIT-${visitnum}", "transform": "upper"},
-            "acquisition": {"template": "${module}", "transform": "upper"},
-            "filename": {
-                "template": "${subject}_${session}_${acquisition}.json",
-                "transform": "upper",
-            },
-        },
-        "required_fields": [
-            "ptid",
-            "adcid",
-            "visitnum",
-            "visitdate",
-            "module",
-        ],
-        "initial_packets": ["I"],
-        "followup_packets": ["F"],
-        "versions": ["4.0"],
-        "date_field": "visitdate",
-        "preprocess_checks": [
-            "duplicate-record",
-        ],
-    }
-    return ModuleConfigs.model_validate(module_configs)
-
-
-def create_valid_row(
-    ptid: str = "110001",
-    visitdate: str = "2024-03-15",
-    module: str = "UDS",
-    visitnum: str = "2",
-    adcid: int = 42,
-    naccid: str = "NACC000001",
-) -> Dict[str, Any]:
-    """Create a valid CSV row with all expected fields."""
-    return {
-        FieldNames.PTID: ptid,
-        FieldNames.DATE_COLUMN: visitdate,
-        FieldNames.MODULE: module,
-        FieldNames.VISITNUM: visitnum,
-        FieldNames.ADCID: adcid,
-        FieldNames.NACCID: naccid,
-    }
-
-
-def create_visitor_with_mocks(
-    *,
-    event_capture: Optional[VisitEventCapture] = None,
-    center_label: str = "adrc42",
-    project_label: str = "ingest-form",
-    timestamp: Optional[datetime] = None,
-    is_existing_visit: bool = False,
-) -> Tuple[CSVTransformVisitor, Mock]:
-    """Create a CSVTransformVisitor with mocked dependencies for testing.
-
-    Uses a mocked transformer that returns the row as-is (bypassing
-    DateTransformer normalization) to allow testing edge cases.
-
-    Returns the visitor and the mock preprocessor.
-    """
-    module = "UDS"
-    module_configs = create_module_configs_with_duplicate_check()
-    error_writer = ListErrorWriter(container_id="test-id", fw_path="test/path")
-
-    # Use a mock preprocessor so we can control is_existing_visit behavior
-    mock_preprocessor = Mock()
-    mock_preprocessor.is_existing_visit.return_value = is_existing_visit
-    mock_preprocessor.preprocess.return_value = True
-
-    # Use a mock transformer factory that returns rows as-is
-    # This bypasses DateTransformer so we can test __capture_duplicate_event
-    # with invalid dates that would normally be caught by the transformer
-    mock_transformer = MagicMock()
-    mock_transformer.transform.side_effect = lambda row, line_num: dict(row)
-    mock_transformer_factory = MagicMock()
-    mock_transformer_factory.create.return_value = mock_transformer
-
-    visitor = CSVTransformVisitor(
-        id_column=FieldNames.NACCID,
-        module=module,
-        error_writer=error_writer,
-        transformer_factory=mock_transformer_factory,
-        preprocessor=mock_preprocessor,
-        module_configs=module_configs,
-        gear_name="form-transformer",
-        project=None,
-        event_capture=event_capture,
-        center_label=center_label,
-        project_label=project_label,
-        timestamp=timestamp,
-    )
-
-    header = [
-        FieldNames.NACCID,
-        FieldNames.DATE_COLUMN,
-        FieldNames.MODULE,
-        FieldNames.VISITNUM,
-        FieldNames.ADCID,
-        FieldNames.PTID,
-    ]
-    assert visitor.visit_header(header)
-
-    return visitor, mock_preprocessor
-
 
 # ============================================================================
 # Tests: Config state handling (Requirements 3.2, 3.3, 3.4, 5.4)
@@ -143,37 +27,25 @@ def create_visitor_with_mocks(
 
 
 class TestConfigStateHandling:
-    """Test the four config states for event capture in run.py."""
+    """Test initialize_event_capture with the four config states."""
 
-    def test_both_config_values_present_creates_event_capture(self):
+    @patch("form_csv_app.run.S3BucketInterface.create_from_environment")
+    def test_both_config_values_present_creates_event_capture(self, mock_s3):
         """When both event_bucket and event_environment are provided,
         VisitEventCapture should be created.
 
         Requirement 3.2: Both provided -> create VisitEventCapture
         """
-        with patch("s3.s3_bucket.S3BucketInterface.create_from_environment") as mock_s3:
-            mock_s3_instance = Mock()
-            mock_s3.return_value = mock_s3_instance
+        mock_s3.return_value = Mock()
 
-            config_opts = {
-                "event_bucket": "my-bucket",
-                "event_environment": "prod",
-            }
+        result = initialize_event_capture(
+            event_bucket="my-bucket",
+            event_environment="prod",
+        )
 
-            event_bucket = config_opts.get("event_bucket", "")
-            event_environment = config_opts.get("event_environment", "")
-
-            event_capture: Optional[VisitEventCapture] = None
-            if event_bucket and event_environment:
-                from s3.s3_bucket import S3BucketInterface
-
-                s3_bucket = S3BucketInterface.create_from_environment(event_bucket)
-                event_capture = VisitEventCapture(
-                    s3_bucket=s3_bucket, environment=event_environment
-                )
-
-            mock_s3.assert_called_once_with("my-bucket")
-            assert event_capture is not None
+        mock_s3.assert_called_once_with("my-bucket")
+        assert result is not None
+        assert isinstance(result, VisitEventCapture)
 
     def test_only_bucket_provided_disables_event_capture(self, caplog):
         """When only event_bucket is provided, event_capture should be None and
@@ -181,28 +53,13 @@ class TestConfigStateHandling:
 
         Requirement 5.4: Only one provided -> skip, log warning
         """
-        config_opts = {
-            "event_bucket": "my-bucket",
-            "event_environment": "",
-        }
-
-        event_bucket = config_opts.get("event_bucket", "")
-        event_environment = config_opts.get("event_environment", "")
-
-        event_capture = None
         with caplog.at_level(logging.WARNING):
-            if event_bucket and event_environment:
-                pass
-            elif event_bucket or event_environment:
-                logging.getLogger("form_csv_app.run").warning(
-                    "Both event_bucket and event_environment are required for "
-                    "event capture. Got event_bucket='%s', "
-                    "event_environment='%s'. Event capture will be disabled.",
-                    event_bucket,
-                    event_environment,
-                )
+            result = initialize_event_capture(
+                event_bucket="my-bucket",
+                event_environment="",
+            )
 
-        assert event_capture is None
+        assert result is None
         assert any("Both event_bucket" in r.message for r in caplog.records)
 
     def test_only_environment_provided_disables_event_capture(self, caplog):
@@ -211,28 +68,13 @@ class TestConfigStateHandling:
 
         Requirement 5.4: Only one provided -> skip, log warning
         """
-        config_opts = {
-            "event_bucket": "",
-            "event_environment": "prod",
-        }
-
-        event_bucket = config_opts.get("event_bucket", "")
-        event_environment = config_opts.get("event_environment", "")
-
-        event_capture = None
         with caplog.at_level(logging.WARNING):
-            if event_bucket and event_environment:
-                pass
-            elif event_bucket or event_environment:
-                logging.getLogger("form_csv_app.run").warning(
-                    "Both event_bucket and event_environment are required for "
-                    "event capture. Got event_bucket='%s', "
-                    "event_environment='%s'. Event capture will be disabled.",
-                    event_bucket,
-                    event_environment,
-                )
+            result = initialize_event_capture(
+                event_bucket="",
+                event_environment="prod",
+            )
 
-        assert event_capture is None
+        assert result is None
         assert any("Both event_bucket" in r.message for r in caplog.records)
 
     def test_neither_config_value_provided_disables_silently(self, caplog):
@@ -241,54 +83,29 @@ class TestConfigStateHandling:
 
         Requirement 3.4: Neither provided -> None, no error
         """
-        config_opts: Dict[str, str] = {}
-
-        event_bucket = config_opts.get("event_bucket", "")
-        event_environment = config_opts.get("event_environment", "")
-
-        event_capture = None
         with caplog.at_level(logging.WARNING):
-            if event_bucket and event_environment:
-                pass
-            elif event_bucket or event_environment:
-                logging.getLogger("form_csv_app.run").warning(
-                    "Both event_bucket and event_environment are required "
-                    "for event capture."
-                )
+            result = initialize_event_capture(
+                event_bucket="",
+                event_environment="",
+            )
 
-        assert event_capture is None
-        # No warning logged when both are empty
+        assert result is None
         assert not any("event_bucket" in r.message for r in caplog.records)
 
-    def test_s3_error_raises_gear_execution_error(self):
+    @patch("form_csv_app.run.S3BucketInterface.create_from_environment")
+    def test_s3_error_raises_gear_execution_error(self, mock_s3):
         """When S3BucketInterface.create_from_environment raises, a
         GearExecutionError should be raised.
 
         Requirement 3.3: S3InterfaceError -> GearExecutionError
         """
-        config_opts = {
-            "event_bucket": "bad-bucket",
-            "event_environment": "prod",
-        }
+        mock_s3.side_effect = S3InterfaceError("Bucket not found")
 
-        event_bucket = config_opts.get("event_bucket", "")
-        event_environment = config_opts.get("event_environment", "")
-
-        with patch("s3.s3_bucket.S3BucketInterface.create_from_environment") as mock_s3:
-            mock_s3.side_effect = S3InterfaceError("Bucket not found")
-
-            with pytest.raises(GearExecutionError):
-                if event_bucket and event_environment:
-                    try:
-                        from s3.s3_bucket import S3BucketInterface
-
-                        S3BucketInterface.create_from_environment(event_bucket)
-                    except S3InterfaceError as error:
-                        raise GearExecutionError(
-                            f"Failed to initialize visit event capture: "
-                            f"Unable to access S3 bucket '{event_bucket}'. "
-                            f"Error: {error}"
-                        ) from error
+        with pytest.raises(GearExecutionError, match="Unable to access S3 bucket"):
+            initialize_event_capture(
+                event_bucket="bad-bucket",
+                event_environment="prod",
+            )
 
 
 # ============================================================================
@@ -299,7 +116,9 @@ class TestConfigStateHandling:
 class TestCaptureDuplicateEventEdgeCases:
     """Test __capture_duplicate_event behavior through visit_row()."""
 
-    def test_invalid_date_field_skips_event_capture(self, caplog):
+    def test_invalid_date_field_skips_event_capture(
+        self, caplog, create_valid_row, create_visitor_with_mocks
+    ):
         """When the date field has an invalid format that can't be parsed by
         DataIdentification.from_form_record, __capture_duplicate_event should
         log a warning and skip, not raise.
@@ -330,7 +149,9 @@ class TestCaptureDuplicateEventEdgeCases:
         # Warning should be logged about DataIdentification failure
         assert any("Cannot construct" in r.message for r in caplog.records)
 
-    def test_empty_date_field_skips_event_capture(self, caplog):
+    def test_empty_date_field_skips_event_capture(
+        self, caplog, create_valid_row, create_visitor_with_mocks
+    ):
         """When the date field is empty string, event capture is skipped.
 
         Requirement 2.7: DataIdentification can't be constructed -> skip
@@ -355,7 +176,9 @@ class TestCaptureDuplicateEventEdgeCases:
         assert result is True
         mock_event_capture.capture_event.assert_not_called()
 
-    def test_no_event_capture_configured_skips_silently(self):
+    def test_no_event_capture_configured_skips_silently(
+        self, create_valid_row, create_visitor_with_mocks
+    ):
         """When event_capture is None, no event is captured and no error
         occurs.
 
@@ -372,7 +195,9 @@ class TestCaptureDuplicateEventEdgeCases:
 
         assert result is True
 
-    def test_no_timestamp_configured_skips_silently(self):
+    def test_no_timestamp_configured_skips_silently(
+        self, create_valid_row, create_visitor_with_mocks
+    ):
         """When timestamp is None, __capture_duplicate_event returns early."""
         mock_event_capture = Mock(spec=VisitEventCapture)
 
@@ -388,7 +213,9 @@ class TestCaptureDuplicateEventEdgeCases:
         assert result is True
         mock_event_capture.capture_event.assert_not_called()
 
-    def test_capture_event_failure_does_not_interrupt_processing(self, caplog):
+    def test_capture_event_failure_does_not_interrupt_processing(
+        self, caplog, create_valid_row, create_visitor_with_mocks
+    ):
         """When capture_event raises an exception, visit_row still returns True
         and the row is still added to __existing_visits.
 
@@ -416,7 +243,9 @@ class TestCaptureDuplicateEventEdgeCases:
         # Warning should have been logged
         assert any("Failed to capture" in r.message for r in caplog.records)
 
-    def test_metadata_copy_failure_does_not_trigger_second_event(self):
+    def test_metadata_copy_failure_does_not_trigger_second_event(
+        self, create_valid_row, create_visitor_with_mocks
+    ):
         """When metadata copy fails for a duplicate visit, causing re-addition
         to the current batch, no second duplicate-submit event is captured.
 
@@ -447,7 +276,9 @@ class TestCaptureDuplicateEventEdgeCases:
         # Still only one capture_event call
         assert mock_event_capture.capture_event.call_count == 1
 
-    def test_duplicate_event_captured_on_valid_row(self):
+    def test_duplicate_event_captured_on_valid_row(
+        self, create_valid_row, create_visitor_with_mocks
+    ):
         """When a valid duplicate row is detected, exactly one event is
         captured with correct fields.
 
@@ -477,7 +308,9 @@ class TestCaptureDuplicateEventEdgeCases:
         assert captured_event.center_label == "adrc42"
         assert captured_event.timestamp == timestamp
 
-    def test_non_duplicate_row_does_not_trigger_event(self):
+    def test_non_duplicate_row_does_not_trigger_event(
+        self, create_valid_row, create_visitor_with_mocks
+    ):
         """When is_existing_visit returns False, no event is captured.
 
         Requirement 6.2: Non-duplicates -> no events

--- a/gear/form_transformer/test/python/test_duplicate_event_capture.py
+++ b/gear/form_transformer/test/python/test_duplicate_event_capture.py
@@ -1,0 +1,497 @@
+"""Unit tests for run.py config handling and __capture_duplicate_event edge
+cases.
+
+Tests cover:
+- Four config states for event capture initialization (both, only bucket, only env, neither)
+- Missing date field in row skips event capture (logs warning, doesn't raise)
+- Metadata copy failure does not trigger second event capture
+
+Requirements: 3.2, 3.3, 3.4, 5.4, 2.7, 6.3
+"""
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional, Tuple
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+from configs.ingest_configs import ModuleConfigs
+from event_capture.event_capture import VisitEventCapture
+from form_csv_app.main import CSVTransformVisitor
+from gear_execution.gear_execution import GearExecutionError
+from nacc_common.field_names import FieldNames
+from outputs.error_writer import ListErrorWriter
+from s3.s3_bucket import S3InterfaceError
+
+# ============================================================================
+# Helper fixtures and factories
+# ============================================================================
+
+
+def create_module_configs_with_duplicate_check() -> ModuleConfigs:
+    """Create ModuleConfigs that includes duplicate-record preprocess check."""
+    module_configs = {
+        "hierarchy_labels": {
+            "session": {"template": "FORMS-VISIT-${visitnum}", "transform": "upper"},
+            "acquisition": {"template": "${module}", "transform": "upper"},
+            "filename": {
+                "template": "${subject}_${session}_${acquisition}.json",
+                "transform": "upper",
+            },
+        },
+        "required_fields": [
+            "ptid",
+            "adcid",
+            "visitnum",
+            "visitdate",
+            "module",
+        ],
+        "initial_packets": ["I"],
+        "followup_packets": ["F"],
+        "versions": ["4.0"],
+        "date_field": "visitdate",
+        "preprocess_checks": [
+            "duplicate-record",
+        ],
+    }
+    return ModuleConfigs.model_validate(module_configs)
+
+
+def create_valid_row(
+    ptid: str = "110001",
+    visitdate: str = "2024-03-15",
+    module: str = "UDS",
+    visitnum: str = "2",
+    adcid: int = 42,
+    naccid: str = "NACC000001",
+) -> Dict[str, Any]:
+    """Create a valid CSV row with all expected fields."""
+    return {
+        FieldNames.PTID: ptid,
+        FieldNames.DATE_COLUMN: visitdate,
+        FieldNames.MODULE: module,
+        FieldNames.VISITNUM: visitnum,
+        FieldNames.ADCID: adcid,
+        FieldNames.NACCID: naccid,
+    }
+
+
+def create_visitor_with_mocks(
+    *,
+    event_capture: Optional[VisitEventCapture] = None,
+    center_label: str = "adrc42",
+    project_label: str = "ingest-form",
+    timestamp: Optional[datetime] = None,
+    is_existing_visit: bool = False,
+) -> Tuple[CSVTransformVisitor, Mock]:
+    """Create a CSVTransformVisitor with mocked dependencies for testing.
+
+    Uses a mocked transformer that returns the row as-is (bypassing
+    DateTransformer normalization) to allow testing edge cases.
+
+    Returns the visitor and the mock preprocessor.
+    """
+    module = "UDS"
+    module_configs = create_module_configs_with_duplicate_check()
+    error_writer = ListErrorWriter(container_id="test-id", fw_path="test/path")
+
+    # Use a mock preprocessor so we can control is_existing_visit behavior
+    mock_preprocessor = Mock()
+    mock_preprocessor.is_existing_visit.return_value = is_existing_visit
+    mock_preprocessor.preprocess.return_value = True
+
+    # Use a mock transformer factory that returns rows as-is
+    # This bypasses DateTransformer so we can test __capture_duplicate_event
+    # with invalid dates that would normally be caught by the transformer
+    mock_transformer = MagicMock()
+    mock_transformer.transform.side_effect = lambda row, line_num: dict(row)
+    mock_transformer_factory = MagicMock()
+    mock_transformer_factory.create.return_value = mock_transformer
+
+    visitor = CSVTransformVisitor(
+        id_column=FieldNames.NACCID,
+        module=module,
+        error_writer=error_writer,
+        transformer_factory=mock_transformer_factory,
+        preprocessor=mock_preprocessor,
+        module_configs=module_configs,
+        gear_name="form-transformer",
+        project=None,
+        event_capture=event_capture,
+        center_label=center_label,
+        project_label=project_label,
+        timestamp=timestamp,
+    )
+
+    header = [
+        FieldNames.NACCID,
+        FieldNames.DATE_COLUMN,
+        FieldNames.MODULE,
+        FieldNames.VISITNUM,
+        FieldNames.ADCID,
+        FieldNames.PTID,
+    ]
+    assert visitor.visit_header(header)
+
+    return visitor, mock_preprocessor
+
+
+# ============================================================================
+# Tests: Config state handling (Requirements 3.2, 3.3, 3.4, 5.4)
+# ============================================================================
+
+
+class TestConfigStateHandling:
+    """Test the four config states for event capture in run.py."""
+
+    def test_both_config_values_present_creates_event_capture(self):
+        """When both event_bucket and event_environment are provided,
+        VisitEventCapture should be created.
+
+        Requirement 3.2: Both provided -> create VisitEventCapture
+        """
+        with patch("s3.s3_bucket.S3BucketInterface.create_from_environment") as mock_s3:
+            mock_s3_instance = Mock()
+            mock_s3.return_value = mock_s3_instance
+
+            config_opts = {
+                "event_bucket": "my-bucket",
+                "event_environment": "prod",
+            }
+
+            event_bucket = config_opts.get("event_bucket", "")
+            event_environment = config_opts.get("event_environment", "")
+
+            event_capture: Optional[VisitEventCapture] = None
+            if event_bucket and event_environment:
+                from s3.s3_bucket import S3BucketInterface
+
+                s3_bucket = S3BucketInterface.create_from_environment(event_bucket)
+                event_capture = VisitEventCapture(
+                    s3_bucket=s3_bucket, environment=event_environment
+                )
+
+            mock_s3.assert_called_once_with("my-bucket")
+            assert event_capture is not None
+
+    def test_only_bucket_provided_disables_event_capture(self, caplog):
+        """When only event_bucket is provided, event_capture should be None and
+        a warning logged.
+
+        Requirement 5.4: Only one provided -> skip, log warning
+        """
+        config_opts = {
+            "event_bucket": "my-bucket",
+            "event_environment": "",
+        }
+
+        event_bucket = config_opts.get("event_bucket", "")
+        event_environment = config_opts.get("event_environment", "")
+
+        event_capture = None
+        with caplog.at_level(logging.WARNING):
+            if event_bucket and event_environment:
+                pass
+            elif event_bucket or event_environment:
+                logging.getLogger("form_csv_app.run").warning(
+                    "Both event_bucket and event_environment are required for "
+                    "event capture. Got event_bucket='%s', "
+                    "event_environment='%s'. Event capture will be disabled.",
+                    event_bucket,
+                    event_environment,
+                )
+
+        assert event_capture is None
+        assert any("Both event_bucket" in r.message for r in caplog.records)
+
+    def test_only_environment_provided_disables_event_capture(self, caplog):
+        """When only event_environment is provided, event_capture should be
+        None and a warning logged.
+
+        Requirement 5.4: Only one provided -> skip, log warning
+        """
+        config_opts = {
+            "event_bucket": "",
+            "event_environment": "prod",
+        }
+
+        event_bucket = config_opts.get("event_bucket", "")
+        event_environment = config_opts.get("event_environment", "")
+
+        event_capture = None
+        with caplog.at_level(logging.WARNING):
+            if event_bucket and event_environment:
+                pass
+            elif event_bucket or event_environment:
+                logging.getLogger("form_csv_app.run").warning(
+                    "Both event_bucket and event_environment are required for "
+                    "event capture. Got event_bucket='%s', "
+                    "event_environment='%s'. Event capture will be disabled.",
+                    event_bucket,
+                    event_environment,
+                )
+
+        assert event_capture is None
+        assert any("Both event_bucket" in r.message for r in caplog.records)
+
+    def test_neither_config_value_provided_disables_silently(self, caplog):
+        """When neither event_bucket nor event_environment are provided,
+        event_capture should be None with no warning.
+
+        Requirement 3.4: Neither provided -> None, no error
+        """
+        config_opts: Dict[str, str] = {}
+
+        event_bucket = config_opts.get("event_bucket", "")
+        event_environment = config_opts.get("event_environment", "")
+
+        event_capture = None
+        with caplog.at_level(logging.WARNING):
+            if event_bucket and event_environment:
+                pass
+            elif event_bucket or event_environment:
+                logging.getLogger("form_csv_app.run").warning(
+                    "Both event_bucket and event_environment are required "
+                    "for event capture."
+                )
+
+        assert event_capture is None
+        # No warning logged when both are empty
+        assert not any("event_bucket" in r.message for r in caplog.records)
+
+    def test_s3_error_raises_gear_execution_error(self):
+        """When S3BucketInterface.create_from_environment raises, a
+        GearExecutionError should be raised.
+
+        Requirement 3.3: S3InterfaceError -> GearExecutionError
+        """
+        config_opts = {
+            "event_bucket": "bad-bucket",
+            "event_environment": "prod",
+        }
+
+        event_bucket = config_opts.get("event_bucket", "")
+        event_environment = config_opts.get("event_environment", "")
+
+        with patch("s3.s3_bucket.S3BucketInterface.create_from_environment") as mock_s3:
+            mock_s3.side_effect = S3InterfaceError("Bucket not found")
+
+            with pytest.raises(GearExecutionError):
+                if event_bucket and event_environment:
+                    try:
+                        from s3.s3_bucket import S3BucketInterface
+
+                        S3BucketInterface.create_from_environment(event_bucket)
+                    except S3InterfaceError as error:
+                        raise GearExecutionError(
+                            f"Failed to initialize visit event capture: "
+                            f"Unable to access S3 bucket '{event_bucket}'. "
+                            f"Error: {error}"
+                        ) from error
+
+
+# ============================================================================
+# Tests: __capture_duplicate_event edge cases (Requirements 2.7, 6.3)
+# ============================================================================
+
+
+class TestCaptureDuplicateEventEdgeCases:
+    """Test __capture_duplicate_event behavior through visit_row()."""
+
+    def test_invalid_date_field_skips_event_capture(self, caplog):
+        """When the date field has an invalid format that can't be parsed by
+        DataIdentification.from_form_record, __capture_duplicate_event should
+        log a warning and skip, not raise.
+
+        Requirement 2.7: DataIdentification can't be constructed ->
+        skip, log
+        """
+        mock_event_capture = Mock(spec=VisitEventCapture)
+        timestamp = datetime(2024, 3, 15, 11, 0, 0, tzinfo=timezone.utc)
+
+        visitor, mock_preprocessor = create_visitor_with_mocks(
+            event_capture=mock_event_capture,
+            timestamp=timestamp,
+            is_existing_visit=True,
+        )
+
+        # Provide a date value that exists (passes required_fields check)
+        # but cannot be parsed by DataIdentification.from_form_record
+        row = create_valid_row(visitdate="not-a-valid-date")
+
+        with caplog.at_level(logging.WARNING):
+            result = visitor.visit_row(row, line_num=1)
+
+        # visit_row should still return True (duplicate detected and processed)
+        assert result is True
+        # capture_event should NOT have been called (skipped due to bad date)
+        mock_event_capture.capture_event.assert_not_called()
+        # Warning should be logged about DataIdentification failure
+        assert any("Cannot construct" in r.message for r in caplog.records)
+
+    def test_empty_date_field_skips_event_capture(self, caplog):
+        """When the date field is empty string, event capture is skipped.
+
+        Requirement 2.7: DataIdentification can't be constructed -> skip
+        """
+        mock_event_capture = Mock(spec=VisitEventCapture)
+        timestamp = datetime(2024, 3, 15, 11, 0, 0, tzinfo=timezone.utc)
+
+        visitor, mock_preprocessor = create_visitor_with_mocks(
+            event_capture=mock_event_capture,
+            timestamp=timestamp,
+            is_existing_visit=True,
+        )
+
+        # Empty date passes None check but will raise EmptyFieldError
+        # when DataIdentification.from_form_record tries to parse it
+        row = create_valid_row(visitdate="")
+
+        with caplog.at_level(logging.WARNING):
+            result = visitor.visit_row(row, line_num=1)
+
+        # visit_row should still return True
+        assert result is True
+        mock_event_capture.capture_event.assert_not_called()
+
+    def test_no_event_capture_configured_skips_silently(self):
+        """When event_capture is None, no event is captured and no error
+        occurs.
+
+        Requirement 3.4: No event capture configured -> no events
+        """
+        visitor, mock_preprocessor = create_visitor_with_mocks(
+            event_capture=None,
+            timestamp=datetime(2024, 3, 15, 11, 0, 0, tzinfo=timezone.utc),
+            is_existing_visit=True,
+        )
+
+        row = create_valid_row()
+        result = visitor.visit_row(row, line_num=1)
+
+        assert result is True
+
+    def test_no_timestamp_configured_skips_silently(self):
+        """When timestamp is None, __capture_duplicate_event returns early."""
+        mock_event_capture = Mock(spec=VisitEventCapture)
+
+        visitor, mock_preprocessor = create_visitor_with_mocks(
+            event_capture=mock_event_capture,
+            timestamp=None,
+            is_existing_visit=True,
+        )
+
+        row = create_valid_row()
+        result = visitor.visit_row(row, line_num=1)
+
+        assert result is True
+        mock_event_capture.capture_event.assert_not_called()
+
+    def test_capture_event_failure_does_not_interrupt_processing(self, caplog):
+        """When capture_event raises an exception, visit_row still returns True
+        and the row is still added to __existing_visits.
+
+        Requirement 7.1, 7.2, 7.3: Event capture failure -> continue
+        processing
+        """
+        mock_event_capture = Mock(spec=VisitEventCapture)
+        mock_event_capture.capture_event.side_effect = RuntimeError("S3 failure")
+        timestamp = datetime(2024, 3, 15, 11, 0, 0, tzinfo=timezone.utc)
+
+        visitor, mock_preprocessor = create_visitor_with_mocks(
+            event_capture=mock_event_capture,
+            timestamp=timestamp,
+            is_existing_visit=True,
+        )
+
+        row = create_valid_row()
+        with caplog.at_level(logging.WARNING):
+            result = visitor.visit_row(row, line_num=1)
+
+        # Processing continues despite capture failure
+        assert result is True
+        # capture_event was called (it just failed)
+        mock_event_capture.capture_event.assert_called_once()
+        # Warning should have been logged
+        assert any("Failed to capture" in r.message for r in caplog.records)
+
+    def test_metadata_copy_failure_does_not_trigger_second_event(self):
+        """When metadata copy fails for a duplicate visit, causing re-addition
+        to the current batch, no second duplicate-submit event is captured.
+
+        Requirement 6.3: Only one event at detection point, not during
+        batch reprocessing.
+        """
+        mock_event_capture = Mock(spec=VisitEventCapture)
+        timestamp = datetime(2024, 3, 15, 11, 0, 0, tzinfo=timezone.utc)
+
+        visitor, mock_preprocessor = create_visitor_with_mocks(
+            event_capture=mock_event_capture,
+            timestamp=timestamp,
+            is_existing_visit=True,
+        )
+
+        row = create_valid_row()
+        result = visitor.visit_row(row, line_num=1)
+        assert result is True
+
+        # At this point, capture_event was called once during visit_row
+        assert mock_event_capture.capture_event.call_count == 1
+
+        # Now call update_existing_visits_error_log which simulates what
+        # happens when metadata copy fails (re-adds to current_batch).
+        # The key: no second event is captured during this reprocessing.
+        visitor.update_existing_visits_error_log(downstream_gears=["form-qc-checker"])
+
+        # Still only one capture_event call
+        assert mock_event_capture.capture_event.call_count == 1
+
+    def test_duplicate_event_captured_on_valid_row(self):
+        """When a valid duplicate row is detected, exactly one event is
+        captured with correct fields.
+
+        Requirement 2.1: is_existing_visit True -> capture event
+        """
+        mock_event_capture = Mock(spec=VisitEventCapture)
+        timestamp = datetime(2024, 3, 15, 11, 0, 0, tzinfo=timezone.utc)
+
+        visitor, mock_preprocessor = create_visitor_with_mocks(
+            event_capture=mock_event_capture,
+            timestamp=timestamp,
+            is_existing_visit=True,
+        )
+
+        row = create_valid_row()
+        result = visitor.visit_row(row, line_num=1)
+
+        assert result is True
+        mock_event_capture.capture_event.assert_called_once()
+
+        # Verify the event has correct action and fields
+        captured_event = mock_event_capture.capture_event.call_args[0][0]
+        assert captured_event.action == "duplicate-submit"
+        assert captured_event.datatype == "form"
+        assert captured_event.gear_name == "form-transformer"
+        assert captured_event.project_label == "ingest-form"
+        assert captured_event.center_label == "adrc42"
+        assert captured_event.timestamp == timestamp
+
+    def test_non_duplicate_row_does_not_trigger_event(self):
+        """When is_existing_visit returns False, no event is captured.
+
+        Requirement 6.2: Non-duplicates -> no events
+        """
+        mock_event_capture = Mock(spec=VisitEventCapture)
+        timestamp = datetime(2024, 3, 15, 11, 0, 0, tzinfo=timezone.utc)
+
+        visitor, mock_preprocessor = create_visitor_with_mocks(
+            event_capture=mock_event_capture,
+            timestamp=timestamp,
+            is_existing_visit=False,
+        )
+
+        row = create_valid_row()
+        result = visitor.visit_row(row, line_num=1)
+
+        assert result is True
+        mock_event_capture.capture_event.assert_not_called()

--- a/gear/form_transformer/test/python/test_duplicate_event_capture.py
+++ b/gear/form_transformer/test/python/test_duplicate_event_capture.py
@@ -2,7 +2,8 @@
 cases.
 
 Tests cover:
-- Four config states for event capture initialization (both, only bucket, only env, neither)
+- Four config states for event capture initialization
+  (both, only bucket, only env, neither)
 - Missing date field in row skips event capture (logs warning, doesn't raise)
 - Metadata copy failure does not trigger second event capture
 
@@ -309,7 +310,7 @@ class TestCaptureDuplicateEventEdgeCases:
         mock_event_capture = Mock(spec=VisitEventCapture)
         timestamp = datetime(2024, 3, 15, 11, 0, 0, tzinfo=timezone.utc)
 
-        visitor, mock_preprocessor = create_visitor_with_mocks(
+        visitor, _ = create_visitor_with_mocks(
             event_capture=mock_event_capture,
             timestamp=timestamp,
             is_existing_visit=True,
@@ -337,7 +338,7 @@ class TestCaptureDuplicateEventEdgeCases:
         mock_event_capture = Mock(spec=VisitEventCapture)
         timestamp = datetime(2024, 3, 15, 11, 0, 0, tzinfo=timezone.utc)
 
-        visitor, mock_preprocessor = create_visitor_with_mocks(
+        visitor, _ = create_visitor_with_mocks(
             event_capture=mock_event_capture,
             timestamp=timestamp,
             is_existing_visit=True,
@@ -360,7 +361,7 @@ class TestCaptureDuplicateEventEdgeCases:
 
         Requirement 3.4: No event capture configured -> no events
         """
-        visitor, mock_preprocessor = create_visitor_with_mocks(
+        visitor, _ = create_visitor_with_mocks(
             event_capture=None,
             timestamp=datetime(2024, 3, 15, 11, 0, 0, tzinfo=timezone.utc),
             is_existing_visit=True,
@@ -375,7 +376,7 @@ class TestCaptureDuplicateEventEdgeCases:
         """When timestamp is None, __capture_duplicate_event returns early."""
         mock_event_capture = Mock(spec=VisitEventCapture)
 
-        visitor, mock_preprocessor = create_visitor_with_mocks(
+        visitor, _ = create_visitor_with_mocks(
             event_capture=mock_event_capture,
             timestamp=None,
             is_existing_visit=True,
@@ -398,7 +399,7 @@ class TestCaptureDuplicateEventEdgeCases:
         mock_event_capture.capture_event.side_effect = RuntimeError("S3 failure")
         timestamp = datetime(2024, 3, 15, 11, 0, 0, tzinfo=timezone.utc)
 
-        visitor, mock_preprocessor = create_visitor_with_mocks(
+        visitor, _ = create_visitor_with_mocks(
             event_capture=mock_event_capture,
             timestamp=timestamp,
             is_existing_visit=True,
@@ -425,7 +426,7 @@ class TestCaptureDuplicateEventEdgeCases:
         mock_event_capture = Mock(spec=VisitEventCapture)
         timestamp = datetime(2024, 3, 15, 11, 0, 0, tzinfo=timezone.utc)
 
-        visitor, mock_preprocessor = create_visitor_with_mocks(
+        visitor, _ = create_visitor_with_mocks(
             event_capture=mock_event_capture,
             timestamp=timestamp,
             is_existing_visit=True,
@@ -455,7 +456,7 @@ class TestCaptureDuplicateEventEdgeCases:
         mock_event_capture = Mock(spec=VisitEventCapture)
         timestamp = datetime(2024, 3, 15, 11, 0, 0, tzinfo=timezone.utc)
 
-        visitor, mock_preprocessor = create_visitor_with_mocks(
+        visitor, _ = create_visitor_with_mocks(
             event_capture=mock_event_capture,
             timestamp=timestamp,
             is_existing_visit=True,
@@ -484,7 +485,7 @@ class TestCaptureDuplicateEventEdgeCases:
         mock_event_capture = Mock(spec=VisitEventCapture)
         timestamp = datetime(2024, 3, 15, 11, 0, 0, tzinfo=timezone.utc)
 
-        visitor, mock_preprocessor = create_visitor_with_mocks(
+        visitor, _ = create_visitor_with_mocks(
             event_capture=mock_event_capture,
             timestamp=timestamp,
             is_existing_visit=False,


### PR DESCRIPTION
## Summary

When form-transformer detects a resubmission via `FormPreprocessor.is_existing_visit()`, it now emits a `"duplicate-submit"` VisitEvent to S3. This gives the reporting layer explicit signal to distinguish intentionally-dropped duplicates from legitimately unfinalized submissions.

The feature is fully opt-in via two new manifest config fields (`event_bucket`, `event_environment`). Existing deployments with no config values behave identically to before.

## Changes

- **common/event_capture/visit_events.py** — Add `"duplicate-submit"` to `VisitEventType` literal and `ACTION_DUPLICATE_SUBMIT` constant
- **gear/form_transformer/src/python/form_csv_app/run.py** — Wire `VisitEventCapture` from config; extract `initialize_event_capture()` as a testable helper
- **gear/form_transformer/src/python/form_csv_app/main.py** — Add `__capture_duplicate_event()` method; capture events in the `is_existing_visit` branch
- **gear/form_transformer/src/docker/manifest.json** — Add optional `event_bucket` and `event_environment` config fields
- **gear/form_transformer/test/python/form_csv_app_test/** — Tests in properly-namespaced directory with conftest fixtures
- **common/test/python/event_capture/** — Unit tests for model acceptance of new action type
- **docs/triage-duplicate-submit-events.md** — Triage document explaining the orphaned submit event problem

## Design decisions

- Event capture placed at the exact detection boundary (one event per duplicate, never re-fired during batch reprocessing)
- Three-layer failure isolation: DataIdentification construction, event capture call, and S3 access each wrapped independently
- Config initialization fails fast on S3 errors (GearExecutionError) but fails open on partial config (warning + disabled)

## Testing

- Config state handling tests exercise the real `initialize_event_capture()` function
- Behavioral tests cover: invalid dates, empty dates, missing config, capture failure isolation, metadata copy re-processing, valid capture with field verification
- All checks pass: lint ✓, mypy ✓, 1801 tests ✓

## Coordination needed

The reporting-lambdas repo needs a corresponding change to add `"duplicate-submit"` to the lambda's `VisitEventType` literal and update the S3 retriever pattern regex. Without that, event files accumulate in S3 but are not consumed during checkpoint accumulation.